### PR TITLE
Add user-configurable keybindings in Settings

### DIFF
--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -1,4 +1,6 @@
 import type { CSSProperties, ReactNode } from "react";
+import { useFormattedBinding } from "~/lib/keybindings/store";
+import type { HotkeyAction } from "~/lib/keybindings/types";
 
 export type KbdVariant = "onPrimary" | "ghost" | "inline";
 
@@ -32,48 +34,6 @@ const VARIANT_STYLE: Record<KbdVariant, CSSProperties> = {
   },
 };
 
-const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
-
-export type HotkeyCombo =
-  | "mod+enter"
-  | "mod+n"
-  | "mod+e"
-  | "mod+p"
-  | "mod+m"
-  | "mod+/"
-  | "mod+."
-  | "mod+l"
-  | "ctrl+`"
-  | "enter"
-  | "escape";
-
-export function hotkeyLabel(combo: HotkeyCombo): string {
-  switch (combo) {
-    case "mod+enter":
-      return isMac ? "⌘↵" : "Ctrl+↵";
-    case "mod+n":
-      return isMac ? "⌘N" : "Ctrl+N";
-    case "mod+e":
-      return isMac ? "⌘E" : "Ctrl+E";
-    case "mod+p":
-      return isMac ? "⌘P" : "Ctrl+P";
-    case "mod+m":
-      return isMac ? "⌘M" : "Ctrl+M";
-    case "mod+/":
-      return isMac ? "⌘/" : "Ctrl+/";
-    case "mod+.":
-      return isMac ? "⌘." : "Ctrl+.";
-    case "mod+l":
-      return isMac ? "⌘L" : "Ctrl+L";
-    case "ctrl+`":
-      return "⌃~";
-    case "enter":
-      return "↵";
-    case "escape":
-      return "Esc";
-  }
-}
-
 export function Kbd({
   variant = "ghost",
   children,
@@ -84,4 +44,18 @@ export function Kbd({
   style?: CSSProperties;
 }) {
   return <kbd style={{ ...BASE, ...VARIANT_STYLE[variant], ...style }}>{children}</kbd>;
+}
+
+/** Render the user's current binding for an action. */
+export function KbdAction({
+  action,
+  variant = "ghost",
+  style,
+}: {
+  action: HotkeyAction;
+  variant?: KbdVariant;
+  style?: CSSProperties;
+}) {
+  const label = useFormattedBinding(action);
+  return <Kbd variant={variant} style={style}>{label}</Kbd>;
 }

--- a/src/components/views/KeybindingsSettings.tsx
+++ b/src/components/views/KeybindingsSettings.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Btn } from "~/components/ui/Btn";
+import { Kbd } from "~/components/ui/Kbd";
+import { useKeybindings } from "~/lib/keybindings/store";
+import { formatBinding } from "~/lib/keybindings/format";
+import { bindingComboKey, bindingsEqual, eventToBinding, isValidBinding } from "~/lib/keybindings/match";
+import { DEFAULT_BINDINGS } from "~/lib/keybindings/defaults";
+import { ACTION_META, HOTKEY_ACTIONS, type Binding, type HotkeyAction } from "~/lib/keybindings/types";
+
+export function KeybindingsSettings() {
+  const { bindings, setBinding, resetBinding, resetAll } = useKeybindings();
+  const [recordingFor, setRecordingFor] = useState<HotkeyAction | null>(null);
+  const [pendingBinding, setPendingBinding] = useState<Binding | null>(null);
+  const [recordError, setRecordError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // Conflict map across all current bindings.
+  const conflicts = useMemo(() => {
+    const byCombo = new Map<string, HotkeyAction[]>();
+    for (const action of HOTKEY_ACTIONS) {
+      const k = bindingComboKey(bindings[action]);
+      const arr = byCombo.get(k) ?? [];
+      arr.push(action);
+      byCombo.set(k, arr);
+    }
+    const conflicting = new Set<HotkeyAction>();
+    for (const arr of byCombo.values()) {
+      if (arr.length > 1) for (const a of arr) conflicting.add(a);
+    }
+    return conflicting;
+  }, [bindings]);
+
+  // Conflict for the *pending* (unsaved) capture: would it collide with another action?
+  const pendingConflict = useMemo<HotkeyAction | null>(() => {
+    if (!recordingFor || !pendingBinding) return null;
+    const k = bindingComboKey(pendingBinding);
+    for (const action of HOTKEY_ACTIONS) {
+      if (action === recordingFor) continue;
+      if (bindingComboKey(bindings[action]) === k) return action;
+    }
+    return null;
+  }, [recordingFor, pendingBinding, bindings]);
+
+  const cancelRecording = () => {
+    setRecordingFor(null);
+    setPendingBinding(null);
+    setRecordError(null);
+  };
+
+  const startRecording = (action: HotkeyAction) => {
+    setRecordingFor(action);
+    setPendingBinding(null);
+    setRecordError(null);
+  };
+
+  const saveRecording = async () => {
+    if (!recordingFor || !pendingBinding || pendingConflict || saving) return;
+    setSaving(true);
+    try {
+      await setBinding(recordingFor, pendingBinding);
+      cancelRecording();
+    } catch (e: any) {
+      setRecordError(e?.message || "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onReset = async (action: HotkeyAction) => {
+    await resetBinding(action);
+    if (recordingFor === action) cancelRecording();
+  };
+
+  const onResetAll = async () => {
+    await resetAll();
+    cancelRecording();
+  };
+
+  return (
+    <div>
+      {conflicts.size > 0 && (
+        <ConflictBanner count={conflicts.size} />
+      )}
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {HOTKEY_ACTIONS.map((action) => (
+          <BindingRow
+            key={action}
+            action={action}
+            binding={bindings[action]}
+            isDefault={bindingsEqual(bindings[action], DEFAULT_BINDINGS[action])}
+            recording={recordingFor === action}
+            pendingBinding={recordingFor === action ? pendingBinding : null}
+            pendingConflict={recordingFor === action ? pendingConflict : null}
+            recordError={recordingFor === action ? recordError : null}
+            saving={saving}
+            inConflict={conflicts.has(action)}
+            onStartRecording={() => startRecording(action)}
+            onCancelRecording={cancelRecording}
+            onCapture={(b) => {
+              setPendingBinding(b);
+              setRecordError(null);
+            }}
+            onCaptureError={(msg) => setRecordError(msg)}
+            onSave={saveRecording}
+            onReset={() => onReset(action)}
+          />
+        ))}
+      </div>
+      <div style={{ marginTop: 16, display: "flex", justifyContent: "flex-end" }}>
+        <Btn variant="ghost" size="sm" icon="refresh" onClick={onResetAll}>
+          Reset all to defaults
+        </Btn>
+      </div>
+    </div>
+  );
+}
+
+function ConflictBanner({ count }: { count: number }) {
+  return (
+    <div
+      role="alert"
+      style={{
+        marginBottom: 12,
+        padding: "8px 12px",
+        border: "1px solid #b04a4a",
+        background: "rgba(176, 74, 74, 0.12)",
+        color: "#ff9b9b",
+        borderRadius: 6,
+        fontFamily: "var(--mono)",
+        fontSize: 11,
+      }}
+    >
+      {count} actions share the same shortcut. Resolve the conflicts below.
+    </div>
+  );
+}
+
+function BindingRow({
+  action,
+  binding,
+  isDefault,
+  recording,
+  pendingBinding,
+  pendingConflict,
+  recordError,
+  saving,
+  inConflict,
+  onStartRecording,
+  onCancelRecording,
+  onCapture,
+  onCaptureError,
+  onSave,
+  onReset,
+}: {
+  action: HotkeyAction;
+  binding: Binding;
+  isDefault: boolean;
+  recording: boolean;
+  pendingBinding: Binding | null;
+  pendingConflict: HotkeyAction | null;
+  recordError: string | null;
+  saving: boolean;
+  inConflict: boolean;
+  onStartRecording: () => void;
+  onCancelRecording: () => void;
+  onCapture: (b: Binding) => void;
+  onCaptureError: (msg: string) => void;
+  onSave: () => void;
+  onReset: () => void;
+}) {
+  const captureRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!recording) return;
+    captureRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancelRecording();
+        return;
+      }
+      if (e.key === "Enter" && pendingBinding && !pendingConflict) {
+        e.preventDefault();
+        onSave();
+        return;
+      }
+      const candidate = eventToBinding(e);
+      if (!candidate) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const valid = isValidBinding(candidate);
+      if (!valid.ok) {
+        onCaptureError(valid.reason);
+        return;
+      }
+      onCapture(candidate);
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [recording, pendingBinding, pendingConflict, onCancelRecording, onSave, onCapture, onCaptureError]);
+
+  const meta = ACTION_META[action];
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr auto",
+        alignItems: "center",
+        gap: 12,
+        padding: "10px 12px",
+        background: inConflict ? "rgba(176, 74, 74, 0.08)" : "var(--surface-0)",
+        border: `1px solid ${inConflict ? "#b04a4a" : "var(--border)"}`,
+        borderRadius: 7,
+      }}
+    >
+      <div>
+        <div style={{ fontFamily: "var(--mono)", fontSize: 12, fontWeight: 600 }}>
+          {meta.label}
+        </div>
+        <div style={{ fontFamily: "var(--mono)", fontSize: 10.5, color: "var(--text-dim)", marginTop: 2 }}>
+          {meta.description}
+        </div>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        {recording ? (
+          <div
+            ref={captureRef}
+            tabIndex={0}
+            aria-label="Press a key combination to bind"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "6px 10px",
+              border: `1px dashed ${pendingConflict ? "#b04a4a" : "var(--accent)"}`,
+              borderRadius: 6,
+              outline: "none",
+              minWidth: 220,
+              fontFamily: "var(--mono)",
+              fontSize: 11,
+            }}
+          >
+            <span style={{ color: pendingConflict ? "#ff9b9b" : "var(--text-dim)" }}>
+              {pendingBinding ? formatBinding(pendingBinding) : "Press keys…"}
+            </span>
+            {pendingConflict && (
+              <span style={{ color: "#ff9b9b" }}>
+                conflicts with “{ACTION_META[pendingConflict].label}”
+              </span>
+            )}
+            {recordError && !pendingConflict && (
+              <span style={{ color: "#ff9b9b" }}>{recordError}</span>
+            )}
+            <Btn
+              variant="ghost"
+              size="sm"
+              onClick={onCancelRecording}
+              style={{ marginLeft: "auto" }}
+            >
+              Cancel <Kbd variant="inline">Esc</Kbd>
+            </Btn>
+            <Btn
+              variant="primary"
+              size="sm"
+              onClick={onSave}
+              disabled={!pendingBinding || !!pendingConflict || saving}
+            >
+              Save <Kbd variant="onPrimary">↵</Kbd>
+            </Btn>
+          </div>
+        ) : (
+          <>
+            <Kbd variant="ghost">{formatBinding(binding)}</Kbd>
+            <Btn variant="ghost" size="sm" onClick={onStartRecording}>
+              Rebind
+            </Btn>
+            {!isDefault && (
+              <Btn variant="ghost" size="sm" onClick={onReset}>
+                Reset
+              </Btn>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/views/NewAgentButton.tsx
+++ b/src/components/views/NewAgentButton.tsx
@@ -1,5 +1,5 @@
 import { Btn } from "~/components/ui/Btn";
-import { Kbd, hotkeyLabel } from "~/components/ui/Kbd";
+import { KbdAction } from "~/components/ui/Kbd";
 import type { Project } from "~/db/schema";
 
 export function NewAgentButton({
@@ -13,14 +13,13 @@ export function NewAgentButton({
   onConfigure: () => void;
   disabled?: boolean;
 }) {
-  const hotkey = hotkeyLabel("mod+n");
   const remembered = !!(project.rememberAgentSettings && project.savedAgent);
 
   if (!remembered) {
     return (
       <Btn variant="primary" icon="plus" onClick={onPrimary} disabled={disabled}>
         New agent
-        <Kbd variant="onPrimary">{hotkey}</Kbd>
+        <KbdAction action="agent.new" variant="onPrimary" />
       </Btn>
     );
   }
@@ -36,7 +35,7 @@ export function NewAgentButton({
         style={{ borderRadius: "7px 0 0 7px", borderRight: "none" }}
       >
         New agent
-        <Kbd variant="onPrimary">{hotkey}</Kbd>
+        <KbdAction action="agent.new" variant="onPrimary" />
       </Btn>
       <Btn
         variant="primary"

--- a/src/components/views/NewAgentDialog.tsx
+++ b/src/components/views/NewAgentDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Modal } from "~/components/ui/Modal";
 import { Btn } from "~/components/ui/Btn";
-import { Kbd, hotkeyLabel } from "~/components/ui/Kbd";
+import { KbdAction } from "~/components/ui/Kbd";
 import { isEditableTarget, useHotkey } from "~/lib/use-hotkey";
 import { AGENT_META } from "~/lib/design-meta";
 import { getElectron } from "~/lib/electron";
@@ -150,7 +150,7 @@ export function NewAgentDialog({
     return () => window.removeEventListener("keydown", onKey);
   }, [open, agent, agents, submitting, project, rememberSettings, dangerouslySkipPermissions]);
 
-  useHotkey("mod+enter", () => void submit(), { enabled: open });
+  useHotkey("dialog.submit", () => void submit(), { enabled: open });
 
   return (
     <Modal
@@ -165,7 +165,7 @@ export function NewAgentDialog({
           </Btn>
           <Btn variant="primary" icon="play" onClick={submit} disabled={submitting}>
             Start agent
-            <Kbd variant="onPrimary">{hotkeyLabel("mod+enter")}</Kbd>
+            <KbdAction action="dialog.submit" variant="onPrimary" />
           </Btn>
         </>
       }

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -4,7 +4,7 @@ import { Btn } from "~/components/ui/Btn";
 import { TextField } from "~/components/ui/TextField";
 import { Icon } from "~/components/ui/Icon";
 import { ProjectIcon } from "~/components/ui/ProjectIcon";
-import { Kbd, hotkeyLabel } from "~/components/ui/Kbd";
+import { KbdAction } from "~/components/ui/Kbd";
 import { useHotkey } from "~/lib/use-hotkey";
 import { ICON_COLORS } from "~/lib/design-meta";
 import { getElectron } from "~/lib/electron";
@@ -134,7 +134,7 @@ export function ProjectDialog({
     }
   };
 
-  useHotkey("mod+enter", () => void submit(), { enabled: open });
+  useHotkey("dialog.submit", () => void submit(), { enabled: open });
 
   return (
     <Modal
@@ -161,7 +161,7 @@ export function ProjectDialog({
           </Btn>
           <Btn variant="primary" onClick={submit}>
             {project ? "Save" : "Add project"}
-            <Kbd variant="onPrimary">{hotkeyLabel("mod+enter")}</Kbd>
+            <KbdAction action="dialog.submit" variant="onPrimary" />
           </Btn>
         </>
       }

--- a/src/components/views/ProjectPicker.tsx
+++ b/src/components/views/ProjectPicker.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "@tanstack/react-router";
 import { Icon } from "~/components/ui/Icon";
 import { ProjectIcon } from "~/components/ui/ProjectIcon";
-import { Kbd, hotkeyLabel } from "~/components/ui/Kbd";
+import { KbdAction } from "~/components/ui/Kbd";
 import { api } from "~/lib/api";
 import { useServerEvents } from "~/lib/use-events";
 import { isEditableTarget, useHotkey } from "~/lib/use-hotkey";
@@ -100,7 +100,7 @@ export function ProjectPicker({ projectId }: { projectId?: string }) {
   };
 
   useHotkey(
-    "mod+p",
+    "project.picker",
     (e) => {
       if (isEditableTarget(e.target) && !wrapRef.current?.contains(e.target as Node)) return;
       e.preventDefault();
@@ -190,9 +190,7 @@ export function ProjectPicker({ projectId }: { projectId?: string }) {
         {current && <ProjectIcon project={current} size={14} />}
         <span>{label}</span>
         <Icon name="chevron-down" size={11} style={{ color: "var(--text-faint)" }} />
-        <Kbd variant="ghost" style={{ marginLeft: 2 }}>
-          {hotkeyLabel("mod+p")}
-        </Kbd>
+        <KbdAction action="project.picker" variant="ghost" style={{ marginLeft: 2 }} />
       </button>
       {open && (
         <div

--- a/src/components/views/TerminalPanel.tsx
+++ b/src/components/views/TerminalPanel.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "~/components/ui/Icon";
-import { Kbd, hotkeyLabel } from "~/components/ui/Kbd";
+import { KbdAction } from "~/components/ui/Kbd";
 import { useResizablePanel } from "~/lib/use-resizable-panel";
 import { TerminalPane, type TerminalDescriptor } from "./TerminalPane";
 import type { Project, Task } from "~/db/schema";
@@ -76,7 +76,7 @@ export function TerminalPanel({
           Agent
         </span>
         <span style={{ marginLeft: "auto", color: "var(--text-faint)", fontSize: 10.5 }}>
-          Close <Kbd variant="ghost">{hotkeyLabel("mod+l")}</Kbd>
+          Close <KbdAction action="terminal.close" variant="ghost" />
         </span>
       </div>
       <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>

--- a/src/db/keybindings.ts
+++ b/src/db/keybindings.ts
@@ -1,0 +1,67 @@
+import { getSetting, setSetting } from "./settings";
+import { DEFAULT_BINDINGS } from "~/lib/keybindings/defaults";
+import { HOTKEY_ACTIONS, type Binding, type BindingMap, type HotkeyAction } from "~/lib/keybindings/types";
+
+// Decoupled scope so adding per-user later is a one-line caller change.
+const DEFAULT_SCOPE = "global";
+const settingKey = (scope: string) => `keybindings:${scope}`;
+
+function isHotkeyAction(s: string): s is HotkeyAction {
+  return (HOTKEY_ACTIONS as readonly string[]).includes(s);
+}
+
+function isBinding(v: unknown): v is Binding {
+  if (!v || typeof v !== "object") return false;
+  const b = v as Record<string, unknown>;
+  return (
+    typeof b.mod === "boolean" &&
+    typeof b.shift === "boolean" &&
+    typeof b.alt === "boolean" &&
+    typeof b.key === "string" &&
+    b.key.length > 0
+  );
+}
+
+function readOverrides(scope: string): Partial<BindingMap> {
+  const raw = getSetting(settingKey(scope));
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const out: Partial<BindingMap> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (isHotkeyAction(k) && isBinding(v)) out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeOverrides(scope: string, overrides: Partial<BindingMap>): void {
+  setSetting(settingKey(scope), JSON.stringify(overrides));
+}
+
+export function getBindings(scope: string = DEFAULT_SCOPE): BindingMap {
+  const overrides = readOverrides(scope);
+  return { ...DEFAULT_BINDINGS, ...overrides };
+}
+
+export function setBinding(action: HotkeyAction, binding: Binding, scope: string = DEFAULT_SCOPE): BindingMap {
+  const overrides = readOverrides(scope);
+  overrides[action] = binding;
+  writeOverrides(scope, overrides);
+  return { ...DEFAULT_BINDINGS, ...overrides };
+}
+
+export function resetBinding(action: HotkeyAction, scope: string = DEFAULT_SCOPE): BindingMap {
+  const overrides = readOverrides(scope);
+  delete overrides[action];
+  writeOverrides(scope, overrides);
+  return { ...DEFAULT_BINDINGS, ...overrides };
+}
+
+export function resetAllBindings(scope: string = DEFAULT_SCOPE): BindingMap {
+  writeOverrides(scope, {});
+  return { ...DEFAULT_BINDINGS };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type { Group, Project, Task, UserTerminal } from "~/db/schema";
 import type { ProjectWithCounts } from "~/server/services/projects";
+import type { Binding, BindingMap, HotkeyAction } from "~/lib/keybindings/types";
 
 async function req<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, {
@@ -96,6 +97,19 @@ export const api = {
     }),
   deleteUserTerminal: (id: string) =>
     req<void>(`/api/user-terminals/${id}`, { method: "DELETE" }),
+
+  getKeybindings: () => req<{ bindings: BindingMap }>("/api/keybindings"),
+  setKeybinding: (action: HotkeyAction, binding: Binding) =>
+    req<{ bindings: BindingMap }>("/api/keybindings", {
+      method: "PUT",
+      body: JSON.stringify({ action, binding }),
+    }),
+  resetKeybinding: (action: HotkeyAction) =>
+    req<{ bindings: BindingMap }>(`/api/keybindings?action=${encodeURIComponent(action)}`, {
+      method: "DELETE",
+    }),
+  resetAllKeybindings: () =>
+    req<{ bindings: BindingMap }>("/api/keybindings", { method: "DELETE" }),
 
   getSettings: () => req<{ apiToken: string }>("/api/settings"),
   regenerateToken: () =>

--- a/src/lib/keybindings/__tests__/match.test.ts
+++ b/src/lib/keybindings/__tests__/match.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { matchBinding, eventToBinding, bindingComboKey, bindingsEqual, isValidBinding } from "../match";
+import { DEFAULT_BINDINGS } from "../defaults";
+import { HOTKEY_ACTIONS } from "../types";
+
+function ev(init: { key: string; metaKey?: boolean; ctrlKey?: boolean; shiftKey?: boolean; altKey?: boolean }): KeyboardEvent {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...init,
+  } as unknown as KeyboardEvent;
+}
+
+describe("matchBinding", () => {
+  it("matches every default binding against an event built from it", () => {
+    for (const action of HOTKEY_ACTIONS) {
+      const b = DEFAULT_BINDINGS[action];
+      const e = ev({ metaKey: b.mod, shiftKey: b.shift, altKey: b.alt, key: b.key });
+      expect(matchBinding(e, b)).toBe(true);
+    }
+  });
+
+  it("rejects when modifiers differ", () => {
+    const b = DEFAULT_BINDINGS["agent.new"];
+    expect(matchBinding(ev({ key: b.key }), b)).toBe(false);
+  });
+
+  it("treats Shift+~ as a match for `", () => {
+    expect(
+      matchBinding(ev({ metaKey: true, shiftKey: false, key: "~" }), { mod: true, shift: false, alt: false, key: "`" }),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive for letter keys", () => {
+    const b = { mod: true, shift: false, alt: false, key: "n" };
+    expect(matchBinding(ev({ metaKey: true, key: "N" }), b)).toBe(true);
+  });
+});
+
+describe("eventToBinding", () => {
+  it("ignores lone modifier keys", () => {
+    expect(eventToBinding(ev({ key: "Meta", metaKey: true }))).toBeNull();
+  });
+
+  it("captures Cmd+Shift+P", () => {
+    const b = eventToBinding(ev({ metaKey: true, shiftKey: true, key: "P" }));
+    expect(b).toEqual({ mod: true, shift: true, alt: false, key: "p" });
+  });
+});
+
+describe("isValidBinding", () => {
+  it("requires Cmd/Ctrl", () => {
+    expect(isValidBinding({ mod: false, shift: false, alt: false, key: "n" }).ok).toBe(false);
+  });
+  it("accepts a valid mod+key", () => {
+    expect(isValidBinding({ mod: true, shift: false, alt: false, key: "n" }).ok).toBe(true);
+  });
+});
+
+describe("bindingComboKey + bindingsEqual", () => {
+  it("treats the same combo as equal regardless of key casing", () => {
+    const a = { mod: true, shift: false, alt: false, key: "N" };
+    const b = { mod: true, shift: false, alt: false, key: "n" };
+    expect(bindingComboKey(a)).toBe(bindingComboKey(b));
+    expect(bindingsEqual(a, b)).toBe(true);
+  });
+});

--- a/src/lib/keybindings/defaults.ts
+++ b/src/lib/keybindings/defaults.ts
@@ -1,0 +1,16 @@
+import type { Binding, BindingMap } from "./types";
+
+export function makeBinding(partial: Partial<Binding> & { key: string }): Binding {
+  return { mod: false, shift: false, alt: false, ...partial };
+}
+
+export const DEFAULT_BINDINGS: BindingMap = {
+  "agent.new": makeBinding({ mod: true, key: "n" }),
+  "project.edit": makeBinding({ mod: true, key: "e" }),
+  "project.picker": makeBinding({ mod: true, key: "p" }),
+  "nav.toggle": makeBinding({ mod: true, key: "m" }),
+  "search.focus": makeBinding({ mod: true, key: "/" }),
+  "terminal.toggle": makeBinding({ mod: true, key: "`" }),
+  "terminal.close": makeBinding({ mod: true, key: "l" }),
+  "dialog.submit": makeBinding({ mod: true, key: "Enter" }),
+};

--- a/src/lib/keybindings/format.ts
+++ b/src/lib/keybindings/format.ts
@@ -1,0 +1,30 @@
+import type { Binding } from "./types";
+
+const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+
+const KEY_GLYPH: Record<string, string> = {
+  Enter: "↵",
+  enter: "↵",
+  ArrowUp: "↑",
+  ArrowDown: "↓",
+  ArrowLeft: "←",
+  ArrowRight: "→",
+  Escape: "Esc",
+  Tab: "⇥",
+  " ": "Space",
+};
+
+function formatKey(key: string): string {
+  if (KEY_GLYPH[key]) return KEY_GLYPH[key];
+  if (key.length === 1) return key.toUpperCase();
+  return key;
+}
+
+export function formatBinding(b: Binding): string {
+  const parts: string[] = [];
+  if (b.mod) parts.push(isMac ? "⌘" : "Ctrl");
+  if (b.alt) parts.push(isMac ? "⌥" : "Alt");
+  if (b.shift) parts.push(isMac ? "⇧" : "Shift");
+  parts.push(formatKey(b.key));
+  return isMac ? parts.join("") : parts.join("+");
+}

--- a/src/lib/keybindings/match.ts
+++ b/src/lib/keybindings/match.ts
@@ -1,0 +1,46 @@
+import type { Binding } from "./types";
+
+function normalizeKey(key: string): string {
+  if (key.length === 1) return key.toLowerCase();
+  return key;
+}
+
+export function eventToBinding(e: KeyboardEvent): Binding | null {
+  const key = e.key;
+  if (key === "Meta" || key === "Control" || key === "Shift" || key === "Alt") return null;
+  return {
+    mod: e.metaKey || e.ctrlKey,
+    shift: e.shiftKey,
+    alt: e.altKey,
+    key: normalizeKey(key),
+  };
+}
+
+export function matchBinding(e: KeyboardEvent, b: Binding): boolean {
+  const mod = e.metaKey || e.ctrlKey;
+  if (mod !== b.mod) return false;
+  if (e.shiftKey !== b.shift) return false;
+  if (e.altKey !== b.alt) return false;
+  const ek = normalizeKey(e.key);
+  // Allow shifted symbol equivalents (e.g. binding "`" matches Shift+~ on US layouts).
+  if (ek === b.key) return true;
+  if (b.key === "`" && ek === "~") return true;
+  return false;
+}
+
+export function bindingsEqual(a: Binding, b: Binding): boolean {
+  return a.mod === b.mod && a.shift === b.shift && a.alt === b.alt && normalizeKey(a.key) === normalizeKey(b.key);
+}
+
+export function bindingComboKey(b: Binding): string {
+  return `${b.mod ? "M" : ""}${b.shift ? "S" : ""}${b.alt ? "A" : ""}|${normalizeKey(b.key)}`;
+}
+
+export function isValidBinding(b: Binding): { ok: true } | { ok: false; reason: string } {
+  if (!b.mod) return { ok: false, reason: "Binding must include Cmd/Ctrl." };
+  if (!b.key) return { ok: false, reason: "Missing key." };
+  if (b.key === "Meta" || b.key === "Control" || b.key === "Shift" || b.key === "Alt") {
+    return { ok: false, reason: "Binding must include a non-modifier key." };
+  }
+  return { ok: true };
+}

--- a/src/lib/keybindings/store.tsx
+++ b/src/lib/keybindings/store.tsx
@@ -1,0 +1,67 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { api } from "~/lib/api";
+import { DEFAULT_BINDINGS } from "./defaults";
+import { formatBinding } from "./format";
+import type { Binding, BindingMap, HotkeyAction } from "./types";
+
+type Ctx = {
+  bindings: BindingMap;
+  setBinding: (action: HotkeyAction, b: Binding) => Promise<void>;
+  resetBinding: (action: HotkeyAction) => Promise<void>;
+  resetAll: () => Promise<void>;
+  refresh: () => Promise<void>;
+};
+
+const KeybindingsContext = createContext<Ctx | null>(null);
+
+export function KeybindingsProvider({ children }: { children: ReactNode }) {
+  const [bindings, setBindings] = useState<BindingMap>(DEFAULT_BINDINGS);
+
+  const refresh = useCallback(async () => {
+    try {
+      const r = await api.getKeybindings();
+      setBindings(r.bindings);
+    } catch {
+      // Keep current bindings on transient failure.
+    }
+  }, []);
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const value = useMemo<Ctx>(
+    () => ({
+      bindings,
+      refresh,
+      async setBinding(action, b) {
+        const r = await api.setKeybinding(action, b);
+        setBindings(r.bindings);
+      },
+      async resetBinding(action) {
+        const r = await api.resetKeybinding(action);
+        setBindings(r.bindings);
+      },
+      async resetAll() {
+        const r = await api.resetAllKeybindings();
+        setBindings(r.bindings);
+      },
+    }),
+    [bindings, refresh],
+  );
+
+  return <KeybindingsContext.Provider value={value}>{children}</KeybindingsContext.Provider>;
+}
+
+export function useKeybindings(): Ctx {
+  const ctx = useContext(KeybindingsContext);
+  if (!ctx) throw new Error("useKeybindings must be used within KeybindingsProvider");
+  return ctx;
+}
+
+export function useBinding(action: HotkeyAction): Binding {
+  return useKeybindings().bindings[action];
+}
+
+export function useFormattedBinding(action: HotkeyAction): string {
+  return formatBinding(useBinding(action));
+}

--- a/src/lib/keybindings/types.ts
+++ b/src/lib/keybindings/types.ts
@@ -1,0 +1,32 @@
+export const HOTKEY_ACTIONS = [
+  "agent.new",
+  "project.edit",
+  "project.picker",
+  "nav.toggle",
+  "search.focus",
+  "terminal.toggle",
+  "terminal.close",
+  "dialog.submit",
+] as const;
+
+export type HotkeyAction = (typeof HOTKEY_ACTIONS)[number];
+
+export type Binding = {
+  mod: boolean;
+  shift: boolean;
+  alt: boolean;
+  key: string;
+};
+
+export type BindingMap = Record<HotkeyAction, Binding>;
+
+export const ACTION_META: Record<HotkeyAction, { label: string; description: string }> = {
+  "agent.new": { label: "New agent / project", description: "Create a new agent on a project page, or a new project on the home page." },
+  "project.edit": { label: "Edit project", description: "Open the edit dialog for the current project." },
+  "project.picker": { label: "Open project picker", description: "Open the cross-project quick switcher." },
+  "nav.toggle": { label: "Toggle nav menu", description: "Show or hide the navigation menu." },
+  "search.focus": { label: "Focus search", description: "Focus the project search field on the home page." },
+  "terminal.toggle": { label: "Toggle terminal panel", description: "Show or hide the bottom terminal panel." },
+  "terminal.close": { label: "Close terminal", description: "Deselect / close the active terminal session." },
+  "dialog.submit": { label: "Submit dialog", description: "Submit a dialog form (New agent, edit project, etc.)." },
+};

--- a/src/lib/use-hotkey.ts
+++ b/src/lib/use-hotkey.ts
@@ -1,36 +1,20 @@
 import { useEffect, useRef } from "react";
-import type { HotkeyCombo } from "~/components/ui/Kbd";
+import { matchBinding } from "~/lib/keybindings/match";
+import { useKeybindings } from "~/lib/keybindings/store";
+import { HOTKEY_ACTIONS, type HotkeyAction } from "~/lib/keybindings/types";
 
-export function matchHotkey(e: KeyboardEvent, combo: HotkeyCombo): boolean {
-  const mod = e.metaKey || e.ctrlKey;
-  // All `mod+*` combos require *only* the mod key — no Shift/Alt — so muscle
-  // memory like Cmd+Shift+P (browser command palette) doesn't trigger our
-  // bindings. ctrl+` accepts Shift since `~` requires it on US layouts.
-  const plain = !e.shiftKey && !e.altKey;
-  switch (combo) {
-    case "mod+enter":
-      return mod && plain && e.key === "Enter";
-    case "mod+n":
-      return mod && plain && (e.key === "n" || e.key === "N");
-    case "mod+e":
-      return mod && plain && (e.key === "e" || e.key === "E");
-    case "mod+p":
-      return mod && plain && (e.key === "p" || e.key === "P");
-    case "mod+m":
-      return mod && plain && (e.key === "m" || e.key === "M");
-    case "mod+/":
-      return mod && plain && e.key === "/";
-    case "mod+.":
-      return mod && plain && e.key === ".";
-    case "mod+l":
-      return mod && plain && (e.key === "l" || e.key === "L");
-    case "ctrl+`":
-      return mod && !e.altKey && (e.key === "`" || e.key === "~");
-    case "enter":
-      return plain && !mod && e.key === "Enter";
-    case "escape":
-      return e.key === "Escape";
+export type HotkeyTarget = HotkeyAction | "enter" | "escape";
+
+function isAction(t: HotkeyTarget): t is HotkeyAction {
+  return (HOTKEY_ACTIONS as readonly string[]).includes(t);
+}
+
+function matchLiteral(e: KeyboardEvent, t: "enter" | "escape"): boolean {
+  if (t === "enter") {
+    const mod = e.metaKey || e.ctrlKey;
+    return !mod && !e.shiftKey && !e.altKey && e.key === "Enter";
   }
+  return e.key === "Escape";
 }
 
 export function isEditableTarget(target: EventTarget | null): boolean {
@@ -50,7 +34,7 @@ export type HotkeyOptions = {
 };
 
 export function useHotkey(
-  combo: HotkeyCombo,
+  target: HotkeyTarget,
   handler: (e: KeyboardEvent) => void,
   options: HotkeyOptions = {},
 ) {
@@ -63,18 +47,24 @@ export function useHotkey(
   const handlerRef = useRef(handler);
   handlerRef.current = handler;
 
+  // Always call useKeybindings so hook order stays stable; bindings ref read inside listener.
+  const { bindings } = useKeybindings();
+  const bindingsRef = useRef(bindings);
+  bindingsRef.current = bindings;
+
   useEffect(() => {
     if (!enabled) return;
     const onKey = (e: KeyboardEvent) => {
-      if (!matchHotkey(e, combo)) return;
+      const matched = isAction(target)
+        ? matchBinding(e, bindingsRef.current[target])
+        : matchLiteral(e, target);
+      if (!matched) return;
       if (ignoreEditable && isEditableTarget(e.target)) return;
       if (preventDefault) e.preventDefault();
-      // In capture phase, stop propagation so descendants (xterm.js textarea)
-      // never see the key. Bubble-phase listeners stay non-intrusive.
       if (capture) e.stopPropagation();
       handlerRef.current(e);
     };
     window.addEventListener("keydown", onKey, capture);
     return () => window.removeEventListener("keydown", onKey, capture);
-  }, [combo, enabled, ignoreEditable, preventDefault, capture]);
+  }, [target, enabled, ignoreEditable, preventDefault, capture]);
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,8 +9,9 @@ import {
 import { getElectron } from "~/lib/electron";
 import { TopBar, type Crumb } from "~/components/ui/TopBar";
 import { Btn } from "~/components/ui/Btn";
-import { Kbd, hotkeyLabel } from "~/components/ui/Kbd";
-import { matchHotkey } from "~/lib/use-hotkey";
+import { KbdAction } from "~/components/ui/Kbd";
+import { useHotkey } from "~/lib/use-hotkey";
+import { KeybindingsProvider } from "~/lib/keybindings/store";
 import { useTheme } from "~/lib/use-theme";
 import { TerminalProvider, useTerminals } from "~/lib/terminal-store";
 import {
@@ -40,11 +41,13 @@ function RootComponent() {
         <HeadContent />
       </head>
       <body>
-        <TerminalProvider>
-          <UserTerminalProvider>
-            <Shell />
-          </UserTerminalProvider>
-        </TerminalProvider>
+        <KeybindingsProvider>
+          <TerminalProvider>
+            <UserTerminalProvider>
+              <Shell />
+            </UserTerminalProvider>
+          </TerminalProvider>
+        </KeybindingsProvider>
         <Scripts />
       </body>
     </html>
@@ -69,25 +72,15 @@ function Shell() {
 
   const goHome = () => router.navigate({ to: "/" });
 
-  // Cmd/Ctrl + [ / ] cycles through user terminals; opens panel if hidden.
+  useHotkey("terminal.toggle", () => userTerminals.togglePanel());
+  useHotkey("nav.toggle", () => router.navigate({ to: "/" }));
+  // Cmd/Ctrl + [ / ] / T are non-rebindable terminal-focused shortcuts.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return;
-      // Global app shortcuts fire regardless of focus — including when xterm's
-      // hidden textarea has focus (which counts as "editable").
-      if (matchHotkey(e, "ctrl+`")) {
-        e.preventDefault();
-        userTerminals.togglePanel();
-        return;
-      }
       if ((e.key === "t" || e.key === "T") && !e.shiftKey && !e.altKey) {
         e.preventDefault();
         void userTerminals.createTerminal();
-        return;
-      }
-      if (matchHotkey(e, "mod+m")) {
-        e.preventDefault();
-        router.navigate({ to: "/" });
         return;
       }
       if (e.key === "[" && !e.shiftKey && !e.altKey) {
@@ -103,7 +96,7 @@ function Shell() {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [userTerminals, router]);
+  }, [userTerminals]);
 
   // Cmd/Ctrl+W is intercepted in the Electron main process (otherwise the
   // default app menu's "Close Window" item closes the BrowserWindow before any
@@ -129,7 +122,7 @@ function Shell() {
             {path !== "/" && (
               <Btn variant="ghost" icon="home" onClick={goHome}>
                 Mission Control
-                <Kbd variant="ghost">{hotkeyLabel("mod+m")}</Kbd>
+                <KbdAction action="nav.toggle" />
               </Btn>
             )}
             <Btn

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, useRouter } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Btn } from "~/components/ui/Btn";
 import { Icon } from "~/components/ui/Icon";
-import { Kbd, hotkeyLabel } from "~/components/ui/Kbd";
+import { KbdAction } from "~/components/ui/Kbd";
 import { useHotkey } from "~/lib/use-hotkey";
 import { useWheelSwipe } from "~/lib/use-wheel-swipe";
 import { Section } from "~/components/ui/Section";
@@ -40,12 +40,12 @@ function MissionControlPage() {
     setActiveUserTerminalProject(null);
   }, [setActiveUserTerminalProject]);
 
-  useHotkey("mod+/", () => {
+  useHotkey("search.focus", () => {
     searchRef.current?.focus();
     searchRef.current?.select();
   });
 
-  useHotkey("mod+n", () => setShowAdd(true));
+  useHotkey("agent.new", () => setShowAdd(true));
 
   const refresh = useCallback(async () => {
     const [p, g] = await Promise.all([api.listProjects(), api.listGroups()]);
@@ -250,7 +250,7 @@ function MissionControlPage() {
                     fontSize: 11.5,
                   }}
                 />
-                <Kbd>{hotkeyLabel("mod+/")}</Kbd>
+                <KbdAction action="search.focus" />
               </div>
 
               <div
@@ -296,7 +296,7 @@ function MissionControlPage() {
               </Btn>
               <Btn variant="primary" icon="plus" onClick={() => setShowAdd(true)}>
                 Add project
-                <Kbd variant="onPrimary">{hotkeyLabel("mod+n")}</Kbd>
+                <KbdAction action="agent.new" variant="onPrimary" />
               </Btn>
             </div>
           </div>

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -11,7 +11,8 @@ import { LaunchButton } from "~/components/views/LaunchButton";
 import { NewAgentButton } from "~/components/views/NewAgentButton";
 import { AgentGlyph } from "~/components/ui/AgentGlyph";
 import { CursorGlow } from "~/components/ui/CursorGlow";
-import { Kbd, hotkeyLabel } from "~/components/ui/Kbd";
+import { Kbd } from "~/components/ui/Kbd";
+import { useFormattedBinding } from "~/lib/keybindings/store";
 import { Modal } from "~/components/ui/Modal";
 import { useHotkey } from "~/lib/use-hotkey";
 import { useWheelSwipe } from "~/lib/use-wheel-swipe";
@@ -42,8 +43,7 @@ function ProjectPage() {
   const [confirmRemove, setConfirmRemove] = useState(false);
   const [apiToken, setApiToken] = useState<string | null>(null);
 
-  const newAgentHotkey = hotkeyLabel("mod+n");
-  const editProjectHotkey = hotkeyLabel("mod+e");
+  const editProjectHotkey = useFormattedBinding("project.edit");
 
   const headerRef = useRef<HTMLDivElement | null>(null);
   const [headerNarrow, setHeaderNarrow] = useState(false);
@@ -129,9 +129,9 @@ function ProjectPage() {
     setShowNewAgent(true);
   }, [project, showNewAgent, showEdit, startWithSaved]);
 
-  useHotkey("mod+n", onNewAgentPrimary, { ignoreEditable: true });
+  useHotkey("agent.new", onNewAgentPrimary, { ignoreEditable: true });
 
-  useHotkey("mod+e", () => {
+  useHotkey("project.edit", () => {
     if (showNewAgent) return;
     setShowEdit((v) => !v);
   });
@@ -140,7 +140,7 @@ function ProjectPage() {
     !showNewAgent && !showEdit && !confirmRemove && terminals.active !== null;
 
   // Capture phase so xterm.js (focused terminal) can't swallow the key first.
-  useHotkey("mod+l", () => terminals.deselect(), {
+  useHotkey("terminal.close", () => terminals.deselect(), {
     enabled: closePanelEnabled,
     capture: true,
   });

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useState } from "react";
 import { Btn } from "~/components/ui/Btn";
 import { Icon } from "~/components/ui/Icon";
+import { KeybindingsSettings } from "~/components/views/KeybindingsSettings";
 import { api } from "~/lib/api";
 import { getElectron } from "~/lib/electron";
 
@@ -95,6 +96,13 @@ function SettingsPage() {
               monoSize={11}
             />
           </Field>
+        </SettingsSection>
+
+        <SettingsSection
+          title="Keybindings"
+          subtitle="Rebind any global app shortcut. Bindings are saved per-app and apply immediately."
+        >
+          <KeybindingsSettings />
         </SettingsSection>
 
         {userData && (

--- a/src/server/api-router.ts
+++ b/src/server/api-router.ts
@@ -19,6 +19,9 @@ import {
 } from "./services/user-terminals";
 import { events } from "./events";
 import { getOrCreateApiToken, regenerateApiToken } from "~/db/settings";
+import { getBindings, setBinding, resetBinding, resetAllBindings } from "~/db/keybindings";
+import { HOTKEY_ACTIONS, type HotkeyAction } from "~/lib/keybindings/types";
+import { isValidBinding } from "~/lib/keybindings/match";
 import { json, jsonError, requireBearerToken } from "./auth";
 import { generateTitleForTask } from "./services/title-generator";
 
@@ -201,6 +204,36 @@ export async function handleApiRequest(request: Request): Promise<Response | nul
         const body = await readJson<any>(request).catch(() => ({}));
         if ((body as any)?.regenerate) return json({ apiToken: regenerateApiToken() });
         return json({ apiToken: getOrCreateApiToken() });
+      }
+    }
+
+    if (pathname === "/api/keybindings") {
+      if (method === "GET") return json({ bindings: getBindings() });
+      if (method === "PUT") {
+        const body = await readJson<any>(request).catch(() => null);
+        const action = body?.action as string | undefined;
+        const binding = body?.binding;
+        if (!action || !(HOTKEY_ACTIONS as readonly string[]).includes(action)) {
+          return jsonError(400, "invalid action");
+        }
+        if (!binding || typeof binding !== "object") return jsonError(400, "binding required");
+        const candidate = {
+          mod: !!binding.mod,
+          shift: !!binding.shift,
+          alt: !!binding.alt,
+          key: typeof binding.key === "string" ? binding.key : "",
+        };
+        const valid = isValidBinding(candidate);
+        if (!valid.ok) return jsonError(400, valid.reason);
+        return json({ bindings: setBinding(action as HotkeyAction, candidate) });
+      }
+      if (method === "DELETE") {
+        const action = url.searchParams.get("action");
+        if (action === null) return json({ bindings: resetAllBindings() });
+        if (!(HOTKEY_ACTIONS as readonly string[]).includes(action)) {
+          return jsonError(400, "invalid action");
+        }
+        return json({ bindings: resetBinding(action as HotkeyAction) });
       }
     }
 


### PR DESCRIPTION
> Drafted using [agentsystem.dev](https://agentsystem.dev)

## What changed
Every global app shortcut (new agent, project picker, terminal toggle, dialog submit, etc.) is now user-configurable from the Settings page. Bindings persist in the embedded SQLite store and apply immediately across the app — no reload.

## Why
Hotkeys were a closed string union baked into one switch statement, so any user whose muscle memory or keyboard layout disagreed with the defaults had no recourse. The Settings page now has a Keybindings section that records a fresh keystroke, validates it (must include Cmd/Ctrl), warns when it would collide with another action, and lets the user reset individually or all at once.

## How to review
- Start at `src/lib/keybindings/types.ts` for the action catalog and `src/lib/keybindings/defaults.ts` for the default bindings (which match the previous hardcoded combos exactly, so existing muscle memory still works out of the box).
- `src/lib/keybindings/store.tsx` is the client provider; every `useHotkey` and `<KbdAction>` reads from it, so a rebind takes effect immediately.
- `src/db/keybindings.ts` stores overrides as JSON in the existing `app_settings` kv table, scoped by a `"global"` key. The scope param is plumbed through every DA function so adding per-user scoping later is a one-call change.
- `src/components/views/KeybindingsSettings.tsx` is the new UI section; capture flow is keyboard-only and Esc-dismissable to match sibling Modal conventions.

## Things to look out for
- `useHotkey` now reads bindings from React context — every call site must be inside `<KeybindingsProvider>` (mounted at `__root.tsx`).
- `enter` and `escape` remain non-rebindable contextual literals (used inside dialogs); only the named action IDs are configurable.
- Server route `/api/keybindings` (GET/PUT/DELETE) is additive and not authed (mirrors existing `/api/settings`).

Might address #1 — _Add settings page to customize keybindings_