### PR TITLE
feat: terminal zoom controls and pull request creation

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -129,8 +129,11 @@ const electronAPI = {
     kill: (ptyId: string) => ipcRenderer.invoke(IPC.ptyKill, { ptyId }),
     killLaunchProcesses: (opts: { cwd: string; commands: string[]; ports?: number[] }) =>
       ipcRenderer.invoke(IPC.ptyKillLaunchProcesses, opts),
-    onData: (cb: (msg: { ptyId: string; data: string }) => void) => {
-      const listener = (_: Electron.IpcRendererEvent, msg: { ptyId: string; data: string }) => cb(msg);
+    onData: (cb: (msg: { ptyId: string; data: string; seq: number }) => void) => {
+      const listener = (
+        _: Electron.IpcRendererEvent,
+        msg: { ptyId: string; data: string; seq: number },
+      ) => cb(msg);
       ipcRenderer.on(IPC.ptyData, listener);
       return () => ipcRenderer.removeListener(IPC.ptyData, listener);
     },
@@ -140,7 +143,8 @@ const electronAPI = {
       ipcRenderer.on(IPC.ptyExit, listener);
       return () => ipcRenderer.removeListener(IPC.ptyExit, listener);
     },
-    replay: (ptyId: string): Promise<string> => ipcRenderer.invoke(IPC.ptyReplay, { ptyId }) as Promise<string>,
+    replay: (ptyId: string): Promise<{ data: string; nextSeq: number }> =>
+      ipcRenderer.invoke(IPC.ptyReplay, { ptyId }) as Promise<{ data: string; nextSeq: number }>,
   },
   onSwipe: (cb: (direction: "left" | "right" | "up" | "down") => void) => {
     const listener = (_: Electron.IpcRendererEvent, direction: "left" | "right" | "up" | "down") => cb(direction);

--- a/electron/pty-manager.ts
+++ b/electron/pty-manager.ts
@@ -65,8 +65,9 @@ type Pty = {
   id: string;
   taskId: string;
   proc: any;
-  buffer: string[];
+  buffer: PtyBufferChunk[];
   bufferBytes: number;
+  nextSeq: number;
   cwd: string;
   command: string;
   agent?: string;
@@ -75,6 +76,12 @@ type Pty = {
   lastInterruptAt: number;
   spawnStartedAt: number;
   killedByUser: boolean;
+};
+
+type PtyBufferChunk = {
+  seq: number;
+  data: string;
+  bytes: number;
 };
 
 const INTERRUPT_COOLDOWN_MS = 2000;
@@ -181,17 +188,20 @@ function loadNodePty() {
   return nodePty!;
 }
 
-function appendBuffer(p: Pty, chunk: string) {
-  p.buffer.push(chunk);
-  p.bufferBytes += Buffer.byteLength(chunk, "utf8");
+function appendBuffer(p: Pty, data: string): number {
+  const bytes = Buffer.byteLength(data, "utf8");
+  const seq = p.nextSeq++;
+  p.buffer.push({ seq, data, bytes });
+  p.bufferBytes += bytes;
   while (p.bufferBytes > RING_LIMIT_BYTES && p.buffer.length > 1) {
     const dropped = p.buffer.shift()!;
-    p.bufferBytes -= Buffer.byteLength(dropped, "utf8");
+    p.bufferBytes -= dropped.bytes;
   }
+  return seq;
 }
 
 function ptyOutputTail(p: Pty): string {
-  return p.buffer.join("").slice(-SESSION_START_OUTPUT_TAIL_MAX);
+  return p.buffer.map((chunk) => chunk.data).join("").slice(-SESSION_START_OUTPUT_TAIL_MAX);
 }
 
 function send(getWin: () => BrowserWindow | null, channel: string, payload: any) {
@@ -461,6 +471,7 @@ export function registerPtyHandlers(
         proc,
         buffer: [],
         bufferBytes: 0,
+        nextSeq: 1,
         cwd: opts.cwd,
         command: opts.command,
         agent: opts.agent,
@@ -473,11 +484,11 @@ export function registerPtyHandlers(
       ptys.set(id, p);
 
       proc.onData((data: string) => {
-        appendBuffer(p, data);
+        const seq = appendBuffer(p, data);
         const haystack = scanTail(p, data);
         scanForInterrupt(p, haystack);
         scanForCodexHookReview(p, haystack);
-        send(getWin, IPC.ptyData, { ptyId: id, data });
+        send(getWin, IPC.ptyData, { ptyId: id, data, seq });
       });
       proc.onExit(({ exitCode, signal }: { exitCode: number; signal?: number }) => {
         const elapsedMs = Date.now() - p.spawnStartedAt;
@@ -574,8 +585,11 @@ export function registerPtyHandlers(
 
   safeHandle(IPC.ptyReplay, (_evt, { ptyId }: { ptyId: string }) => {
     const p = ptys.get(ptyId);
-    if (!p) return "";
-    return p.buffer.join("");
+    if (!p) return { data: "", nextSeq: 0 };
+    return {
+      data: p.buffer.map((chunk) => chunk.data).join(""),
+      nextSeq: p.nextSeq,
+    };
   }, ipcMain);
 }
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@tanstack/react-start": "1.167.65",
     "@uiw/react-codemirror": "4.25.9",
     "@xterm/addon-fit": "0.11.0",
+    "@xterm/addon-web-links": "0.12.0",
     "@xterm/xterm": "6.0.0",
     "better-sqlite3": "12.10.0",
     "drizzle-orm": "0.45.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@xterm/addon-fit':
         specifier: 0.11.0
         version: 0.11.0
+      '@xterm/addon-web-links':
+        specifier: 0.12.0
+        version: 0.12.0
       '@xterm/xterm':
         specifier: 6.0.0
         version: 6.0.0
@@ -1960,6 +1963,9 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-web-links@0.12.0':
+    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
@@ -7060,6 +7066,8 @@ snapshots:
   '@xmldom/xmldom@0.9.10': {}
 
   '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-web-links@0.12.0': {}
 
   '@xterm/xterm@6.0.0': {}
 

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -33,6 +33,7 @@ export type IconName =
   | "sparkles"
   | "copy"
   | "trash"
+  | "eraser"
   | "github"
   | "chart"
   | "sun"
@@ -40,7 +41,9 @@ export type IconName =
   | "stop"
   | "external-link"
   | "shield"
-  | "bell";
+  | "bell"
+  | "zoom-in"
+  | "zoom-out";
 
 export function Icon({ name, size = 14, style }: { name: IconName; size?: number; style?: CSSProperties }) {
   const common = {
@@ -218,6 +221,13 @@ export function Icon({ name, size = 14, style }: { name: IconName; size?: number
           <path d="M2.5 4h11M6 4V2.5h4V4M3.5 4l.7 9.1c0 .5.4.9.9.9h5.8c.5 0 .9-.4.9-.9L12.5 4M6.5 7v4M9.5 7v4" />
         </svg>
       );
+    case "eraser":
+      return (
+        <svg {...common}>
+          <path d="M11.5 2.5l2 2-7.2 7.2-2.8.8.8-2.8 7.2-7.2z" />
+          <path d="M3 13.5h10" />
+        </svg>
+      );
     case "chart":
       return (
         <svg {...common}>
@@ -271,6 +281,22 @@ export function Icon({ name, size = 14, style }: { name: IconName; size?: number
         <svg {...common}>
           <path d="M5 6a3 3 0 016 0c0 3 1.5 3.5 1.5 5H3.5C3.5 9.5 5 9 5 6z" />
           <path d="M6.5 13a1.7 1.7 0 003 0" />
+        </svg>
+      );
+    case "zoom-in":
+      return (
+        <svg {...common}>
+          <circle cx="7" cy="7" r="4.5" />
+          <path d="M13.5 13.5l-3-3" />
+          <path d="M7 4.5v5M4.5 7h5" />
+        </svg>
+      );
+    case "zoom-out":
+      return (
+        <svg {...common}>
+          <circle cx="7" cy="7" r="4.5" />
+          <path d="M13.5 13.5l-3-3" />
+          <path d="M4.5 7h5" />
         </svg>
       );
     default:

--- a/src/components/ui/TextField.tsx
+++ b/src/components/ui/TextField.tsx
@@ -6,6 +6,7 @@ export function TextField({
   value,
   onChange,
   placeholder,
+  ariaLabel,
   mono,
   rightAddon,
   type = "text",
@@ -17,6 +18,7 @@ export function TextField({
   value: string;
   onChange: (v: string) => void;
   placeholder?: string;
+  ariaLabel?: string;
   mono?: boolean;
   rightAddon?: ReactNode;
   type?: string;
@@ -59,6 +61,7 @@ export function TextField({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
+          aria-label={ariaLabel}
           autoFocus={autoFocus}
           ref={inputRef}
           aria-describedby={hintId}

--- a/src/components/views/AuthGate.tsx
+++ b/src/components/views/AuthGate.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useState, type ReactNode } from "react";
 import { useRouter } from "@tanstack/react-router";
 import { CardFrame } from "~/components/ui/CardFrame";
 import { Icon } from "~/components/ui/Icon";
@@ -16,6 +16,9 @@ type HostedEntitlementsState =
   | { status: "loading"; entitlements: null; error: null }
   | { status: "ready"; entitlements: Entitlements; error: null }
   | { status: "error"; entitlements: null; error: string };
+
+const useHostedSessionEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 function useHostedEntitlements(session: HostedSessionSummary | null) {
   const [state, setState] = useState<HostedEntitlementsState>({
@@ -90,7 +93,7 @@ export function useHostedSession() {
     }
   }, []);
 
-  useEffect(() => {
+  useHostedSessionEffect(() => {
     void refresh();
   }, [refresh]);
 
@@ -265,10 +268,77 @@ function AuthPendingShell() {
     <div
       id="root"
       style={{
-        minHeight: "100vh",
         background: "var(--bg)",
       }}
-    />
+    >
+      <div
+        aria-hidden
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 20,
+          zIndex: 20,
+          ["WebkitAppRegion" as any]: "drag",
+        }}
+      />
+      <div
+        aria-hidden
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          height: 48,
+          padding: "0 20px 0 24px",
+          borderBottom: "1px solid var(--border)",
+          flexShrink: 0,
+          ["WebkitAppRegion" as any]: "drag",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0 }}>
+          <img
+            src="/images/robot.png"
+            alt=""
+            width={22}
+            height={22}
+            style={{ borderRadius: 5, display: "block" }}
+          />
+          <span
+            style={{
+              width: 164,
+              height: 13,
+              borderRadius: 4,
+              background: "var(--surface-2)",
+            }}
+          />
+          <span
+            style={{
+              width: 44,
+              height: 22,
+              borderRadius: 999,
+              border: "1px solid var(--border)",
+            }}
+          />
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ width: 32, height: 32, borderRadius: 8, background: "var(--surface-2)" }} />
+          <span style={{ width: 32, height: 32, borderRadius: 8, background: "var(--surface-2)" }} />
+          <span style={{ width: 32, height: 32, borderRadius: 8, background: "var(--surface-2)" }} />
+        </div>
+      </div>
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          overflow: "hidden",
+          minHeight: 0,
+        }}
+      >
+        <div className="auth-pending-project-rail" aria-hidden />
+        <div style={{ flex: 1, minWidth: 0 }} />
+      </div>
+    </div>
   );
 }
 

--- a/src/components/views/CreatePullRequestButton.tsx
+++ b/src/components/views/CreatePullRequestButton.tsx
@@ -1,0 +1,225 @@
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { Btn } from "~/components/ui/Btn";
+import { Modal } from "~/components/ui/Modal";
+import { Icon } from "~/components/ui/Icon";
+import { formatCreatePullRequestError } from "~/lib/pull-request-errors";
+import { getElectron } from "~/lib/electron";
+import { DEFAULT_BRANCH } from "~/shared/domain";
+import { useGitCreatePullRequest } from "~/queries/git";
+
+export type CreatePullRequestDialogState =
+  | {
+      kind: "gh-missing";
+      compareUrl: string;
+      branch: string;
+      baseBranch: string;
+    }
+  | {
+      kind: "issue";
+      title: string;
+      message: string;
+    };
+
+function openExternal(url: string) {
+  const electron = getElectron();
+  if (electron?.openExternal) {
+    void electron.openExternal(url);
+    return;
+  }
+  window.open(url, "_blank", "noreferrer");
+}
+
+function Spinner() {
+  return (
+    <span style={{ display: "inline-flex", animation: "spin 0.8s linear infinite" }}>
+      <Icon name="refresh" size={11} />
+    </span>
+  );
+}
+
+export function useCreatePullRequestAction({
+  projectId,
+  worktreeId,
+  branch,
+  projectPathUsable = true,
+}: {
+  projectId: string;
+  worktreeId?: string | null;
+  branch?: string | null;
+  projectPathUsable?: boolean;
+}) {
+  const createPr = useGitCreatePullRequest(projectId, worktreeId);
+  const [dialog, setDialog] = useState<CreatePullRequestDialogState | null>(null);
+
+  const onCreate = useCallback(async () => {
+    if (createPr.isPending) return;
+
+    if (!projectPathUsable) {
+      setDialog({
+        kind: "issue",
+        title: "Project folder unavailable",
+        message:
+          "Mission Control cannot access this project's folder. Fix or reveal the project path, then try again.",
+      });
+      return;
+    }
+
+    if (!branch?.trim()) {
+      setDialog({
+        kind: "issue",
+        title: "Branch unavailable",
+        message:
+          "Mission Control could not determine the current branch yet. Wait for git status to finish loading, then try again.",
+      });
+      return;
+    }
+
+    if (branch === DEFAULT_BRANCH) {
+      setDialog({
+        kind: "issue",
+        title: "Switch to a feature branch",
+        message: `You're on ${DEFAULT_BRANCH}. Check out a feature branch for this worktree before opening a pull request into origin/${DEFAULT_BRANCH}.`,
+      });
+      return;
+    }
+
+    try {
+      const result = await createPr.mutateAsync();
+      if (result.kind === "gh-missing") {
+        setDialog({
+          kind: "gh-missing",
+          compareUrl: result.compareUrl,
+          branch: result.branch,
+          baseBranch: result.baseBranch,
+        });
+        return;
+      }
+      openExternal(result.url);
+      toast.success(
+        result.kind === "exists" ? "Opened existing pull request" : "Pull request created",
+      );
+    } catch (error) {
+      const { title, message } = formatCreatePullRequestError(error);
+      setDialog({
+        kind: "issue",
+        title,
+        message,
+      });
+    }
+  }, [branch, createPr, projectPathUsable]);
+
+  return {
+    onCreate,
+    busy: createPr.isPending,
+    dialog,
+    closeDialog: () => setDialog(null),
+  };
+}
+
+export function CreatePullRequestDialog({
+  state,
+  onClose,
+}: {
+  state: CreatePullRequestDialogState | null;
+  onClose: () => void;
+}) {
+  const ghMissing = state?.kind === "gh-missing" ? state : null;
+
+  return (
+    <Modal
+      open={state !== null}
+      onClose={onClose}
+      title={
+        state?.kind === "gh-missing"
+          ? "GitHub CLI not installed"
+          : (state?.title ?? "Create pull request")
+      }
+      width={520}
+      footer={
+        <>
+          <Btn variant="ghost" onClick={onClose}>
+            Close
+          </Btn>
+          {ghMissing && (
+            <Btn
+              variant="primary"
+              icon="external-link"
+              onClick={() => {
+                openExternal(ghMissing.compareUrl);
+                onClose();
+              }}
+            >
+              Open pull request on GitHub
+            </Btn>
+          )}
+        </>
+      }
+    >
+      {state?.kind === "issue" && (
+        <p style={{ margin: 0, color: "var(--text-dim)", fontSize: 13, whiteSpace: "pre-wrap" }}>
+          {state.message}
+        </p>
+      )}
+      {ghMissing && (
+        <div style={{ display: "grid", gap: 12, color: "var(--text-dim)", fontSize: 13 }}>
+          <p style={{ margin: 0 }}>
+            Install the{" "}
+            <a
+              href="https://cli.github.com/"
+              target="_blank"
+              rel="noreferrer"
+              style={{ color: "var(--accent)" }}
+            >
+              GitHub CLI
+            </a>{" "}
+            to create pull requests from Mission Control, or open the compare page for branch{" "}
+            <code style={{ color: "var(--text)" }}>{ghMissing.branch}</code> into{" "}
+            <code style={{ color: "var(--text)" }}>{ghMissing.baseBranch}</code>.
+          </p>
+          <a
+            href={ghMissing.compareUrl}
+            target="_blank"
+            rel="noreferrer"
+            style={{
+              color: "var(--accent)",
+              fontFamily: "var(--mono)",
+              fontSize: 12,
+              wordBreak: "break-all",
+            }}
+          >
+            {ghMissing.compareUrl}
+          </a>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+export function CreatePullRequestMenuItem({
+  onSelect,
+  busy,
+}: {
+  onSelect: () => void;
+  busy?: boolean;
+}) {
+  return (
+    <Btn
+      variant="ghost"
+      icon={busy ? undefined : "github"}
+      onClick={onSelect}
+      disabled={busy}
+      style={{ justifyContent: "flex-start" }}
+      title={`Create pull request to origin/${DEFAULT_BRANCH}`}
+    >
+      {busy ? (
+        <>
+          <Spinner />
+          Creating pull request…
+        </>
+      ) : (
+        "Create pull request"
+      )}
+    </Btn>
+  );
+}

--- a/src/components/views/FileEditorDialog.tsx
+++ b/src/components/views/FileEditorDialog.tsx
@@ -47,11 +47,14 @@ export function FileEditorDialog({
   const [confirmClose, setConfirmClose] = useState(false);
   const watchIdRef = useRef<string | null>(null);
   const mtimeRef = useRef<number>(0);
+  const savingRef = useRef(false);
   const cmRef = useRef<ReactCodeMirrorRef>(null);
 
   if (loaded) mtimeRef.current = loaded.mtimeMs;
 
   const dirty = loaded?.kind === "text" && content !== loaded.content;
+  const contentRef = useRef(content);
+  contentRef.current = content;
   const slash = relPath ? relPath.lastIndexOf("/") : -1;
   const fileName = relPath ? (slash >= 0 ? relPath.slice(slash + 1) : relPath) : "";
   const dirPath = relPath && slash >= 0 ? relPath.slice(0, slash) : "";
@@ -100,6 +103,7 @@ export function FileEditorDialog({
       watchIdRef.current = r.watchId;
       unsub = window.electronAPI!.files.onChanged((msg) => {
         if (msg.watchId !== r.watchId) return;
+        if (savingRef.current) return;
         if (msg.mtimeMs <= mtimeRef.current) return;
         void handleExternalChange();
       });
@@ -121,6 +125,13 @@ export function FileEditorDialog({
     const r = await window.electronAPI.files.read(projectRoot, relPath);
     if (!r.ok) return;
     const next = toLoadedFile(r);
+    // Our own save can race the watcher: disk already matches the editor.
+    if (next.kind === "text" && next.content === contentRef.current) {
+      mtimeRef.current = next.mtimeMs;
+      setLoaded(next);
+      setExternalChanged(false);
+      return;
+    }
     if (dirtyRef.current) {
       setLoaded((prev) => (prev ? { ...prev, mtimeMs: next.mtimeMs } : prev));
       setExternalChanged(true);
@@ -148,9 +159,10 @@ export function FileEditorDialog({
   }, [projectRoot, relPath]);
 
   const doSave = useCallback(
-    async (forceOverwrite: boolean) => {
-      if (!relPath || !window.electronAPI || !loaded) return;
-      if (loaded.kind !== "text") return;
+    async (forceOverwrite: boolean): Promise<boolean> => {
+      if (!relPath || !window.electronAPI || !loaded) return false;
+      if (loaded.kind !== "text") return false;
+      savingRef.current = true;
       setSaving(true);
       setSaveError(null);
       const expectedMtime = forceOverwrite ? null : loaded.mtimeMs;
@@ -173,25 +185,39 @@ export function FileEditorDialog({
           expectedMtime,
         );
       }
-      setSaving(false);
       if (r.ok) {
+        mtimeRef.current = r.mtimeMs;
         setLoaded({ kind: "text", content, mtimeMs: r.mtimeMs });
         setExternalChanged(false);
-        return;
+        setSaving(false);
+        savingRef.current = false;
+        return true;
       }
+      setSaving(false);
+      savingRef.current = false;
       if (r.error === "stale") {
         setExternalChanged(true);
         setSaveError("File changed on disk. Discard your edits and reload, or overwrite anyway.");
-        return;
+        return false;
       }
       // User clicked Cancel in the native confirm dialog — no-op, not an error.
       if (r.error === "user-declined") {
-        return;
+        return false;
       }
       setSaveError(r.error);
+      return false;
     },
     [projectRoot, relPath, loaded, content],
   );
+
+  const saveAndClose = useCallback(async () => {
+    if (loaded?.kind !== "text" || !dirty) {
+      onClose();
+      return;
+    }
+    const ok = await doSave(false);
+    if (ok) onClose();
+  }, [loaded, dirty, doSave, onClose]);
 
   const discardAndReload = useCallback(async () => {
     if (!relPath || !window.electronAPI) return;
@@ -262,11 +288,19 @@ export function FileEditorDialog({
                 Close
               </Btn>
             </StaticHotkeyTooltip>
+            <Btn
+              variant="primary"
+              icon="check"
+              onClick={() => void saveAndClose()}
+              disabled={!loaded || saving}
+            >
+              {saving ? "Saving…" : "Save and close"}
+            </Btn>
             <HotkeyTooltip action="file.save">
               <Btn
                 variant="primary"
                 icon="check"
-                onClick={() => doSave(false)}
+                onClick={() => void doSave(false)}
                 disabled={!loaded || saving || !dirty}
               >
                 {saving ? "Saving…" : "Save"}

--- a/src/components/views/GeneralSettingsPage.tsx
+++ b/src/components/views/GeneralSettingsPage.tsx
@@ -21,6 +21,7 @@ import {
   readCachedLaunchIntroEnabled,
   writeCachedLaunchIntroEnabled,
 } from "~/lib/launch-intro";
+import { DEFAULT_TERMINAL_ZOOM_LEVEL } from "~/shared/terminal-zoom";
 
 export function GeneralSettingsPage() {
   const queryClient = useQueryClient();
@@ -87,6 +88,7 @@ export function GeneralSettingsPage() {
     projectsDashboardView: settings?.projectsDashboardView ?? null,
     selectedWorktreeByProject: settings?.selectedWorktreeByProject ?? null,
     commitCli: settings?.commitCli ?? null,
+    terminalZoomLevel: settings?.terminalZoomLevel ?? DEFAULT_TERMINAL_ZOOM_LEVEL,
     ...queryClient.getQueryData<AppSettings>(queryKeys.settings),
     worktreesEnabled:
       queryClient.getQueryData<AppSettings>(queryKeys.settings)?.worktreesEnabled ??

--- a/src/components/views/GitDiffView/ChangedFilesList.tsx
+++ b/src/components/views/GitDiffView/ChangedFilesList.tsx
@@ -150,6 +150,17 @@ export function ChangedFilesList({
     onSizeChange: persistWidth,
   });
 
+  const handleResizeMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (widthPersistTimerRef.current) {
+        window.clearTimeout(widthPersistTimerRef.current);
+        widthPersistTimerRef.current = null;
+      }
+      onResizeMouseDown(e);
+    },
+    [onResizeMouseDown],
+  );
+
   const closeMenu = useCallback(() => setMenu(null), []);
   useDismissableMenu(menu !== null, closeMenu);
 
@@ -311,15 +322,16 @@ export function ChangedFilesList({
         </Section>
       </div>
       <div
-        onMouseDown={onResizeMouseDown}
+        onMouseDown={handleResizeMouseDown}
         title="Drag to resize"
         style={{
           position: "absolute",
           top: 0,
-          right: -3,
+          right: -5,
           bottom: 0,
-          width: 6,
+          width: 10,
           cursor: "col-resize",
+          touchAction: "none",
           zIndex: 10,
         }}
       />
@@ -999,7 +1011,7 @@ const textBtnStyle: CSSProperties = {
   flexShrink: 0,
 };
 
-const SECTION_HEADER_BACKGROUND = "rgba(3, 6, 8, 0.22)";
+const SECTION_HEADER_BACKGROUND = "#000000";
 
 const SECTION_TONES = {
   staged: {

--- a/src/components/views/GroupsDialog.tsx
+++ b/src/components/views/GroupsDialog.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Modal } from "~/components/ui/Modal";
 import { Btn } from "~/components/ui/Btn";
 import { EscTooltip } from "~/components/ui/Tooltip";
 import { TextField } from "~/components/ui/TextField";
 import { Icon } from "~/components/ui/Icon";
-import type { Group } from "~/db/schema";
+import type { Group, Project } from "~/db/schema";
+
+type GroupsDialogProject = Pick<Project, "id" | "name" | "groupId">;
 
 export function GroupsDialog({
   open,
@@ -14,24 +16,49 @@ export function GroupsDialog({
   onAdd,
   onRemove,
   onRename,
+  onProjectGroupChange,
 }: {
   open: boolean;
   groups: Group[];
-  projects: { groupId: string | null }[];
+  projects: GroupsDialogProject[];
   onClose: () => void;
   onAdd: (name: string) => void | Promise<void>;
   onRemove: (id: string) => void | Promise<void>;
   onRename: (id: string, name: string) => void | Promise<void>;
+  onProjectGroupChange: (projectId: string, groupId: string | null) => void | Promise<void>;
 }) {
   const [newName, setNewName] = useState("");
   const [editing, setEditing] = useState<{ id: string; name: string } | null>(null);
+  const [selectedProjectByGroup, setSelectedProjectByGroup] = useState<Record<string, string>>({});
+  const [updatingProjectId, setUpdatingProjectId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const groupNameById = new Map(groups.map((group) => [group.id, group.name]));
+
+  useEffect(() => {
+    if (open) setError(null);
+  }, [open]);
+
+  const assignProject = async (projectId: string, groupId: string | null) => {
+    setError(null);
+    setUpdatingProjectId(projectId);
+    try {
+      await onProjectGroupChange(projectId, groupId);
+      if (groupId) {
+        setSelectedProjectByGroup((current) => ({ ...current, [groupId]: "" }));
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not update group membership");
+    } finally {
+      setUpdatingProjectId(null);
+    }
+  };
 
   return (
     <Modal
       open={open}
       onClose={onClose}
       title="Manage groups"
-      width={480}
+      width={620}
       footer={
         <EscTooltip label="Done">
           <Btn variant="ghost" onClick={onClose}>
@@ -43,31 +70,60 @@ export function GroupsDialog({
       <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
         <div style={{ display: "flex", gap: 8 }}>
           <div style={{ flex: 1 }}>
-            <TextField value={newName} onChange={setNewName} placeholder="New group name" />
+            <TextField
+              value={newName}
+              onChange={setNewName}
+              placeholder="New group name"
+              ariaLabel="New group name"
+            />
           </div>
           <Btn
             variant="accent"
             icon="plus"
+            disabled={!newName.trim()}
             onClick={async () => {
               if (newName.trim()) {
-                await onAdd(newName.trim());
-                setNewName("");
+                setError(null);
+                try {
+                  await onAdd(newName.trim());
+                  setNewName("");
+                } catch (e) {
+                  setError(e instanceof Error ? e.message : "Could not add group");
+                }
               }
             }}
           >
             Add
           </Btn>
         </div>
+        {error && (
+          <div
+            style={{
+              padding: "8px 12px",
+              border: "1px solid var(--status-failed)",
+              background: "color-mix(in oklch, var(--status-failed) 12%, transparent)",
+              borderRadius: 7,
+              color: "var(--status-failed)",
+              fontFamily: "var(--mono)",
+              fontSize: 11.5,
+            }}
+          >
+            {error}
+          </div>
+        )}
         <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
           {groups.map((g) => {
             const count = projects.filter((p) => p.groupId === g.id).length;
             const isEditing = editing?.id === g.id;
+            const groupProjects = projects.filter((p) => p.groupId === g.id);
+            const availableProjects = projects.filter((p) => p.groupId !== g.id);
+            const selectedProjectId = selectedProjectByGroup[g.id] ?? "";
             return (
               <div
                 key={g.id}
                 style={{
                   display: "flex",
-                  alignItems: "center",
+                  flexDirection: "column",
                   gap: 10,
                   padding: "10px 12px",
                   background: "var(--surface-0)",
@@ -75,130 +131,247 @@ export function GroupsDialog({
                   borderRadius: 8,
                 }}
               >
-                <span
-                  style={{
-                    width: 10,
-                    height: 10,
-                    borderRadius: "50%",
-                    background: g.color,
-                    boxShadow: `0 0 6px ${g.color}66`,
-                  }}
-                />
-                {isEditing ? (
-                  <>
-                    <input
-                      autoFocus
-                      value={editing.name}
-                      onChange={(e) =>
-                        setEditing({ id: g.id, name: e.target.value })
-                      }
-                      onKeyDown={async (e) => {
-                        if (e.key === "Enter" && editing.name.trim()) {
-                          await onRename(g.id, editing.name.trim());
-                          setEditing(null);
-                        } else if (e.key === "Escape") {
-                          setEditing(null);
+                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <span
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: "50%",
+                      background: g.color,
+                      boxShadow: `0 0 6px ${g.color}66`,
+                    }}
+                  />
+                  {isEditing ? (
+                    <>
+                      <input
+                        autoFocus
+                        value={editing.name}
+                        onChange={(e) =>
+                          setEditing({ id: g.id, name: e.target.value })
                         }
-                      }}
-                      style={{
-                        flex: 1,
-                        background: "var(--surface-1)",
-                        border: "1px solid var(--accent)",
-                        borderRadius: 5,
-                        outline: 0,
-                        color: "var(--text)",
-                        padding: "4px 8px",
-                        fontFamily: "var(--mono)",
-                        fontSize: 12.5,
-                      }}
-                    />
-                    <Btn
-                      size="sm"
-                      variant="accent"
-                      onClick={async () => {
-                        if (editing.name.trim()) {
-                          await onRename(g.id, editing.name.trim());
-                          setEditing(null);
+                        onKeyDown={async (e) => {
+                          if (e.key === "Enter" && editing.name.trim()) {
+                            await onRename(g.id, editing.name.trim());
+                            setEditing(null);
+                          } else if (e.key === "Escape") {
+                            setEditing(null);
+                          }
+                        }}
+                        style={{
+                          flex: 1,
+                          background: "var(--surface-1)",
+                          border: "1px solid var(--accent)",
+                          borderRadius: 5,
+                          outline: 0,
+                          color: "var(--text)",
+                          padding: "4px 8px",
+                          fontFamily: "var(--mono)",
+                          fontSize: 12.5,
+                        }}
+                      />
+                      <Btn
+                        size="sm"
+                        variant="accent"
+                        onClick={async () => {
+                          if (editing.name.trim()) {
+                            await onRename(g.id, editing.name.trim());
+                            setEditing(null);
+                          }
+                        }}
+                      >
+                        Save
+                      </Btn>
+                      <button
+                        onClick={() => setEditing(null)}
+                        title="Cancel"
+                        aria-label={`Cancel renaming ${g.name}`}
+                        style={{
+                          background: "transparent",
+                          border: 0,
+                          color: "var(--text-faint)",
+                          cursor: "pointer",
+                          padding: 4,
+                          display: "flex",
+                        }}
+                      >
+                        <Icon name="x" size={12} />
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <span
+                        onClick={() => setEditing({ id: g.id, name: g.name })}
+                        style={{
+                          flex: 1,
+                          fontFamily: "var(--mono)",
+                          fontSize: 12.5,
+                          cursor: "pointer",
+                        }}
+                        title="Click to rename"
+                      >
+                        {g.name}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: "var(--mono)",
+                          fontSize: 11,
+                          color: "var(--text-faint)",
+                        }}
+                      >
+                        {count} {count === 1 ? "project" : "projects"}
+                      </span>
+                      <button
+                        onClick={() => setEditing({ id: g.id, name: g.name })}
+                        title="Rename"
+                        aria-label={`Rename ${g.name}`}
+                        style={{
+                          background: "transparent",
+                          border: 0,
+                          color: "var(--text-faint)",
+                          cursor: "pointer",
+                          padding: 4,
+                          display: "flex",
+                        }}
+                      >
+                        <Icon name="settings" size={12} />
+                      </button>
+                      <button
+                        onClick={async () => {
+                          if (
+                            confirm(
+                              `Remove group "${g.name}"?\n\nProjects in this group will become ungrouped — they aren't deleted.`
+                            )
+                          ) {
+                            await onRemove(g.id);
+                          }
+                        }}
+                        title="Remove group"
+                        aria-label={`Remove ${g.name}`}
+                        style={{
+                          background: "transparent",
+                          border: 0,
+                          color: "var(--text-faint)",
+                          cursor: "pointer",
+                          padding: 4,
+                          display: "flex",
+                        }}
+                      >
+                        <Icon name="trash" size={12} />
+                      </button>
+                    </>
+                  )}
+                </div>
+                {!isEditing && (
+                  <div
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 8,
+                      borderTop: "1px solid var(--border)",
+                      paddingTop: 10,
+                    }}
+                  >
+                    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                      {groupProjects.map((project) => (
+                        <div
+                          key={project.id}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 8,
+                            minHeight: 28,
+                          }}
+                        >
+                          <span
+                            style={{
+                              flex: 1,
+                              minWidth: 0,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                              color: "var(--text)",
+                              fontFamily: "var(--mono)",
+                              fontSize: 11.5,
+                            }}
+                            title={project.name}
+                          >
+                            {project.name}
+                          </span>
+                          <Btn
+                            size="sm"
+                            variant="ghost"
+                            icon="x"
+                            onClick={() => void assignProject(project.id, null)}
+                            disabled={updatingProjectId === project.id}
+                            aria-label={`Remove ${project.name} from ${g.name}`}
+                          >
+                            Remove
+                          </Btn>
+                        </div>
+                      ))}
+                      {groupProjects.length === 0 && (
+                        <div
+                          style={{
+                            color: "var(--text-faint)",
+                            fontFamily: "var(--mono)",
+                            fontSize: 11,
+                          }}
+                        >
+                          No projects in this group
+                        </div>
+                      )}
+                    </div>
+                    <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                      <select
+                        value={selectedProjectId}
+                        onChange={(e) =>
+                          setSelectedProjectByGroup((current) => ({
+                            ...current,
+                            [g.id]: e.target.value,
+                          }))
                         }
-                      }}
-                    >
-                      Save
-                    </Btn>
-                    <button
-                      onClick={() => setEditing(null)}
-                      title="Cancel"
-                      style={{
-                        background: "transparent",
-                        border: 0,
-                        color: "var(--text-faint)",
-                        cursor: "pointer",
-                        padding: 4,
-                        display: "flex",
-                      }}
-                    >
-                      <Icon name="x" size={12} />
-                    </button>
-                  </>
-                ) : (
-                  <>
-                    <span
-                      onClick={() => setEditing({ id: g.id, name: g.name })}
-                      style={{
-                        flex: 1,
-                        fontFamily: "var(--mono)",
-                        fontSize: 12.5,
-                        cursor: "pointer",
-                      }}
-                      title="Click to rename"
-                    >
-                      {g.name}
-                    </span>
-                    <span
-                      style={{
-                        fontFamily: "var(--mono)",
-                        fontSize: 11,
-                        color: "var(--text-faint)",
-                      }}
-                    >
-                      {count} {count === 1 ? "project" : "projects"}
-                    </span>
-                    <button
-                      onClick={() => setEditing({ id: g.id, name: g.name })}
-                      title="Rename"
-                      style={{
-                        background: "transparent",
-                        border: 0,
-                        color: "var(--text-faint)",
-                        cursor: "pointer",
-                        padding: 4,
-                        display: "flex",
-                      }}
-                    >
-                      <Icon name="settings" size={12} />
-                    </button>
-                    <button
-                      onClick={async () => {
-                        if (
-                          confirm(
-                            `Remove group "${g.name}"?\n\nProjects in this group will become ungrouped — they aren't deleted.`
-                          )
-                        ) {
-                          await onRemove(g.id);
-                        }
-                      }}
-                      title="Remove group"
-                      style={{
-                        background: "transparent",
-                        border: 0,
-                        color: "var(--text-faint)",
-                        cursor: "pointer",
-                        padding: 4,
-                        display: "flex",
-                      }}
-                    >
-                      <Icon name="trash" size={12} />
-                    </button>
-                  </>
+                        disabled={availableProjects.length === 0}
+                        aria-label={`Project to add to ${g.name}`}
+                        style={{
+                          flex: 1,
+                          minWidth: 0,
+                          background: "var(--surface-1)",
+                          border: "1px solid var(--border)",
+                          borderRadius: 7,
+                          color: selectedProjectId ? "var(--text)" : "var(--text-faint)",
+                          padding: "8px 10px",
+                          fontFamily: "var(--mono)",
+                          fontSize: 11.5,
+                          outline: 0,
+                        }}
+                      >
+                        <option value="">
+                          {availableProjects.length === 0 ? "All projects are in this group" : "Add project…"}
+                        </option>
+                        {availableProjects.map((project) => {
+                          const currentGroup = project.groupId
+                            ? groupNameById.get(project.groupId)
+                            : null;
+                          const suffix = currentGroup ? ` - from ${currentGroup}` : " - ungrouped";
+                          return (
+                            <option key={project.id} value={project.id}>
+                              {project.name}
+                              {suffix}
+                            </option>
+                          );
+                        })}
+                      </select>
+                      <Btn
+                        size="sm"
+                        variant="accent"
+                        icon="plus"
+                        disabled={!selectedProjectId || updatingProjectId === selectedProjectId}
+                        onClick={() => void assignProject(selectedProjectId, g.id)}
+                      >
+                        Add
+                      </Btn>
+                    </div>
+                  </div>
                 )}
               </div>
             );

--- a/src/components/views/LicenseBadge.tsx
+++ b/src/components/views/LicenseBadge.tsx
@@ -1,14 +1,21 @@
 import { useLicense } from "~/queries";
 import { type LicenseState } from "~/shared/license";
 
-type Tier = "lite" | "pro";
+type Tier = "unknown" | "lite" | "pro";
 
 function deriveTier(license: LicenseState | undefined): Tier {
-  if (!license || !license.hasKey) return "lite";
+  if (!license) return "unknown";
+  if (!license.hasKey) return "lite";
   return license.status === "active" ? "pro" : "lite";
 }
 
 const TIER_STYLE: Record<Tier, { label: string; bg: string; border: string; fg: string }> = {
+  unknown: {
+    label: "",
+    bg: "transparent",
+    border: "var(--border)",
+    fg: "var(--text-faint)",
+  },
   lite: {
     label: "Lite",
     bg: "transparent",
@@ -28,27 +35,31 @@ export function LicenseBadge({ onClick }: { onClick?: () => void }) {
   const tier = deriveTier(license);
   const s = TIER_STYLE[tier];
   const title =
-    tier === "lite"
+    tier === "unknown"
+      ? "Checking Mission Control plan"
+      : tier === "lite"
       ? "Mission Control Lite — click to activate Pro"
       : "Mission Control Pro — click to manage license";
 
   const style = {
-        display: "inline-flex",
-        alignItems: "center",
-        gap: 4,
-        height: 22,
-        padding: "0 8px",
-        borderRadius: 999,
-        border: `1px solid ${s.border}`,
-        background: s.bg,
-        color: s.fg,
-        fontFamily: "var(--mono)",
-        fontSize: 10.5,
-        fontWeight: 600,
-        letterSpacing: "0.04em",
-        textTransform: "uppercase",
-        cursor: onClick ? "pointer" : "default",
-      };
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 4,
+    height: 22,
+    minWidth: 44,
+    justifyContent: "center",
+    padding: "0 8px",
+    borderRadius: 999,
+    border: `1px solid ${s.border}`,
+    background: s.bg,
+    color: s.fg,
+    fontFamily: "var(--mono)",
+    fontSize: 10.5,
+    fontWeight: 600,
+    letterSpacing: "0.04em",
+    textTransform: "uppercase",
+    cursor: onClick ? "pointer" : "default",
+  };
 
   if (!onClick) {
     return (
@@ -62,6 +73,7 @@ export function LicenseBadge({ onClick }: { onClick?: () => void }) {
     <button
       type="button"
       onClick={onClick}
+      aria-label={title}
       title={title}
       style={style}
     >

--- a/src/components/views/ProjectBar.tsx
+++ b/src/components/views/ProjectBar.tsx
@@ -13,6 +13,7 @@ import { useUserTerminals } from "~/lib/user-terminal-store";
 import { useBinding } from "~/lib/keybindings/store";
 import { formatBinding } from "~/lib/keybindings/format";
 import { api } from "~/lib/api";
+import { shouldFlashPinnedProjectLogo } from "./project-bar-activity";
 import { getPinnedProjectStatusDots } from "./project-bar-status-dots";
 import { setProjectPathDragData } from "~/lib/project-path-drag";
 
@@ -118,7 +119,10 @@ export function ProjectBar() {
         const runningCount = project.taskCounts.running;
         const terminalRunning = runningProjectIds.has(project.id);
         const launchRunning = hasRunningLaunchForProject(project.id, project.launchCommands);
-        const projectRunning = runningCount > 0 || terminalRunning;
+        const logoShouldFlash = shouldFlashPinnedProjectLogo({
+          cliRunningCount: runningCount,
+          terminalOpen: terminalRunning,
+        });
         const finishedCount = project.taskCounts.finished;
         const statusDots = getPinnedProjectStatusDots(project.taskCounts);
         const hasStatusDots = statusDots.length > 0;
@@ -244,7 +248,7 @@ export function ProjectBar() {
               }}
             >
               <span
-                className={`pinned-project-logo-surface${projectRunning ? " pinned-project-logo-surface--running" : ""}`}
+                className={`pinned-project-logo-surface${logoShouldFlash ? " pinned-project-logo-surface--running" : ""}`}
                 style={{
                   width: ICON_SIZE,
                   height: ICON_SIZE,

--- a/src/components/views/ProjectCard.tsx
+++ b/src/components/views/ProjectCard.tsx
@@ -2,20 +2,37 @@ import { useState } from "react";
 import { CardFrame } from "~/components/ui/CardFrame";
 import { ProjectIcon } from "~/components/ui/ProjectIcon";
 import { Btn } from "~/components/ui/Btn";
+import { Icon } from "~/components/ui/Icon";
 import { ShimmerBar } from "~/components/ui/ShimmerBar";
 import { StatusDot, StatusPill } from "~/components/ui/StatusDot";
 import { ProjectStatusBadge } from "~/components/ui/ProjectStatusBadge";
 import { TASK_STATUSES } from "~/shared/domain";
 import { useUserTerminals } from "~/lib/user-terminal-store";
+import { useDismissableMenu } from "~/lib/use-dismissable-menu";
 import { getProjectActivity, isProjectActive, type ProjectWithCounts } from "~/shared/projects";
+
+type ProjectCardMenu = { x: number; y: number } | null;
+const MENU_WIDTH = 184;
+const MENU_HEIGHT = 96;
+
+function menuPosition(x: number, y: number): NonNullable<ProjectCardMenu> {
+  return {
+    x: Math.max(8, Math.min(x, window.innerWidth - MENU_WIDTH - 8)),
+    y: Math.max(8, Math.min(y, window.innerHeight - MENU_HEIGHT - 8)),
+  };
+}
 
 export function ProjectCard({
   project,
   onOpen,
+  onEdit,
+  onRemove,
   onTogglePin,
 }: {
   project: ProjectWithCounts;
   onOpen: () => void;
+  onEdit: () => void;
+  onRemove: () => void;
   onTogglePin: (id: string) => void;
 }) {
   const counts = project.taskCounts;
@@ -24,12 +41,24 @@ export function ProjectCard({
   const hasActivity = isProjectActive(activity);
   const totalShown = TASK_STATUSES.reduce((a, s) => a + counts[s], 0);
   const [hovered, setHovered] = useState(false);
+  const [menu, setMenu] = useState<ProjectCardMenu>(null);
+  useDismissableMenu(menu !== null, () => setMenu(null));
+
+  const openMenu = (x: number, y: number) => {
+    setMenu(menuPosition(x, y));
+  };
+
   return (
     <CardFrame
       className="mc-project-card"
       glow
-      focused={hovered}
+      focused={hovered || menu !== null}
       onClick={onOpen}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        openMenu(e.clientX, e.clientY);
+      }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
@@ -117,20 +146,50 @@ export function ProjectCard({
               </div>
             </div>
           </button>
-          <Btn
-            size="sm"
-            variant={project.pinned ? "accent" : "ghost"}
-            icon={project.pinned ? "pin-fill" : "pin"}
-            onClick={(e) => {
-              e.stopPropagation();
-              onTogglePin(project.id);
-            }}
-            aria-label={project.pinned ? `Unpin ${project.name}` : `Pin ${project.name}`}
-            title={project.pinned ? "Unpin" : "Pin"}
-            style={{ pointerEvents: "auto", position: "relative", zIndex: 3 }}
-          >
-            {project.pinned ? "Pinned" : "Pin"}
-          </Btn>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
+            <Btn
+              size="sm"
+              variant={project.pinned ? "primary" : "ghost"}
+              icon={project.pinned ? "pin-fill" : "pin"}
+              onClick={(e) => {
+                e.stopPropagation();
+                onTogglePin(project.id);
+              }}
+              aria-label={project.pinned ? `Unpin ${project.name}` : `Pin ${project.name}`}
+              aria-pressed={project.pinned}
+              title={project.pinned ? "Unpin" : "Pin"}
+              style={{
+                pointerEvents: "auto",
+                position: "relative",
+                zIndex: 3,
+                width: 30,
+                minWidth: 30,
+                padding: 0,
+                paddingInline: 0,
+              }}
+            />
+            <Btn
+              size="sm"
+              variant="ghost"
+              icon="more"
+              onClick={(e) => {
+                e.stopPropagation();
+                const rect = e.currentTarget.getBoundingClientRect();
+                openMenu(rect.left, rect.bottom + 4);
+              }}
+              aria-label={`Project actions for ${project.name}`}
+              aria-haspopup="menu"
+              aria-expanded={menu !== null}
+              title="Project actions"
+              style={{
+                pointerEvents: "auto",
+                position: "relative",
+                zIndex: 3,
+                width: 30,
+                padding: 0,
+              }}
+            />
+          </div>
         </div>
 
         <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
@@ -167,6 +226,90 @@ export function ProjectCard({
           </div>
         )}
       </div>
+      {menu && (
+        <div
+          role="menu"
+          aria-label={`${project.name} actions`}
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            position: "fixed",
+            top: menu.y,
+            left: menu.x,
+            zIndex: 1000,
+            background: "var(--surface-2)",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            padding: 4,
+            minWidth: 176,
+            boxShadow: "0 6px 20px rgba(0,0,0,0.4)",
+          }}
+        >
+          <ProjectCardMenuItem
+            autoFocus
+            icon="settings"
+            label="Edit project"
+            onSelect={() => {
+              setMenu(null);
+              onEdit();
+            }}
+          />
+          <ProjectCardMenuItem
+            icon="trash"
+            label="Remove project"
+            danger
+            onSelect={() => {
+              setMenu(null);
+              onRemove();
+            }}
+          />
+        </div>
+      )}
     </CardFrame>
+  );
+}
+
+function ProjectCardMenuItem({
+  icon,
+  label,
+  onSelect,
+  danger = false,
+  autoFocus = false,
+}: {
+  icon: "settings" | "trash";
+  label: string;
+  onSelect: () => void;
+  danger?: boolean;
+  autoFocus?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      autoFocus={autoFocus}
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelect();
+      }}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        width: "100%",
+        padding: "7px 10px",
+        background: "transparent",
+        border: 0,
+        borderRadius: 4,
+        cursor: "pointer",
+        color: danger ? "var(--status-failed, #e06c75)" : "var(--text)",
+        fontSize: 12,
+        fontFamily: "var(--mono)",
+        textAlign: "left",
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = "var(--surface-3)")}
+      onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+    >
+      <Icon name={icon} size={12} />
+      {label}
+    </button>
   );
 }

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -3,7 +3,6 @@ import { Modal } from "~/components/ui/Modal";
 import { Btn } from "~/components/ui/Btn";
 import { TextField } from "~/components/ui/TextField";
 import { Icon } from "~/components/ui/Icon";
-import { ProjectIcon } from "~/components/ui/ProjectIcon";
 import { HotkeyTooltip, EscTooltip } from "~/components/ui/Tooltip";
 import { useHotkey } from "~/lib/use-hotkey";
 import { ICON_COLORS } from "~/lib/design-meta";
@@ -27,6 +26,7 @@ export function ProjectDialog({
   groups,
   onClose,
   onSave,
+  onCreateGroup,
 }: {
   open: boolean;
   project: Project | null;
@@ -43,15 +43,18 @@ export function ProjectDialog({
     githubUrl?: string;
     worktreeSetupCommand?: string | null;
   }) => Promise<void> | void;
+  onCreateGroup?: (name: string) => Promise<Group> | Group;
 }) {
   const [name, setName] = useState("");
   const [path, setPath] = useState("");
   const [groupId, setGroupId] = useState<string>("");
+  const [groupQuery, setGroupQuery] = useState("");
+  const [groupTypeaheadOpen, setGroupTypeaheadOpen] = useState(false);
+  const [creatingGroup, setCreatingGroup] = useState(false);
   const [icon, setIcon] = useState("");
   const [iconColor, setIconColor] = useState("#ff5a1f");
   const [worktreeSetupCommand, setWorktreeSetupCommand] = useState("");
   const [imagePath, setImagePath] = useState<string | null>(null);
-  const [imageVersion, setImageVersion] = useState(0);
   const [pendingImage, setPendingImage] = useState<
     { sourcePath: string; extension: string } | null
   >(null);
@@ -61,6 +64,16 @@ export function ProjectDialog({
   const hostedRuntime = isWebDaytonaRuntime();
   const hostedCreate = hostedRuntime && !project;
   const hostedRepoName = hostedCreate ? repoNameFromGithubUrl(path) : "";
+  const selectedGroup = groupId ? groups.find((group) => group.id === groupId) ?? null : null;
+  const normalizedGroupQuery = groupQuery.trim().toLowerCase();
+  const exactGroupMatch = normalizedGroupQuery
+    ? groups.find((group) => group.name.toLowerCase() === normalizedGroupQuery) ?? null
+    : null;
+  const filteredGroups = normalizedGroupQuery
+    ? groups.filter((group) => group.name.toLowerCase().includes(normalizedGroupQuery))
+    : groups;
+  const canCreateGroup =
+    !!onCreateGroup && !!groupQuery.trim() && !exactGroupMatch;
 
   useEffect(() => {
     if (open) {
@@ -69,15 +82,26 @@ export function ProjectDialog({
       setName(project?.name || "");
       setPath(project?.path || "");
       setGroupId(project?.groupId || "");
+      setGroupQuery(
+        project?.groupId
+          ? groups.find((group) => group.id === project.groupId)?.name ?? ""
+          : "",
+      );
+      setGroupTypeaheadOpen(false);
+      setCreatingGroup(false);
       setIcon(project?.icon || "");
       setIconColor(project?.iconColor || "#ff5a1f");
       setWorktreeSetupCommand(project?.worktreeSetupCommand || "");
       setImagePath(project?.imagePath ?? null);
-      setImageVersion(project?.updatedAt ?? 0);
       setPendingImage(null);
       setError(null);
     }
   }, [open, project?.id]);
+
+  useEffect(() => {
+    if (!open || !selectedGroup || groupQuery.trim()) return;
+    setGroupQuery(selectedGroup.name);
+  }, [groupQuery, open, selectedGroup]);
 
   const chooseImage = async () => {
     setError(null);
@@ -106,7 +130,6 @@ export function ProjectDialog({
         return;
       }
       setImagePath(result.filename);
-      setImageVersion(Date.now());
     } finally {
       setUploading(false);
     }
@@ -115,7 +138,6 @@ export function ProjectDialog({
   const removeImage = () => {
     setImagePath(null);
     setPendingImage(null);
-    setImageVersion(Date.now());
   };
 
   const browse = async () => {
@@ -131,9 +153,61 @@ export function ProjectDialog({
     }
   };
 
+  const selectGroup = (group: Group) => {
+    setGroupId(group.id);
+    setGroupQuery(group.name);
+    setGroupTypeaheadOpen(false);
+  };
+
+  const clearGroup = () => {
+    setGroupId("");
+    setGroupQuery("");
+    setGroupTypeaheadOpen(false);
+  };
+
+  const createAndSelectGroup = async (groupName: string): Promise<string | null> => {
+    if (!onCreateGroup || creatingGroup) return groupId || null;
+    setError(null);
+    setCreatingGroup(true);
+    try {
+      const group = await onCreateGroup(groupName);
+      selectGroup(group);
+      return group.id;
+    } catch (e: any) {
+      setError(e?.message || "Could not add group");
+      throw e;
+    } finally {
+      setCreatingGroup(false);
+    }
+  };
+
+  const commitGroupQuery = async () => {
+    const trimmed = groupQuery.trim();
+    if (!trimmed) {
+      clearGroup();
+      return;
+    }
+    if (exactGroupMatch) {
+      selectGroup(exactGroupMatch);
+      return;
+    }
+    if (!onCreateGroup || creatingGroup) return;
+    await createAndSelectGroup(trimmed);
+  };
+
+  const resolveGroupIdForSave = async (): Promise<string | null> => {
+    const trimmed = groupQuery.trim();
+    if (!trimmed) return null;
+    if (exactGroupMatch) return exactGroupMatch.id;
+    if (selectedGroup?.name === trimmed) return selectedGroup.id;
+    if (onCreateGroup) return createAndSelectGroup(trimmed);
+    return groupId || null;
+  };
+
   const submit = async () => {
     setError(null);
     try {
+      const effectiveGroupId = await resolveGroupIdForSave();
       const effectiveName =
         name.trim() ||
         hostedRepoName ||
@@ -146,7 +220,7 @@ export function ProjectDialog({
         path: effectivePath,
         icon: icon || effectiveName.slice(0, 2).toUpperCase(),
         iconColor,
-        groupId: groupId || null,
+        groupId: effectiveGroupId,
         ...(project ? { imagePath } : { pendingImage }),
         ...(hostedCreate && path.trim() ? { githubUrl: path.trim() } : {}),
         ...(project ? { worktreeSetupCommand: worktreeSetupCommand.trim() || null } : {}),
@@ -374,44 +448,214 @@ export function ProjectDialog({
           >
             Group
           </label>
-          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-            <button
-              onClick={() => setGroupId("")}
+          <div style={{ position: "relative" }}>
+            <div
               style={{
-                padding: "6px 12px",
-                borderRadius: 999,
-                background: groupId === "" ? "var(--accent-dim)" : "var(--surface-0)",
-                border: `1px solid ${groupId === "" ? "var(--accent)" : "var(--border)"}`,
-                color: groupId === "" ? "var(--accent)" : "var(--text-dim)",
-                fontFamily: "var(--mono)",
-                fontSize: 11,
-                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                background: "var(--surface-0)",
+                border: `1px solid ${groupTypeaheadOpen ? "var(--accent)" : "var(--border)"}`,
+                borderRadius: 7,
+                padding: "0 8px 0 12px",
+                minHeight: 38,
               }}
             >
-              Ungrouped
-            </button>
-            {groups.map((g) => (
-              <button
-                key={g.id}
-                onClick={() => setGroupId(g.id)}
+              {selectedGroup && (
+                <span
+                  aria-hidden
+                  style={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: "50%",
+                    background: selectedGroup.color,
+                    flex: "0 0 auto",
+                  }}
+                />
+              )}
+              <input
+                value={groupQuery}
+                onFocus={() => setGroupTypeaheadOpen(true)}
+                onBlur={() => {
+                  window.setTimeout(() => setGroupTypeaheadOpen(false), 100);
+                }}
+                onChange={(e) => {
+                  const next = e.target.value;
+                  setGroupQuery(next);
+                  setGroupTypeaheadOpen(true);
+                  if (!next.trim()) setGroupId("");
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    void commitGroupQuery();
+                  } else if (e.key === "Escape") {
+                    setGroupTypeaheadOpen(false);
+                  }
+                }}
+                role="combobox"
+                aria-expanded={groupTypeaheadOpen}
+                aria-controls="project-group-options"
+                aria-label="Project group"
+                placeholder="Ungrouped or group name"
                 style={{
-                  padding: "6px 12px",
-                  borderRadius: 999,
-                  background: groupId === g.id ? "var(--accent-dim)" : "var(--surface-0)",
-                  border: `1px solid ${groupId === g.id ? "var(--accent)" : "var(--border)"}`,
-                  color: groupId === g.id ? "var(--accent)" : "var(--text-dim)",
+                  flex: 1,
+                  minWidth: 0,
+                  background: "transparent",
+                  border: 0,
+                  outline: 0,
+                  color: "var(--text)",
+                  padding: "9px 0",
                   fontFamily: "var(--mono)",
-                  fontSize: 11,
-                  cursor: "pointer",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 6,
+                  fontSize: 12.5,
+                }}
+              />
+              {(groupQuery || groupId) && (
+                <button
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={clearGroup}
+                  aria-label="Clear group"
+                  title="Clear group"
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    width: 24,
+                    height: 24,
+                    border: 0,
+                    background: "transparent",
+                    color: "var(--text-faint)",
+                    cursor: "pointer",
+                    padding: 0,
+                  }}
+                >
+                  <Icon name="x" size={12} />
+                </button>
+              )}
+            </div>
+            {groupTypeaheadOpen && (
+              <div
+                id="project-group-options"
+                role="listbox"
+                style={{
+                  position: "absolute",
+                  zIndex: 20,
+                  left: 0,
+                  right: 0,
+                  top: "calc(100% + 6px)",
+                  maxHeight: 220,
+                  overflow: "auto",
+                  background: "var(--surface-1)",
+                  border: "1px solid var(--border)",
+                  borderRadius: 8,
+                  boxShadow: "0 14px 36px rgba(0, 0, 0, 0.32)",
+                  padding: 6,
                 }}
               >
-                <span style={{ width: 7, height: 7, borderRadius: "50%", background: g.color }} />
-                {g.name}
-              </button>
-            ))}
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={groupId === ""}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={clearGroup}
+                  style={{
+                    width: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    minHeight: 32,
+                    border: 0,
+                    borderRadius: 6,
+                    background: groupId === "" ? "var(--accent-dim)" : "transparent",
+                    color: groupId === "" ? "var(--accent)" : "var(--text-dim)",
+                    cursor: "pointer",
+                    padding: "7px 9px",
+                    textAlign: "left",
+                    fontFamily: "var(--mono)",
+                    fontSize: 11.5,
+                  }}
+                >
+                  Ungrouped
+                </button>
+                {filteredGroups.map((group) => (
+                  <button
+                    key={group.id}
+                    type="button"
+                    role="option"
+                    aria-selected={groupId === group.id}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => selectGroup(group)}
+                    style={{
+                      width: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      minHeight: 32,
+                      border: 0,
+                      borderRadius: 6,
+                      background: groupId === group.id ? "var(--accent-dim)" : "transparent",
+                      color: groupId === group.id ? "var(--accent)" : "var(--text)",
+                      cursor: "pointer",
+                      padding: "7px 9px",
+                      textAlign: "left",
+                      fontFamily: "var(--mono)",
+                      fontSize: 11.5,
+                    }}
+                  >
+                    <span
+                      aria-hidden
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        background: group.color,
+                      }}
+                    />
+                    <span
+                      style={{
+                        minWidth: 0,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {group.name}
+                    </span>
+                  </button>
+                ))}
+                {canCreateGroup && (
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={false}
+                    disabled={creatingGroup}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => void commitGroupQuery()}
+                    style={{
+                      width: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      minHeight: 32,
+                      border: 0,
+                      borderRadius: 6,
+                      background: "transparent",
+                      color: "var(--accent)",
+                      cursor: creatingGroup ? "default" : "pointer",
+                      opacity: creatingGroup ? 0.65 : 1,
+                      padding: "7px 9px",
+                      textAlign: "left",
+                      fontFamily: "var(--mono)",
+                      fontSize: 11.5,
+                    }}
+                  >
+                    <Icon name="plus" size={12} />
+                    {creatingGroup ? "Creating..." : `Create "${groupQuery.trim()}"`}
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/views/ProjectsTable.tsx
+++ b/src/components/views/ProjectsTable.tsx
@@ -155,14 +155,14 @@ export function ProjectsTable({
                   <td className="mc-projects-table-cell mc-projects-table-pin">
                     <Btn
                       size="sm"
-                      variant={project.pinned ? "accent" : "ghost"}
+                      variant={project.pinned ? "primary" : "ghost"}
                       icon={project.pinned ? "pin-fill" : "pin"}
                       onClick={() => onTogglePin(project.id)}
                       aria-label={project.pinned ? `Unpin ${project.name}` : `Pin ${project.name}`}
+                      aria-pressed={project.pinned}
                       title={project.pinned ? "Unpin" : "Pin"}
-                    >
-                      {project.pinned ? "Pinned" : "Pin"}
-                    </Btn>
+                      style={{ width: 30, minWidth: 30, padding: 0, paddingInline: 0 }}
+                    />
                   </td>
                 </tr>
               );

--- a/src/components/views/SettingsPanel.tsx
+++ b/src/components/views/SettingsPanel.tsx
@@ -10,12 +10,14 @@ import { GeneralSettingsPage } from "./GeneralSettingsPage";
 import { KeybindingsPage } from "./KeybindingsPage";
 import { LicenseSettingsPage } from "./LicenseSettingsPage";
 import { SessionDebugLogPage } from "./SessionDebugLogPage";
+import { TerminalSettingsPage } from "./TerminalSettingsPage";
 import { ThemeSettingsPage } from "./ThemeSettingsPage";
 import { TermsSettingsPage } from "./TermsSettingsPage";
 
 export type SettingsPanelId =
   | "general"
   | "defaults"
+  | "terminal"
   | "theme"
   | "beta"
   | "license"
@@ -67,6 +69,7 @@ export function SettingsPanel({
   const items: NavItem[] = [
     { id: "general", label: "General", icon: "settings" },
     { id: "defaults", label: "Defaults", icon: "terminal" },
+    { id: "terminal", label: "Terminal", icon: "terminal" },
     { id: "theme", label: "Theme", icon: "sun" },
     { id: "license", label: "License", icon: "sparkles" },
     { id: "keybindings", label: "Keybindings", icon: "settings" },
@@ -271,6 +274,8 @@ export function SettingsPanel({
             <GeneralSettingsPage />
           ) : activePanel === "defaults" ? (
             <DefaultsSettingsPage />
+          ) : activePanel === "terminal" ? (
+            <TerminalSettingsPage />
           ) : activePanel === "theme" ? (
             <ThemeSettingsPage />
           ) : activePanel === "beta" ? (

--- a/src/components/views/TerminalPane.tsx
+++ b/src/components/views/TerminalPane.tsx
@@ -14,12 +14,15 @@ import {
   wireTerminalFileDrop,
 } from "~/lib/terminal-pane-helpers";
 import {
+  applyTerminalFontSize,
   createTerminalOptions,
   createTerminalTheme,
   fitTerminalSurface,
   getTerminalColorScheme,
   watchTerminalColorScheme,
 } from "~/lib/terminal-options";
+import { useTerminalZoom, useTerminalPaneZoomShortcuts } from "~/lib/use-terminal-zoom";
+import { TerminalZoomControls } from "~/components/views/TerminalZoomControls";
 import { ApiError, api, resolveApiToken } from "~/lib/api";
 import {
   agentUsesPersistedSession,
@@ -30,6 +33,16 @@ import {
 import { terminalInputStartsTurn, agentUsesTerminalPromptFallback } from "~/lib/task-status-sync";
 import { accumulateTerminalPrompt } from "~/lib/terminal-prompt-capture";
 import { prefetchTerminalModules } from "~/lib/prefetch-terminal-modules";
+import { attachTerminalLinks } from "~/lib/terminal-links";
+import { resizePtyToTerminal } from "~/lib/terminal-resize";
+import {
+  appendBoundedSequencedData,
+  dataAfterReplay,
+  replayDataOrFallback,
+  sequencedPtyData,
+  type PtyReplaySnapshot,
+  type SequencedPtyData,
+} from "~/lib/terminal-replay";
 import { queryKeys, useTasks } from "~/queries";
 import type { Project, Task } from "~/db/schema";
 import { normalizePtySize } from "~/shared/pty-size";
@@ -80,11 +93,22 @@ export function TerminalPane({
   onPtyReady: (ptyId: string | null) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const paneRef = useRef<HTMLDivElement>(null);
   const fitRef = useRef<XFitAddon | null>(null);
+  const termSurfaceRef = useRef<{ setFontSize: (fontSize: number) => void } | null>(null);
   const queryClient = useQueryClient();
   const [liveStatus, setLiveStatus] = useState("");
   const [startError, setStartError] = useState<string | null>(null);
   const [retryNonce, setRetryNonce] = useState(0);
+  const {
+    level: zoomLevel,
+    fontSize: terminalFontSize,
+    zoomIn,
+    zoomOut,
+    canZoomIn,
+    canZoomOut,
+  } = useTerminalZoom(descriptor.taskId);
+  useTerminalPaneZoomShortcuts(paneRef, zoomIn, zoomOut);
 
   const { data: liveTasks } = useTasks(project.id, project.activeWorktreeId ?? null);
   const liveTask = liveTasks?.find((t) => t.id === task.id) ?? task;
@@ -95,6 +119,10 @@ export function TerminalPane({
     if (typeof window === "undefined") return;
     window.dispatchEvent(new Event(DUPLICATE_ACTIVE_SESSION_EVENT));
   };
+
+  useEffect(() => {
+    termSurfaceRef.current?.setFontSize(terminalFontSize);
+  }, [terminalFontSize]);
 
   useEffect(() => {
     const electron = getElectron();
@@ -109,7 +137,11 @@ export function TerminalPane({
 
       const cursorColor = meta?.color;
       const term = new Terminal(
-        createTerminalOptions({ cursorColor, colorScheme: getTerminalColorScheme() })
+        createTerminalOptions({
+          cursorColor,
+          colorScheme: getTerminalColorScheme(),
+          fontSize: terminalFontSize,
+        })
       );
       const fit = new FitAddon();
       fitRef.current = fit;
@@ -121,18 +153,23 @@ export function TerminalPane({
       const subscriptions: Array<() => void> = [];
       let rafHandle = 0;
       let activePtyId: string | null = null;
-      const pendingElectronData = new Map<string, string[]>();
+      const pendingElectronData = new Map<string, SequencedPtyData[]>();
       const pendingElectronExit = new Map<
         string,
         { ptyId: string; exitCode: number; signal?: number }
       >();
       const PENDING_ELECTRON_OUTPUT_MAX_CHARS = 64_000;
+      let electronReplayPtyId: string | null = null;
+      let electronReplayData: SequencedPtyData[] = [];
+      let electronReplayExit: { ptyId: string; exitCode: number; signal?: number } | null =
+        null;
       let fallbackRunningPosted = false;
       let promptCaptureBuffer = "";
       let promptTitlePosted = false;
       const stopWatchingColorScheme = watchTerminalColorScheme((colorScheme) => {
         term.options.theme = createTerminalTheme({ cursorColor, colorScheme });
       });
+      const detachLinks = attachTerminalLinks(term);
 
       const detachFileDrop = electron
         ? wireTerminalFileDrop({
@@ -226,16 +263,31 @@ export function TerminalPane({
         subscriptions.push(
           electron.pty.onData((msg) => {
             if (activePtyId === msg.ptyId) {
+              if (electronReplayPtyId === msg.ptyId) {
+                appendBoundedSequencedData(
+                  electronReplayData,
+                  sequencedPtyData(msg.seq, msg.data),
+                  PENDING_ELECTRON_OUTPUT_MAX_CHARS,
+                );
+                return;
+              }
               term.write(msg.data);
               return;
             }
-            const previous = (pendingElectronData.get(msg.ptyId) ?? []).join("");
-            pendingElectronData.set(msg.ptyId, [
-              `${previous}${msg.data}`.slice(-PENDING_ELECTRON_OUTPUT_MAX_CHARS),
-            ]);
+            const chunks = pendingElectronData.get(msg.ptyId) ?? [];
+            appendBoundedSequencedData(
+              chunks,
+              sequencedPtyData(msg.seq, msg.data),
+              PENDING_ELECTRON_OUTPUT_MAX_CHARS,
+            );
+            pendingElectronData.set(msg.ptyId, chunks);
           }),
           electron.pty.onExit((msg) => {
             if (activePtyId === msg.ptyId) {
+              if (electronReplayPtyId === msg.ptyId) {
+                electronReplayExit = msg;
+                return;
+              }
               handlePtyExit(msg.exitCode);
               return;
             }
@@ -243,6 +295,24 @@ export function TerminalPane({
           })
         );
       }
+
+      const resizeElectronPtyToSurface = (ptyId: string) => {
+        if (!electron) return Promise.resolve(false);
+        return resizePtyToTerminal(term, (cols, rows) => electron.pty.resize(ptyId, cols, rows));
+      };
+
+      const resizeRemotePtyToSurface = (ptyId: string) =>
+        resizePtyToTerminal(term, (cols, rows) => api.resizeRemotePty(ptyId, cols, rows));
+
+      termSurfaceRef.current = {
+        setFontSize: (nextFontSize) => {
+          applyTerminalFontSize(term, fit, nextFontSize);
+          const id = activePtyId;
+          if (!id) return;
+          if (electron) void resizeElectronPtyToSurface(id);
+          else void resizeRemotePtyToSurface(id).catch(() => undefined);
+        },
+      };
 
       const wireTerminalInput = (ptyId: string) => {
         term.onData((data) => {
@@ -293,11 +363,11 @@ export function TerminalPane({
         });
       };
 
-      const wireElectronPty = (ptyId: string): boolean => {
+      const wireNewElectronPty = (ptyId: string): boolean => {
         if (!electron) return false;
         activePtyId = ptyId;
         for (const chunk of pendingElectronData.get(ptyId) ?? []) {
-          term.write(chunk);
+          term.write(chunk.data);
         }
         pendingElectronData.delete(ptyId);
         const pendingExit = pendingElectronExit.get(ptyId);
@@ -307,6 +377,45 @@ export function TerminalPane({
           return false;
         }
         wireTerminalInput(ptyId);
+        return true;
+      };
+
+      const wireExistingElectronPty = async (ptyId: string): Promise<boolean> => {
+        if (!electron) return false;
+
+        electronReplayPtyId = ptyId;
+        electronReplayData = [];
+        electronReplayExit = pendingElectronExit.get(ptyId) ?? null;
+        pendingElectronExit.delete(ptyId);
+
+        activePtyId = ptyId;
+        const pendingBeforeReplay = pendingElectronData.get(ptyId) ?? [];
+        pendingElectronData.delete(ptyId);
+        wireTerminalInput(ptyId);
+
+        void resizeElectronPtyToSurface(ptyId);
+        let replay: PtyReplaySnapshot = { data: "", nextSeq: 0 };
+        try {
+          replay = await electron.pty.replay(ptyId);
+        } finally {
+          if (electronReplayPtyId === ptyId) {
+            electronReplayPtyId = null;
+          }
+        }
+        if (cancelled || activePtyId !== ptyId) return false;
+
+        const replayData = replayDataOrFallback(replay, pendingBeforeReplay);
+        if (replayData) term.write(replayData);
+
+        for (const chunk of dataAfterReplay(electronReplayData, replay)) term.write(chunk);
+        electronReplayData = [];
+
+        const replayExit = electronReplayExit;
+        electronReplayExit = null;
+        if (replayExit) {
+          handlePtyExit(replayExit.exitCode);
+          return false;
+        }
         return true;
       };
 
@@ -379,6 +488,7 @@ export function TerminalPane({
         if (exitedBeforeReady || streamClosedBeforeReady) return;
         setLiveStatus("connected to remote runtime");
         term.writeln("\x1b[36m[connected to remote runtime]\x1b[0m");
+        await resizeRemotePtyToSurface(ptyId).catch(() => undefined);
         const replay = await api.replayRemotePty(ptyId, { beforeSeq: replayBeforeSeq });
         if (!cancelled && replay.data) term.write(replay.data);
         replaying = false;
@@ -421,7 +531,7 @@ export function TerminalPane({
           return;
         }
         if (electron) {
-          if (wireElectronPty(ptyId)) onPtyReady(ptyId);
+          if (wireNewElectronPty(ptyId)) onPtyReady(ptyId);
         } else {
           await wireRemotePty(ptyId);
           if (activePtyId === ptyId) onPtyReady(ptyId);
@@ -439,9 +549,7 @@ export function TerminalPane({
             // Re-attach to a live PTY: subscribe BEFORE replay so any chunk
             // emitted between the calls is queued, not lost.
             if (electron) {
-              wireElectronPty(descriptor.ptyId);
-              const buf = await electron.pty.replay(descriptor.ptyId);
-              if (!cancelled && buf) term.write(buf);
+              await wireExistingElectronPty(descriptor.ptyId);
             } else {
               await wireRemotePty(descriptor.ptyId);
             }
@@ -484,9 +592,11 @@ export function TerminalPane({
         cancelAnimationFrame(rafHandle);
         for (const off of subscriptions) off();
         stopWatchingColorScheme();
+        detachLinks();
         detachFileDrop();
         ro.disconnect();
         fitRef.current = null;
+        termSurfaceRef.current = null;
         term.dispose();
       };
     })();
@@ -499,6 +609,7 @@ export function TerminalPane({
 
   return (
     <div
+      ref={paneRef}
       style={{
         flex: 1,
         minHeight: 120,
@@ -591,6 +702,13 @@ export function TerminalPane({
           </div>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+          <TerminalZoomControls
+            level={zoomLevel}
+            canZoomIn={canZoomIn}
+            canZoomOut={canZoomOut}
+            onZoomIn={zoomIn}
+            onZoomOut={zoomOut}
+          />
           <HotkeyTooltip action="session.clone" label="Clone session">
             <Btn
               variant="ghost"

--- a/src/components/views/TerminalPanel.tsx
+++ b/src/components/views/TerminalPanel.tsx
@@ -107,6 +107,7 @@ export function TerminalPanel({
     <CardFrame
       ref={rootRef}
       focused={focused}
+      data-session-terminal-panel
       style={{
         width: expanded ? "100%" : width,
         flex: expanded ? 1 : undefined,

--- a/src/components/views/TerminalSettingsPage.tsx
+++ b/src/components/views/TerminalSettingsPage.tsx
@@ -1,0 +1,147 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { Field, SettingsSection } from "~/components/views/SettingsParts";
+import { api, type AppSettings } from "~/lib/api";
+import { queryKeys, useSettings } from "~/queries";
+import { DEFAULT_ACCENT_COLOR } from "~/lib/accent-colors";
+import { TERMINAL_FONT_SIZE } from "~/lib/terminal-options";
+import {
+  DEFAULT_TERMINAL_ZOOM_LEVEL,
+  TERMINAL_ZOOM_LABELS,
+  TERMINAL_ZOOM_LEVELS,
+  TERMINAL_ZOOM_MAX,
+  TERMINAL_ZOOM_MIN,
+  terminalFontSizeForLevel,
+  type TerminalZoomLevel,
+} from "~/shared/terminal-zoom";
+
+export function TerminalSettingsPage() {
+  const queryClient = useQueryClient();
+  const { data: settings } = useSettings();
+  const level = settings?.terminalZoomLevel ?? DEFAULT_TERMINAL_ZOOM_LEVEL;
+  const fontSize = terminalFontSizeForLevel(level);
+
+  const optimisticSettings = (
+    patch: Partial<Pick<AppSettings, "terminalZoomLevel">>,
+  ): AppSettings => ({
+    agentSystemBannerDisabled: settings?.agentSystemBannerDisabled ?? false,
+    accentColor: settings?.accentColor ?? DEFAULT_ACCENT_COLOR,
+    minimalTheme: settings?.minimalTheme ?? false,
+    mouseGradientDisabled: settings?.mouseGradientDisabled ?? false,
+    sessionFinishToastEnabled: settings?.sessionFinishToastEnabled ?? true,
+    sessionFinishOsNotificationEnabled:
+      settings?.sessionFinishOsNotificationEnabled ?? false,
+    launchOverlayEnabled: settings?.launchOverlayEnabled ?? false,
+    automaticUpdateDownloadsEnabled: settings?.automaticUpdateDownloadsEnabled ?? false,
+    automaticUpdateInstallOnQuitEnabled:
+      settings?.automaticUpdateInstallOnQuitEnabled ?? false,
+    worktreesEnabled: settings?.worktreesEnabled ?? false,
+    gitDiffChangedFilesView: settings?.gitDiffChangedFilesView ?? null,
+    gitDiffChangedFilesWidth: settings?.gitDiffChangedFilesWidth ?? null,
+    projectsDashboardView: settings?.projectsDashboardView ?? null,
+    selectedWorktreeByProject: settings?.selectedWorktreeByProject ?? null,
+    commitCli: settings?.commitCli ?? null,
+    terminalZoomLevel: level,
+    ...queryClient.getQueryData<AppSettings>(queryKeys.settings),
+    ...patch,
+  });
+
+  const setLevel = async (next: TerminalZoomLevel) => {
+    const previous = queryClient.getQueryData<AppSettings>(queryKeys.settings);
+    const optimistic = optimisticSettings({ terminalZoomLevel: next });
+    queryClient.setQueryData(queryKeys.settings, optimistic);
+    try {
+      const updated = await api.updateSettings({ terminalZoomLevel: next });
+      queryClient.setQueryData(queryKeys.settings, { ...optimistic, ...updated });
+    } catch (error) {
+      if (previous) queryClient.setQueryData(queryKeys.settings, previous);
+      throw error;
+    }
+  };
+
+  return (
+    <SettingsSection
+      title="Terminal"
+      subtitle="Default text size for new terminals and sessions without a per-pane override."
+      headingLevel="h1"
+    >
+      <Field label="Default zoom">
+        <div style={{ display: "flex", flexDirection: "column", gap: 10, maxWidth: 420 }}>
+          <div
+            style={{
+              fontSize: 12,
+              color: "var(--text-dim)",
+              lineHeight: 1.55,
+            }}
+          >
+            Applies to every terminal until you zoom that pane in or out from its header.
+            Per-pane zoom is remembered separately.
+          </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 12,
+              fontFamily: "var(--mono)",
+              fontSize: 11.5,
+              color: "var(--text)",
+            }}
+          >
+            <span>{TERMINAL_ZOOM_LABELS[level]}</span>
+            <span style={{ color: "var(--text-dim)" }}>{fontSize}px</span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={TERMINAL_ZOOM_LEVELS.length - 1}
+            step={1}
+            value={TERMINAL_ZOOM_LEVELS.indexOf(level)}
+            onChange={(event) => {
+              const index = Number(event.currentTarget.value);
+              const next = TERMINAL_ZOOM_LEVELS[index];
+              if (next !== undefined) void setLevel(next);
+            }}
+            aria-label="Default terminal zoom level"
+            aria-valuemin={TERMINAL_ZOOM_MIN}
+            aria-valuemax={TERMINAL_ZOOM_MAX}
+            aria-valuenow={level}
+            aria-valuetext={TERMINAL_ZOOM_LABELS[level]}
+            style={{
+              width: "100%",
+              accentColor: "var(--accent)",
+            }}
+          />
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              fontFamily: "var(--mono)",
+              fontSize: 10.5,
+              color: "var(--text-faint)",
+            }}
+          >
+            {TERMINAL_ZOOM_LEVELS.map((step) => (
+              <span key={step}>{step > 0 ? `+${step}` : step}</span>
+            ))}
+          </div>
+          <div
+            style={{
+              marginTop: 4,
+              padding: "10px 12px",
+              borderRadius: 7,
+              border: "1px solid var(--border)",
+              background: "var(--terminal-bg)",
+              fontFamily: "var(--mono)",
+              fontSize,
+              color: "var(--text)",
+              lineHeight: 1.4,
+            }}
+            aria-hidden
+          >
+            $ mission-control — preview at {fontSize}px (base {TERMINAL_FONT_SIZE}px)
+          </div>
+        </div>
+      </Field>
+    </SettingsSection>
+  );
+}

--- a/src/components/views/TerminalZoomControls.tsx
+++ b/src/components/views/TerminalZoomControls.tsx
@@ -1,0 +1,43 @@
+import { Btn } from "~/components/ui/Btn";
+import { TERMINAL_ZOOM_LABELS } from "~/shared/terminal-zoom";
+
+export function TerminalZoomControls({
+  level,
+  canZoomIn,
+  canZoomOut,
+  onZoomIn,
+  onZoomOut,
+}: {
+  level: number;
+  canZoomIn: boolean;
+  canZoomOut: boolean;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+}) {
+  const label = TERMINAL_ZOOM_LABELS[level as keyof typeof TERMINAL_ZOOM_LABELS] ?? "Default";
+
+  return (
+    <>
+      <Btn
+        variant="ghost"
+        size="sm"
+        icon="zoom-out"
+        onClick={onZoomOut}
+        disabled={!canZoomOut}
+        aria-label="Zoom out terminal text"
+        title={`Zoom out (${label})`}
+        style={{ width: 34, padding: 0 }}
+      />
+      <Btn
+        variant="ghost"
+        size="sm"
+        icon="zoom-in"
+        onClick={onZoomIn}
+        disabled={!canZoomIn}
+        aria-label="Zoom in terminal text"
+        title={`Zoom in (${label})`}
+        style={{ width: 34, padding: 0 }}
+      />
+    </>
+  );
+}

--- a/src/components/views/ThemeSettingsPage.tsx
+++ b/src/components/views/ThemeSettingsPage.tsx
@@ -15,6 +15,7 @@ import {
   hasCachedLaunchIntroPreference,
   readCachedLaunchIntroEnabled,
 } from "~/lib/launch-intro";
+import { DEFAULT_TERMINAL_ZOOM_LEVEL } from "~/shared/terminal-zoom";
 
 // Pixel size of the color-swatch dot used in the accent-color picker (both
 // the selected-check badge and the per-row preview swatch use this size).
@@ -51,6 +52,7 @@ export function ThemeSettingsPage() {
     projectsDashboardView: settings?.projectsDashboardView ?? null,
     selectedWorktreeByProject: settings?.selectedWorktreeByProject ?? null,
     commitCli: settings?.commitCli ?? null,
+    terminalZoomLevel: settings?.terminalZoomLevel ?? DEFAULT_TERMINAL_ZOOM_LEVEL,
     ...queryClient.getQueryData<AppSettings>(queryKeys.settings),
     worktreesEnabled:
       queryClient.getQueryData<AppSettings>(queryKeys.settings)?.worktreesEnabled ??

--- a/src/components/views/UserTerminalPane.tsx
+++ b/src/components/views/UserTerminalPane.tsx
@@ -9,6 +9,7 @@ import {
   wireTerminalFileDrop,
 } from "~/lib/terminal-pane-helpers";
 import {
+  applyTerminalFontSize,
   createTerminalOptions,
   createTerminalTheme,
   fitTerminalSurface,
@@ -16,20 +17,26 @@ import {
   getTerminalColorScheme,
   watchTerminalColorScheme,
 } from "~/lib/terminal-options";
+import { useTerminalZoom, useTerminalPaneZoomShortcuts } from "~/lib/use-terminal-zoom";
+import { TerminalZoomControls } from "~/components/views/TerminalZoomControls";
 import { prefetchTerminalModules } from "~/lib/prefetch-terminal-modules";
+import { attachTerminalLinks } from "~/lib/terminal-links";
+import { resizePtyToTerminal } from "~/lib/terminal-resize";
+import {
+  dataAfterReplay,
+  sequencedPtyData,
+  type PtyReplaySnapshot,
+  type SequencedPtyData,
+} from "~/lib/terminal-replay";
 import { ApiError, api } from "~/lib/api";
+import { CLEAR_USER_TERMINAL_EVENT } from "~/lib/design-meta";
 import type { UserTerminal } from "~/db/schema";
 import { normalizePtySize } from "~/shared/pty-size";
 import { HOSTED_WORKSPACE_ROOT } from "~/shared/hosted-workspace";
 
-// Pattern shared by the link provider and the launch-URL detector. The two
-// callers differ only in whether the port is a capture group.
+// Pattern for the launch-URL detector (port capture group for dev-server URLs).
 const LOOPBACK_URL_BASE = String.raw`\bhttps?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])`;
 const LOOPBACK_URL_TAIL = String.raw`(?:\/[^\s'"<>)\]]*)?`;
-const LOOPBACK_URL_REGEX = new RegExp(
-  `${LOOPBACK_URL_BASE}(?::\\d+)?${LOOPBACK_URL_TAIL}`,
-  "g",
-);
 const LOOPBACK_URL_WITH_PORT_GROUP_REGEX = new RegExp(
   `${LOOPBACK_URL_BASE}(?::(\\d+))?${LOOPBACK_URL_TAIL}`,
   "g",
@@ -48,7 +55,7 @@ export function UserTerminalPane({
   onHide,
   onDelete,
   onRename,
-  isLast,
+  isLast: _isLast,
 }: {
   terminal: UserTerminal;
   ptyId: string | null;
@@ -65,7 +72,20 @@ export function UserTerminalPane({
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const cardRef = useRef<HTMLElement | null>(null);
-  const termRef = useRef<{ focus: () => void } | null>(null);
+  const termRef = useRef<{
+    focus: () => void;
+    clear: () => void;
+    setFontSize: (fontSize: number) => void;
+  } | null>(null);
+  const {
+    level: zoomLevel,
+    fontSize: terminalFontSize,
+    zoomIn,
+    zoomOut,
+    canZoomIn,
+    canZoomOut,
+  } = useTerminalZoom(terminal.id);
+  useTerminalPaneZoomShortcuts(cardRef, zoomIn, zoomOut);
   const [editing, setEditing] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [draftName, setDraftName] = useState(terminal.name);
@@ -96,6 +116,20 @@ export function UserTerminalPane({
   useEffect(() => setDraftName(terminal.name), [terminal.name]);
 
   useEffect(() => {
+    termRef.current?.setFontSize(terminalFontSize);
+  }, [terminalFontSize]);
+
+  useEffect(() => {
+    const onClear = () => {
+      const root = cardRef.current;
+      if (!root?.contains(document.activeElement)) return;
+      termRef.current?.clear();
+    };
+    window.addEventListener(CLEAR_USER_TERMINAL_EVENT, onClear);
+    return () => window.removeEventListener(CLEAR_USER_TERMINAL_EVENT, onClear);
+  }, []);
+
+  useEffect(() => {
     const electron = getElectron();
     if (!containerRef.current) return;
 
@@ -110,12 +144,12 @@ export function UserTerminalPane({
         createTerminalOptions({
           colorScheme: getTerminalColorScheme(),
           cursorColor: getCurrentAccentColor(),
+          fontSize: terminalFontSize,
         })
       );
       const fit = new FitAddon();
       term.loadAddon(fit);
       term.open(containerRef.current);
-      termRef.current = { focus: () => term.focus() };
       term.focus();
       const stopWatchingColorScheme = watchTerminalColorScheme((colorScheme) => {
         term.options.theme = createTerminalTheme({
@@ -123,31 +157,7 @@ export function UserTerminalPane({
           cursorColor: getCurrentAccentColor(),
         });
       });
-      term.registerLinkProvider({
-        provideLinks(y, callback) {
-          const line = term.buffer.active.getLine(y - 1)?.translateToString(true) ?? "";
-          const links: any[] = [];
-          const regex = new RegExp(LOOPBACK_URL_REGEX.source, "g");
-          let match: RegExpExecArray | null;
-          while ((match = regex.exec(line)) !== null) {
-            const text = match[0]!;
-            links.push({
-              text,
-              range: {
-                start: { x: match.index + 1, y: 1 },
-                end: { x: match.index + text.length, y: 1 },
-              },
-              activate(event: MouseEvent, uri: string) {
-                if (event.metaKey || event.ctrlKey) {
-                  if (electron) void electron.openExternal(uri);
-                  else window.open(uri, "_blank", "noopener,noreferrer");
-                }
-              },
-            });
-          }
-          callback(links);
-        },
-      });
+      const detachLinks = attachTerminalLinks(term);
       const onFocusIn = () => onFocus();
       const focusEl = containerRef.current;
       focusEl.addEventListener("focusin", onFocusIn);
@@ -155,6 +165,10 @@ export function UserTerminalPane({
       const subscriptions: Array<() => void> = [];
       let rafHandle = 0;
       let activePtyId: string | null = null;
+      let electronReplayPtyId: string | null = null;
+      let electronReplayData: SequencedPtyData[] = [];
+      let electronReplayExit: { ptyId: string; exitCode: number; signal?: number } | null =
+        null;
 
       const detachFileDrop = electron
         ? wireTerminalFileDrop({
@@ -194,6 +208,23 @@ export function UserTerminalPane({
         term.writeln(`\x1b[2m[process exited (code=${exitCode ?? "unknown"})]\x1b[0m`);
         onPtyExit();
       };
+      const resizeElectronPtyToSurface = (id: string) => {
+        if (!electron) return Promise.resolve(false);
+        return resizePtyToTerminal(term, (cols, rows) => electron.pty.resize(id, cols, rows));
+      };
+      const resizeRemotePtyToSurface = (id: string) =>
+        resizePtyToTerminal(term, (cols, rows) => api.resizeRemotePty(id, cols, rows));
+      termRef.current = {
+        focus: () => term.focus(),
+        clear: () => term.clear(),
+        setFontSize: (nextFontSize) => {
+          applyTerminalFontSize(term, fit, nextFontSize);
+          const id = activePtyId;
+          if (!id) return;
+          if (electron) void resizeElectronPtyToSurface(id);
+          else void resizeRemotePtyToSurface(id).catch(() => undefined);
+        },
+      };
       const wireTerminalInput = (id: string) => {
         term.onData((data) => {
           if (electron) electron.pty.write(id, data);
@@ -211,17 +242,59 @@ export function UserTerminalPane({
         subscriptions.push(
           electron.pty.onData((msg) => {
             if (msg.ptyId === id) {
+              if (electronReplayPtyId === id) {
+                electronReplayData.push(sequencedPtyData(msg.seq, msg.data));
+                return;
+              }
               term.write(msg.data);
               detectLaunchUrl(msg.data);
             }
           }),
           electron.pty.onExit((msg) => {
             if (msg.ptyId === id) {
+              if (electronReplayPtyId === id) {
+                electronReplayExit = msg;
+                return;
+              }
               handleExit(msg.exitCode);
             }
           })
         );
         wireTerminalInput(id);
+      };
+      const replayExistingElectronPty = async (id: string) => {
+        if (!electron) return;
+        electronReplayPtyId = id;
+        electronReplayData = [];
+        electronReplayExit = null;
+        wireElectronPty(id);
+        void resizeElectronPtyToSurface(id);
+
+        let replay: PtyReplaySnapshot = { data: "", nextSeq: 0 };
+        try {
+          replay = await electron.pty.replay(id);
+        } finally {
+          if (electronReplayPtyId === id) {
+            electronReplayPtyId = null;
+          }
+        }
+        if (cancelled || activePtyId !== id) return;
+
+        if (replay.data) {
+          term.write(replay.data);
+          detectLaunchUrl(replay.data);
+        }
+        for (const chunk of dataAfterReplay(electronReplayData, replay)) {
+          term.write(chunk);
+          detectLaunchUrl(chunk);
+        }
+        electronReplayData = [];
+
+        const replayExit = electronReplayExit as
+          | { ptyId: string; exitCode: number; signal?: number }
+          | null;
+        electronReplayExit = null;
+        if (replayExit) handleExit(replayExit.exitCode);
       };
       const wireRemotePty = async (id: string) => {
         activePtyId = id;
@@ -278,6 +351,7 @@ export function UserTerminalPane({
         ]);
         setLiveStatus("connected to remote runtime");
         term.writeln("\x1b[36m[connected to remote runtime]\x1b[0m");
+        await resizeRemotePtyToSurface(id).catch(() => undefined);
         const replay = await api.replayRemotePty(id, { beforeSeq: replayBeforeSeq });
         if (!cancelled && replay.data) {
           term.write(replay.data);
@@ -300,9 +374,7 @@ export function UserTerminalPane({
 
           if (ptyId) {
             if (electron) {
-              wireElectronPty(ptyId);
-              const buf = await electron.pty.replay(ptyId);
-              if (!cancelled && buf) term.write(buf);
+              await replayExistingElectronPty(ptyId);
             } else {
               await wireRemotePty(ptyId);
             }
@@ -361,6 +433,7 @@ export function UserTerminalPane({
         cancelAnimationFrame(rafHandle);
         focusEl.removeEventListener("focusin", onFocusIn);
         detachFileDrop();
+        detachLinks();
         stopWatchingColorScheme();
         for (const off of subscriptions) off();
         ro.disconnect();
@@ -373,7 +446,6 @@ export function UserTerminalPane({
       cancelled = true;
       cleanup?.();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [terminal.id, retryNonce]);
 
   // Bring focus to the xterm when this pane becomes focused via cycling or
@@ -480,34 +552,42 @@ export function UserTerminalPane({
             {terminal.name}
           </span>
         )}
-        <button
-          onClick={() => setConfirmDelete(true)}
-          title="Delete terminal (kills the process)"
-          style={{
-            background: "transparent",
-            border: 0,
-            padding: 4,
-            color: "var(--text-faint)",
-            cursor: "pointer",
-            display: "flex",
-          }}
-        >
-          <Icon name="trash" size={11} />
-        </button>
-        <button
-          onClick={onHide}
-          title="Hide terminal (keeps it running)"
-          style={{
-            background: "transparent",
-            border: 0,
-            padding: 4,
-            color: "var(--text-faint)",
-            cursor: "pointer",
-            display: "flex",
-          }}
-        >
-          <Icon name="x" size={11} />
-        </button>
+        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+          <TerminalZoomControls
+            level={zoomLevel}
+            canZoomIn={canZoomIn}
+            canZoomOut={canZoomOut}
+            onZoomIn={zoomIn}
+            onZoomOut={zoomOut}
+          />
+          <Btn
+            variant="ghost"
+            size="sm"
+            icon="eraser"
+            onClick={() => termRef.current?.clear()}
+            title="Clear terminal output"
+            aria-label="Clear terminal output"
+            style={{ width: 34, padding: 0 }}
+          />
+          <Btn
+            variant="ghost"
+            size="sm"
+            icon="trash"
+            onClick={() => setConfirmDelete(true)}
+            title="Delete terminal (kills the process)"
+            aria-label="Delete terminal (kills the process)"
+            style={{ width: 34, padding: 0 }}
+          />
+          <Btn
+            variant="ghost"
+            size="sm"
+            icon="x"
+            onClick={onHide}
+            title="Hide terminal (keeps it running)"
+            aria-label="Hide terminal (keeps it running)"
+            style={{ width: 34, padding: 0 }}
+          />
+        </div>
       </div>
       <ConfirmDialog
         open={confirmDelete}

--- a/src/components/views/UserTerminalPanel.tsx
+++ b/src/components/views/UserTerminalPanel.tsx
@@ -150,6 +150,7 @@ export function UserTerminalPanel() {
   return (
     <CardFrame
       frame="slanted"
+      data-user-terminal-panel
       style={{
         width: "100%",
         height: panelOpen ? height : "auto",

--- a/src/components/views/__tests__/project-bar-activity.test.ts
+++ b/src/components/views/__tests__/project-bar-activity.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { shouldFlashPinnedProjectLogo } from "../project-bar-activity";
+
+describe("shouldFlashPinnedProjectLogo", () => {
+  it("does not flash for an open terminal without a running CLI session", () => {
+    expect(
+      shouldFlashPinnedProjectLogo({
+        cliRunningCount: 0,
+        terminalOpen: true,
+      })
+    ).toBe(false);
+  });
+
+  it("flashes when at least one CLI session is running", () => {
+    expect(
+      shouldFlashPinnedProjectLogo({
+        cliRunningCount: 1,
+        terminalOpen: false,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/components/views/project-bar-activity.ts
+++ b/src/components/views/project-bar-activity.ts
@@ -1,0 +1,11 @@
+export type PinnedProjectLogoActivity = {
+  cliRunningCount: number;
+  terminalOpen: boolean;
+};
+
+export function shouldFlashPinnedProjectLogo({
+  cliRunningCount,
+}: PinnedProjectLogoActivity): boolean {
+  // Open terminals can have PTYs without a running CLI session lifecycle.
+  return cliRunningCount > 0;
+}

--- a/src/lib/__tests__/pull-request-errors.test.ts
+++ b/src/lib/__tests__/pull-request-errors.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "~/lib/api";
+import { formatCreatePullRequestError } from "../pull-request-errors";
+
+describe("formatCreatePullRequestError", () => {
+  it("explains a missing API route instead of showing bare not found", () => {
+    const error = new ApiError("not found", 404, { error: "not found" });
+    expect(formatCreatePullRequestError(error)).toEqual({
+      title: "Create pull request unavailable",
+      message: expect.stringContaining("create-pull-request API"),
+    });
+  });
+
+  it("surfaces server guidance about shipping first", () => {
+    const error = new ApiError(
+      'Branch "feature/x" has no commits ahead of main yet. Accept your changes in Review Changes, then use Ship to commit and push before opening a pull request.',
+      400,
+      {
+        error:
+          'Branch "feature/x" has no commits ahead of main yet. Accept your changes in Review Changes, then use Ship to commit and push before opening a pull request.',
+      },
+    );
+    expect(formatCreatePullRequestError(error)).toEqual({
+      title: "Commit before opening a pull request",
+      message: error.message,
+    });
+  });
+
+  it("maps gh no-commits-between errors to a push-first message", () => {
+    const error = new ApiError("gh pr create failed", 400, {
+      error: "gh pr create failed",
+      stderr: "pull request create failed: No commits between main and feature/x",
+    });
+    expect(formatCreatePullRequestError(error)).toEqual({
+      title: "Nothing to merge yet",
+      message: expect.stringContaining("Ship"),
+    });
+  });
+
+  it("maps missing remote branch errors to a push-first message", () => {
+    const error = new ApiError("gh pr create failed", 400, {
+      error: "gh pr create failed",
+      stderr: "remote branch not found on origin",
+    });
+    expect(formatCreatePullRequestError(error)).toEqual({
+      title: "Push your branch first",
+      message: expect.stringContaining("Ship"),
+    });
+  });
+});

--- a/src/lib/__tests__/shell-query-cache.test.ts
+++ b/src/lib/__tests__/shell-query-cache.test.ts
@@ -1,0 +1,119 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ProjectWithCounts } from "~/shared/projects";
+import {
+  SHELL_QUERY_CACHE_KEYS,
+  installShellQueryCache,
+  readCachedLicense,
+  readCachedProjects,
+} from "../shell-query-cache";
+
+function mockWindowStorage() {
+  const store = new Map<string, string>();
+  const previousWindow = globalThis.window;
+
+  globalThis.window = {
+    localStorage: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+    },
+  } as unknown as Window & typeof globalThis;
+
+  return {
+    store,
+    restore() {
+      globalThis.window = previousWindow;
+    },
+  };
+}
+
+function makeProject(overrides: Partial<ProjectWithCounts> = {}): ProjectWithCounts {
+  return {
+    id: "project-1",
+    name: "Core",
+    path: "/tmp/core",
+    icon: "folder",
+    iconColor: "#ffffff",
+    imagePath: null,
+    groupId: null,
+    pinned: true,
+    branch: "main",
+    launchCommands: null,
+    launchUrl: null,
+    worktreeSetupCommand: null,
+    rememberAgentSettings: false,
+    savedAgent: null,
+    savedSkipPermissions: false,
+    savedBareSession: false,
+    createdAt: 1,
+    updatedAt: 1,
+    taskCounts: {
+      ready: 0,
+      running: 0,
+      "needs-input": 0,
+      interrupted: 0,
+      finished: 0,
+      terminated: 0,
+      disconnected: 0,
+      total: 0,
+      activeNonDone: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("shell query cache", () => {
+  let storage: ReturnType<typeof mockWindowStorage>;
+
+  beforeEach(() => {
+    storage = mockWindowStorage();
+  });
+
+  afterEach(() => {
+    storage.restore();
+  });
+
+  it("persists shell queries when the query cache receives fresh data", () => {
+    const queryClient = new QueryClient();
+    const projects = [makeProject()];
+    const license = {
+      hasKey: true,
+      maskedKey: "****1234",
+      status: "active" as const,
+      plan: "Pro",
+      lastValidatedAt: "2026-05-25T00:00:00.000Z",
+      payload: null,
+    };
+
+    installShellQueryCache(queryClient);
+    queryClient.setQueryData(["projects"], projects);
+    queryClient.setQueryData(["license"], license);
+
+    expect(readCachedProjects()).toEqual(projects);
+    expect(readCachedLicense()).toEqual(license);
+  });
+
+  it("ignores similarly-prefixed detail query keys", () => {
+    const queryClient = new QueryClient();
+    const projects = [makeProject({ id: "detail" })];
+
+    installShellQueryCache(queryClient);
+    queryClient.setQueryData(["projects", "detail"], projects);
+
+    expect(readCachedProjects()).toBeUndefined();
+  });
+
+  it("ignores cache envelopes from older versions", () => {
+    storage.store.set(
+      SHELL_QUERY_CACHE_KEYS.projects,
+      JSON.stringify({ version: 0, savedAt: Date.now(), data: [makeProject()] }),
+    );
+
+    expect(readCachedProjects()).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/terminal-links.test.ts
+++ b/src/lib/__tests__/terminal-links.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isMacPlatform, openTerminalLink, terminalLinkRequiresModifier } from "../terminal-links";
+
+describe("terminal links", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("requires Cmd on macOS", () => {
+    vi.stubGlobal("navigator", { platform: "MacIntel", userAgent: "Macintosh" });
+    expect(isMacPlatform()).toBe(true);
+    expect(terminalLinkRequiresModifier({ metaKey: true, ctrlKey: false })).toBe(true);
+    expect(terminalLinkRequiresModifier({ metaKey: false, ctrlKey: true })).toBe(false);
+    expect(terminalLinkRequiresModifier({ metaKey: false, ctrlKey: false })).toBe(false);
+  });
+
+  it("requires Ctrl on non-macOS", () => {
+    vi.stubGlobal("navigator", { platform: "Win32", userAgent: "Windows NT 10.0" });
+    expect(isMacPlatform()).toBe(false);
+    expect(terminalLinkRequiresModifier({ metaKey: false, ctrlKey: true })).toBe(true);
+    expect(terminalLinkRequiresModifier({ metaKey: true, ctrlKey: false })).toBe(false);
+    expect(terminalLinkRequiresModifier({ metaKey: false, ctrlKey: false })).toBe(false);
+  });
+
+  it("opens links through electron when available", () => {
+    const openExternal = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("window", { electronAPI: { openExternal } });
+    openTerminalLink("https://example.com/docs");
+    expect(openExternal).toHaveBeenCalledWith("https://example.com/docs");
+  });
+
+  it("falls back to an anchor click in the browser", () => {
+    const click = vi.fn();
+    const anchor = { href: "", target: "", rel: "", click };
+    const createElement = vi.fn().mockReturnValue(anchor);
+    vi.stubGlobal("document", { createElement });
+    vi.stubGlobal("window", { electronAPI: undefined });
+    openTerminalLink("https://example.com/docs");
+    expect(createElement).toHaveBeenCalledWith("a");
+    expect(anchor.href).toBe("https://example.com/docs");
+    expect(anchor.target).toBe("_blank");
+    expect(anchor.rel).toBe("noopener noreferrer");
+    expect(click).toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/terminal-replay.test.ts
+++ b/src/lib/__tests__/terminal-replay.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendBoundedSequencedData,
+  dataAfterReplay,
+  replayDataOrFallback,
+  sequencedPtyData,
+} from "../terminal-replay";
+
+describe("terminal replay helpers", () => {
+  it("drops live chunks that are already included in the replay snapshot", () => {
+    expect(
+      dataAfterReplay(
+        [
+          { seq: 3, data: "already replayed" },
+          { seq: 4, data: "new redraw" },
+        ],
+        { data: "snapshot", nextSeq: 4 },
+      ),
+    ).toEqual(["new redraw"]);
+  });
+
+  it("falls back to pending data when an exited PTY no longer has replay data", () => {
+    expect(
+      replayDataOrFallback(
+        { data: "", nextSeq: 0 },
+        [
+          { seq: 1, data: "last " },
+          { seq: 2, data: "frame" },
+        ],
+      ),
+    ).toBe("last frame");
+  });
+
+  it("bounds queued live chunks during replay", () => {
+    const chunks = [
+      { seq: 1, data: "abcd" },
+      { seq: 2, data: "efgh" },
+    ];
+
+    appendBoundedSequencedData(chunks, { seq: 3, data: "ijkl" }, 8);
+
+    expect(chunks).toEqual([
+      { seq: 2, data: "efgh" },
+      { seq: 3, data: "ijkl" },
+    ]);
+  });
+
+  it("treats unsequenced legacy live chunks as post-replay data", () => {
+    expect(sequencedPtyData(undefined, "legacy")).toEqual({
+      seq: Number.MAX_SAFE_INTEGER,
+      data: "legacy",
+    });
+  });
+});

--- a/src/lib/__tests__/terminal-resize.test.ts
+++ b/src/lib/__tests__/terminal-resize.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { resizePtyToTerminal } from "../terminal-resize";
+
+describe("resizePtyToTerminal", () => {
+  it("normalizes the visible terminal dimensions before resizing the PTY", () => {
+    const resize = vi.fn();
+
+    resizePtyToTerminal({ cols: 142.8, rows: 41.2 }, resize);
+
+    expect(resize).toHaveBeenCalledWith(142, 41);
+  });
+
+  it("clamps unusable dimensions to PTY-safe bounds", () => {
+    const resize = vi.fn();
+
+    resizePtyToTerminal({ cols: 0, rows: 3 }, resize);
+
+    expect(resize).toHaveBeenCalledWith(10, 10);
+  });
+});

--- a/src/lib/__tests__/terminal-zoom-keyboard.test.ts
+++ b/src/lib/__tests__/terminal-zoom-keyboard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { terminalZoomStepFromKeyboard } from "~/lib/terminal-pane-helpers";
+
+function keyEvent(init: Partial<KeyboardEvent> & Pick<KeyboardEvent, "key">): KeyboardEvent {
+  return {
+    type: "keydown",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    code: "",
+    ...init,
+  } as KeyboardEvent;
+}
+
+describe("terminalZoomStepFromKeyboard", () => {
+  it("detects mod+= and mod++ as zoom in", () => {
+    expect(terminalZoomStepFromKeyboard(keyEvent({ metaKey: true, key: "=" }))).toBe(1);
+    expect(terminalZoomStepFromKeyboard(keyEvent({ metaKey: true, key: "+" }))).toBe(1);
+    expect(terminalZoomStepFromKeyboard(keyEvent({ ctrlKey: true, key: "=", code: "Equal" }))).toBe(
+      1,
+    );
+  });
+
+  it("detects mod+- as zoom out", () => {
+    expect(terminalZoomStepFromKeyboard(keyEvent({ metaKey: true, key: "-" }))).toBe(-1);
+    expect(terminalZoomStepFromKeyboard(keyEvent({ ctrlKey: true, key: "-", code: "Minus" }))).toBe(
+      -1,
+    );
+  });
+
+  it("ignores unmodified or alt-modified keys", () => {
+    expect(terminalZoomStepFromKeyboard(keyEvent({ key: "=" }))).toBeNull();
+    expect(terminalZoomStepFromKeyboard(keyEvent({ metaKey: true, altKey: true, key: "=" }))).toBeNull();
+    expect(terminalZoomStepFromKeyboard(keyEvent({ metaKey: true, key: "k" }))).toBeNull();
+  });
+});

--- a/src/lib/__tests__/terminal-zoom.test.ts
+++ b/src/lib/__tests__/terminal-zoom.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampTerminalZoomLevel,
+  normalizeTerminalZoomLevel,
+  stepTerminalZoomLevel,
+  terminalFontSizeForLevel,
+} from "~/shared/terminal-zoom";
+import {
+  resolveTerminalZoomLevel,
+} from "~/lib/terminal-zoom-storage";
+
+describe("terminal zoom helpers", () => {
+  it("maps zoom levels to font sizes in 2px steps", () => {
+    expect(terminalFontSizeForLevel(-2)).toBe(8);
+    expect(terminalFontSizeForLevel(0)).toBe(12);
+    expect(terminalFontSizeForLevel(2)).toBe(16);
+  });
+
+  it("normalizes and clamps zoom levels", () => {
+    expect(normalizeTerminalZoomLevel("1")).toBe(1);
+    expect(normalizeTerminalZoomLevel(99)).toBeNull();
+    expect(clampTerminalZoomLevel(-9)).toBe(-2);
+    expect(clampTerminalZoomLevel(9)).toBe(2);
+  });
+
+  it("steps within bounds", () => {
+    expect(stepTerminalZoomLevel(0, 1)).toBe(1);
+    expect(stepTerminalZoomLevel(2, 1)).toBeNull();
+    expect(stepTerminalZoomLevel(-2, -1)).toBeNull();
+  });
+});
+
+describe("terminal zoom storage", () => {
+  it("falls back to the global level when no override exists", () => {
+    expect(resolveTerminalZoomLevel("missing-instance", -1)).toBe(-1);
+  });
+});

--- a/src/lib/add-project-store.tsx
+++ b/src/lib/add-project-store.tsx
@@ -14,6 +14,7 @@ import {
 } from "~/queries";
 import { isWebDaytonaRuntime } from "~/lib/runtime";
 import { FREE_PROJECT_CAP, isProTier } from "~/shared/license";
+import type { Group } from "~/db/schema";
 
 type Ctx = {
   open: () => void;
@@ -46,6 +47,17 @@ export function AddProjectProvider({ children }: { children: React.ReactNode }) 
   }, [queryClient]);
   const close = useCallback(() => setIsOpen(false), []);
   const closePaywall = useCallback(() => setPaywallOpen(false), []);
+  const createGroupForSelection = useCallback(
+    async (name: string) => {
+      const { group } = await api.createGroup({ name });
+      queryClient.setQueryData<Group[]>(queryKeys.groups, (current) =>
+        current ? [...current, group] : [group],
+      );
+      await queryClient.invalidateQueries({ queryKey: queryKeys.groups });
+      return group;
+    },
+    [queryClient],
+  );
 
   useHotkey(
     "project.add",
@@ -64,6 +76,7 @@ export function AddProjectProvider({ children }: { children: React.ReactNode }) 
         project={null}
         groups={groups}
         onClose={close}
+        onCreateGroup={createGroupForSelection}
         onSave={async (data) => {
           const { pendingImage, imagePath: _ignore, ...createBody } = data;
           try {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,6 +4,7 @@ import type { ProjectPathStatus, ProjectWithCounts } from "~/shared/projects";
 import { DEV_SERVER_ORIGIN } from "~/shared/dev-server";
 import type {
   CommitResult,
+  CreatePullRequestResult,
   GitDiff,
   GitStatus,
   PushResult,
@@ -20,6 +21,7 @@ import type {
   ProjectsDashboardView,
   SelectedWorktreeByProject,
 } from "~/shared/ui-preferences";
+import type { TerminalZoomLevel } from "~/shared/terminal-zoom";
 import { getClientRuntime } from "~/lib/runtime";
 import { MISSION_CONTROL_RUNTIME_HEADER } from "~/shared/runtime";
 import { pruneStoredSessionFinishNotifications } from "~/lib/session-notification-store";
@@ -50,6 +52,8 @@ export type AppSettings = {
    * the server auto-detects and seeds it on the first ship attempt.
    */
   commitCli: CommitCli | null;
+  /** Default terminal text zoom (-2 … +2). Per-pane overrides live in localStorage. */
+  terminalZoomLevel: TerminalZoomLevel;
 };
 
 type RemotePtyCreateBody = {
@@ -408,6 +412,7 @@ export const api = {
         | "projectsDashboardView"
         | "selectedWorktreeByProject"
         | "commitCli"
+        | "terminalZoomLevel"
       >
     >,
   ) =>
@@ -454,6 +459,11 @@ export const api = {
     }),
   gitPush: (projectId: string, worktreeId?: string | null) =>
     req<PushResult>(`/api/projects/${projectId}/git/push`, {
+      method: "POST",
+      body: JSON.stringify({ worktreeId: worktreeId ?? null }),
+    }),
+  gitCreatePullRequest: (projectId: string, worktreeId?: string | null) =>
+    req<CreatePullRequestResult>(`/api/projects/${projectId}/git/create-pr`, {
       method: "POST",
       body: JSON.stringify({ worktreeId: worktreeId ?? null }),
     }),

--- a/src/lib/design-meta.ts
+++ b/src/lib/design-meta.ts
@@ -38,6 +38,13 @@ export function pickByPriority<T extends { status: TaskStatus }>(tasks: T[]): T 
 
 export const DUPLICATE_ACTIVE_SESSION_EVENT = "mc:duplicate-active-session";
 
+/** Dispatched when Cmd+K (terminal.expandToggle) fires while a bottom user TTY has focus. */
+export const CLEAR_USER_TERMINAL_EVENT = "mc:clear-user-terminal";
+
+/** Dispatched on Cmd+/Cmd- when an xterm (user or session) has keyboard focus. */
+export const TERMINAL_ZOOM_IN_EVENT = "mc:terminal-zoom-in";
+export const TERMINAL_ZOOM_OUT_EVENT = "mc:terminal-zoom-out";
+
 /** Dispatched by leaf components (e.g. ShipFailedDialog) to ask the Shell
  * to open the Settings panel at a specific page. Listened to by __root.tsx. */
 export const OPEN_SETTINGS_EVENT = "mc:open-settings";

--- a/src/lib/pull-request-errors.ts
+++ b/src/lib/pull-request-errors.ts
@@ -1,0 +1,103 @@
+import { ApiError } from "~/lib/api";
+
+export type CreatePullRequestErrorView = {
+  title: string;
+  message: string;
+};
+
+export function formatCreatePullRequestError(error: unknown): CreatePullRequestErrorView {
+  if (error instanceof ApiError) {
+    const body =
+      error.body && typeof error.body === "object"
+        ? (error.body as { error?: unknown; stderr?: unknown })
+        : null;
+    const serverMessage = typeof body?.error === "string" ? body.error : error.message;
+    const stderr = typeof body?.stderr === "string" ? body.stderr.trim() : "";
+
+    if (error.status === 404 || serverMessage.trim().toLowerCase() === "not found") {
+      return {
+        title: "Create pull request unavailable",
+        message:
+          "Mission Control could not reach the create-pull-request API. Restart the app after updating, or open GitHub and create the pull request manually.",
+      };
+    }
+
+    if (serverMessage.includes("Ship") || serverMessage.includes("Review Changes")) {
+      return {
+        title: "Commit before opening a pull request",
+        message: serverMessage,
+      };
+    }
+
+    const classified = classifyGhGitPrError(serverMessage, stderr);
+    if (classified) return classified;
+
+    const detail = stderr && stderr !== serverMessage ? `\n\n${stderr}` : "";
+    return {
+      title: "Could not create pull request",
+      message: `${serverMessage}${detail}`.trim(),
+    };
+  }
+
+  if (error instanceof Error && error.message.trim()) {
+    return { title: "Could not create pull request", message: error.message };
+  }
+
+  return {
+    title: "Could not create pull request",
+    message:
+      "Something went wrong. Commit and push your branch with Ship, then try again.",
+  };
+}
+
+function classifyGhGitPrError(
+  message: string,
+  stderr: string,
+): CreatePullRequestErrorView | null {
+  const text = `${message}\n${stderr}`.toLowerCase();
+
+  if (/no commits between/.test(text)) {
+    return {
+      title: "Nothing to merge yet",
+      message:
+        "This branch has no commits ahead of the base branch. Use Review Changes to accept your edits, then Ship to commit and push before opening a pull request.",
+    };
+  }
+
+  if (
+    /branch.*not found/.test(text) ||
+    /could not resolve/.test(text) ||
+    /invalid head/.test(text) ||
+    /head ref must be a branch/.test(text)
+  ) {
+    return {
+      title: "Push your branch first",
+      message:
+        "Your branch is not on GitHub yet (or GitHub cannot see it). Use Ship to commit and push, then try creating the pull request again.",
+    };
+  }
+
+  if (/no upstream branch/.test(text) || /set upstream/.test(text) || /set-upstream/.test(text)) {
+    return {
+      title: "Push your branch first",
+      message:
+        "This branch has not been pushed to origin yet. Use Ship to commit and push, then try again.",
+    };
+  }
+
+  if (/git push failed/.test(text)) {
+    return {
+      title: "Push failed",
+      message: stderr.trim() || message,
+    };
+  }
+
+  if (/authentication failed/.test(text) || /permission denied/.test(text) || /401/.test(text)) {
+    return {
+      title: "GitHub authentication required",
+      message: stderr.trim() || message,
+    };
+  }
+
+  return null;
+}

--- a/src/lib/shell-query-cache.ts
+++ b/src/lib/shell-query-cache.ts
@@ -1,0 +1,138 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import type { Group } from "~/db/schema";
+import type { AppSettings } from "~/lib/api";
+import type { LicenseState } from "~/shared/license";
+import type { ProjectWithCounts } from "~/shared/projects";
+
+export const SHELL_QUERY_CACHE_VERSION = 1;
+
+export const SHELL_QUERY_CACHE_KEYS = {
+  projects: "mc:shell-cache:projects:v1",
+  groups: "mc:shell-cache:groups:v1",
+  settings: "mc:shell-cache:settings:v1",
+  license: "mc:shell-cache:license:v1",
+} as const;
+
+type CacheEnvelope<T> = {
+  version: typeof SHELL_QUERY_CACHE_VERSION;
+  savedAt: number;
+  data: T;
+};
+
+const installedClients = new WeakSet<QueryClient>();
+
+function readCache<T>(key: string): T | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Partial<CacheEnvelope<T>> | null;
+    if (!parsed || parsed.version !== SHELL_QUERY_CACHE_VERSION) return undefined;
+    return parsed.data as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeCache<T>(key: string, data: T): void {
+  if (typeof window === "undefined") return;
+  try {
+    const payload: CacheEnvelope<T> = {
+      version: SHELL_QUERY_CACHE_VERSION,
+      savedAt: Date.now(),
+      data,
+    };
+    window.localStorage.setItem(key, JSON.stringify(payload));
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isExactQueryKey(queryKey: QueryKey, key: string): boolean {
+  return queryKey.length === 1 && queryKey[0] === key;
+}
+
+function hasPinnedProjects(projects: ProjectWithCounts[]): boolean {
+  return projects.some((project) => project.pinned);
+}
+
+function syncPinnedProjectDocumentState(projects: ProjectWithCounts[]): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.toggleAttribute(
+    "data-has-pinned-projects",
+    hasPinnedProjects(projects),
+  );
+}
+
+export function readCachedProjects(): ProjectWithCounts[] | undefined {
+  const data = readCache<unknown>(SHELL_QUERY_CACHE_KEYS.projects);
+  return Array.isArray(data) ? (data as ProjectWithCounts[]) : undefined;
+}
+
+export function readCachedGroups(): Group[] | undefined {
+  const data = readCache<unknown>(SHELL_QUERY_CACHE_KEYS.groups);
+  return Array.isArray(data) ? (data as Group[]) : undefined;
+}
+
+export function readCachedSettings(): AppSettings | undefined {
+  const data = readCache<unknown>(SHELL_QUERY_CACHE_KEYS.settings);
+  return isObject(data) ? (data as AppSettings) : undefined;
+}
+
+export function readCachedLicense(): LicenseState | undefined {
+  const data = readCache<unknown>(SHELL_QUERY_CACHE_KEYS.license);
+  return isObject(data) ? (data as LicenseState) : undefined;
+}
+
+export function writeCachedProjects(projects: ProjectWithCounts[]): void {
+  writeCache(SHELL_QUERY_CACHE_KEYS.projects, projects);
+  syncPinnedProjectDocumentState(projects);
+}
+
+export function writeCachedGroups(groups: Group[]): void {
+  writeCache(SHELL_QUERY_CACHE_KEYS.groups, groups);
+}
+
+export function writeCachedSettings(settings: AppSettings): void {
+  writeCache(SHELL_QUERY_CACHE_KEYS.settings, settings);
+}
+
+export function writeCachedLicense(license: LicenseState): void {
+  writeCache(SHELL_QUERY_CACHE_KEYS.license, license);
+}
+
+export function installShellQueryCache(queryClient: QueryClient): void {
+  if (typeof window === "undefined" || installedClients.has(queryClient)) return;
+  installedClients.add(queryClient);
+
+  queryClient.getQueryCache().subscribe((event) => {
+    const { query } = event;
+    if (query.state.status !== "success") return;
+
+    const { queryKey } = query;
+    const { data } = query.state;
+
+    if (isExactQueryKey(queryKey, "projects") && Array.isArray(data)) {
+      writeCachedProjects(data as ProjectWithCounts[]);
+      return;
+    }
+
+    if (isExactQueryKey(queryKey, "groups") && Array.isArray(data)) {
+      writeCachedGroups(data as Group[]);
+      return;
+    }
+
+    if (isExactQueryKey(queryKey, "settings") && isObject(data)) {
+      writeCachedSettings(data as AppSettings);
+      return;
+    }
+
+    if (isExactQueryKey(queryKey, "license") && isObject(data)) {
+      writeCachedLicense(data as LicenseState);
+    }
+  });
+}

--- a/src/lib/terminal-links.ts
+++ b/src/lib/terminal-links.ts
@@ -1,0 +1,66 @@
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import type { ILinkHandler, Terminal } from "@xterm/xterm";
+import { getElectron } from "./electron";
+
+export function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac/.test(navigator.platform) || /Mac/.test(navigator.userAgent);
+}
+
+/** True when the platform link modifier (Cmd on macOS, Ctrl elsewhere) is held. */
+export function terminalLinkRequiresModifier(event: Pick<MouseEvent, "metaKey" | "ctrlKey">): boolean {
+  return isMacPlatform() ? event.metaKey : event.ctrlKey;
+}
+
+export function openTerminalLink(uri: string): void {
+  const electron = getElectron();
+  if (electron?.openExternal) {
+    void electron.openExternal(uri);
+    return;
+  }
+
+  if (typeof document === "undefined") return;
+
+  // Avoid window.open() — Electron's default popup path blocks the blank-window
+  // trick xterm's built-in handler uses ("Opening link blocked as opener...").
+  const anchor = document.createElement("a");
+  anchor.href = uri;
+  anchor.target = "_blank";
+  anchor.rel = "noopener noreferrer";
+  anchor.click();
+}
+
+function createLinkActivateHandler(
+  openLink: (uri: string) => void = openTerminalLink,
+): (event: MouseEvent, uri: string) => void {
+  return (event, uri) => {
+    if (!terminalLinkRequiresModifier(event)) return;
+    openLink(uri);
+  };
+}
+
+export function createTerminalLinkHandler(
+  openLink: (uri: string) => void = openTerminalLink,
+): ILinkHandler {
+  const activate = createLinkActivateHandler(openLink);
+  return {
+    activate(event, text) {
+      activate(event, text);
+    },
+  };
+}
+
+/** Wire URL pattern links (WebLinksAddon) and OSC 8 hyperlinks with Cmd/Ctrl+Click. */
+export function attachTerminalLinks(
+  term: Terminal,
+  openLink: (uri: string) => void = openTerminalLink,
+): () => void {
+  const activate = createLinkActivateHandler(openLink);
+  term.options.linkHandler = createTerminalLinkHandler(openLink);
+  const webLinks = new WebLinksAddon(activate);
+  term.loadAddon(webLinks);
+  return () => {
+    webLinks.dispose();
+    term.options.linkHandler = null;
+  };
+}

--- a/src/lib/terminal-options.ts
+++ b/src/lib/terminal-options.ts
@@ -146,13 +146,15 @@ export function watchTerminalColorScheme(
 export function createTerminalOptions({
   cursorColor = getCurrentAccentColor(),
   colorScheme = "dark",
+  fontSize = TERMINAL_FONT_SIZE,
 }: {
   cursorColor?: string;
   colorScheme?: TerminalColorScheme;
+  fontSize?: number;
 } = {}): ITerminalOptions {
   return {
     fontFamily: TERMINAL_FONT_FAMILY,
-    fontSize: TERMINAL_FONT_SIZE,
+    fontSize,
     // Keep xterm's default line height so multi-row ANSI art (OpenCode's
     // startup wordmark, box drawing, background fills) renders flush.
     lineHeight: 1,
@@ -188,4 +190,19 @@ export function fitTerminalSurface(
   if (term.rows > 0) {
     term.refresh(0, term.rows - 1);
   }
+}
+
+export function applyTerminalFontSize(
+  term: {
+    options: { fontSize?: number };
+    cols: number;
+    rows: number;
+    refresh: (start: number, end: number) => void;
+  },
+  fit: { fit: () => void },
+  fontSize: number,
+): void {
+  if (term.options.fontSize === fontSize) return;
+  term.options.fontSize = fontSize;
+  fitTerminalSurface(term, fit);
 }

--- a/src/lib/terminal-pane-helpers.ts
+++ b/src/lib/terminal-pane-helpers.ts
@@ -13,6 +13,38 @@ type TerminalLike = {
   attachCustomKeyEventHandler(handler: (e: KeyboardEvent) => boolean): void;
 };
 
+/** True when keyboard focus is inside an xterm surface in the bottom user terminal panel. */
+export function isUserTerminalXtermFocused(): boolean {
+  if (typeof document === "undefined") return false;
+  const el = document.activeElement;
+  if (!(el instanceof HTMLElement)) return false;
+  if (!el.closest("[data-user-terminal-panel]")) return false;
+  return !!el.closest(".xterm");
+}
+
+/** True when keyboard focus is inside an xterm surface in the session terminal panel. */
+export function isSessionTerminalXtermFocused(): boolean {
+  if (typeof document === "undefined") return false;
+  const el = document.activeElement;
+  if (!(el instanceof HTMLElement)) return false;
+  if (!el.closest("[data-session-terminal-panel]")) return false;
+  return !!el.closest(".xterm");
+}
+
+export function isTerminalXtermFocused(): boolean {
+  return isUserTerminalXtermFocused() || isSessionTerminalXtermFocused();
+}
+
+/** Cmd/Ctrl + =/+ zoom in, Cmd/Ctrl + - zoom out; null when not a zoom chord. */
+export function terminalZoomStepFromKeyboard(e: KeyboardEvent): 1 | -1 | null {
+  if (e.type !== "keydown") return null;
+  if (!(e.metaKey || e.ctrlKey)) return null;
+  if (e.altKey) return null;
+  if (e.key === "+" || e.key === "=" || e.code === "Equal") return 1;
+  if (e.key === "-" || e.code === "Minus") return -1;
+  return null;
+}
+
 /**
  * Wire native drag-and-drop on `host` so dropped files or pinned-project
  * paths paste into the active PTY (matches iTerm / Terminal.app behavior;

--- a/src/lib/terminal-replay.ts
+++ b/src/lib/terminal-replay.ts
@@ -1,0 +1,43 @@
+export type SequencedPtyData = {
+  seq: number;
+  data: string;
+};
+
+export type PtyReplaySnapshot = {
+  data: string;
+  nextSeq: number;
+};
+
+export function sequencedPtyData(seq: number | undefined, data: string): SequencedPtyData {
+  return {
+    seq: typeof seq === "number" && Number.isFinite(seq) ? seq : Number.MAX_SAFE_INTEGER,
+    data,
+  };
+}
+
+export function appendBoundedSequencedData(
+  chunks: SequencedPtyData[],
+  chunk: SequencedPtyData,
+  maxChars: number,
+): void {
+  chunks.push(chunk);
+  let chars = chunks.reduce((total, item) => total + item.data.length, 0);
+  while (chars > maxChars && chunks.length > 1) {
+    const dropped = chunks.shift();
+    chars -= dropped?.data.length ?? 0;
+  }
+}
+
+export function dataAfterReplay(
+  chunks: SequencedPtyData[],
+  replay: PtyReplaySnapshot,
+): string[] {
+  return chunks.filter((chunk) => chunk.seq >= replay.nextSeq).map((chunk) => chunk.data);
+}
+
+export function replayDataOrFallback(
+  replay: PtyReplaySnapshot,
+  fallbackChunks: SequencedPtyData[],
+): string {
+  return replay.data || fallbackChunks.map((chunk) => chunk.data).join("");
+}

--- a/src/lib/terminal-resize.ts
+++ b/src/lib/terminal-resize.ts
@@ -1,0 +1,14 @@
+import { normalizePtySize } from "~/shared/pty-size";
+
+type TerminalSizeSource = {
+  cols: number;
+  rows: number;
+};
+
+export function resizePtyToTerminal<T>(
+  term: TerminalSizeSource,
+  resize: (cols: number, rows: number) => T,
+): T {
+  const ptySize = normalizePtySize({ cols: term.cols, rows: term.rows });
+  return resize(ptySize.cols, ptySize.rows);
+}

--- a/src/lib/terminal-zoom-storage.ts
+++ b/src/lib/terminal-zoom-storage.ts
@@ -1,0 +1,41 @@
+import {
+  clampTerminalZoomLevel,
+  DEFAULT_TERMINAL_ZOOM_LEVEL,
+  type TerminalZoomLevel,
+} from "~/shared/terminal-zoom";
+
+const INSTANCE_ZOOM_PREFIX = "mc:terminalZoom:";
+
+function instanceZoomKey(instanceId: string): string {
+  return `${INSTANCE_ZOOM_PREFIX}${instanceId}`;
+}
+
+export function readTerminalInstanceZoom(instanceId: string): TerminalZoomLevel | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(instanceZoomKey(instanceId));
+    if (raw === null) return null;
+    return clampTerminalZoomLevel(Number(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function writeTerminalInstanceZoom(
+  instanceId: string,
+  level: TerminalZoomLevel,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(instanceZoomKey(instanceId), String(level));
+  } catch {
+    // ignore quota / privacy-mode errors
+  }
+}
+
+export function resolveTerminalZoomLevel(
+  instanceId: string,
+  globalLevel: TerminalZoomLevel = DEFAULT_TERMINAL_ZOOM_LEVEL,
+): TerminalZoomLevel {
+  return readTerminalInstanceZoom(instanceId) ?? globalLevel;
+}

--- a/src/lib/use-resizable-panel.ts
+++ b/src/lib/use-resizable-panel.ts
@@ -41,8 +41,16 @@ export function useResizablePanel(opts: {
     return Number.isFinite(n) && n >= minSize ? n : defaultSize;
   });
 
+  const sizeRef = useRef(size);
+  sizeRef.current = size;
+
+  const isDraggingRef = useRef(false);
+  const onSizeChangeRef = useRef(onSizeChange);
+  onSizeChangeRef.current = onSizeChange;
+
   useEffect(() => {
     if (storedSize === undefined || storedSize === null) return;
+    if (isDraggingRef.current) return;
     setSize((current) => {
       const next = clampSize(storedSize);
       return current === next ? current : next;
@@ -55,18 +63,27 @@ export function useResizablePanel(opts: {
     } catch {
       /* localStorage unavailable */
     }
-    onSizeChange?.(size);
-  }, [onSizeChange, storageKey, size]);
+  }, [storageKey, size]);
 
   const dragRef = useRef<{ start: number; startSize: number } | null>(null);
+
+  const finishDrag = useCallback(() => {
+    if (!isDraggingRef.current) return;
+    isDraggingRef.current = false;
+    dragRef.current = null;
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+    onSizeChangeRef.current?.(sizeRef.current);
+  }, []);
 
   const onMouseDown = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
       const startCoord = axis === "x" ? e.clientX : e.clientY;
-      dragRef.current = { start: startCoord, startSize: size };
+      isDraggingRef.current = true;
+      dragRef.current = { start: startCoord, startSize: sizeRef.current };
       const onMove = (ev: MouseEvent) => {
-        if (!dragRef.current) return;
+        if (!dragRef.current || !isDraggingRef.current) return;
         const cur = axis === "x" ? ev.clientX : ev.clientY;
         const delta =
           resizeEdge === "start"
@@ -76,18 +93,16 @@ export function useResizablePanel(opts: {
         setSize(next);
       };
       const onUp = () => {
-        dragRef.current = null;
         window.removeEventListener("mousemove", onMove);
         window.removeEventListener("mouseup", onUp);
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
+        finishDrag();
       };
       window.addEventListener("mousemove", onMove);
       window.addEventListener("mouseup", onUp);
       document.body.style.cursor = axis === "x" ? "col-resize" : "row-resize";
       document.body.style.userSelect = "none";
     },
-    [axis, size, resizeEdge, clampSize],
+    [axis, resizeEdge, clampSize, finishDrag],
   );
 
   return { size, onMouseDown };

--- a/src/lib/use-terminal-zoom.ts
+++ b/src/lib/use-terminal-zoom.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useMemo, useState, type RefObject } from "react";
+import {
+  TERMINAL_ZOOM_IN_EVENT,
+  TERMINAL_ZOOM_OUT_EVENT,
+} from "~/lib/design-meta";
+import {
+  DEFAULT_TERMINAL_ZOOM_LEVEL,
+  stepTerminalZoomLevel,
+  terminalFontSizeForLevel,
+  type TerminalZoomLevel,
+} from "~/shared/terminal-zoom";
+import {
+  readTerminalInstanceZoom,
+  writeTerminalInstanceZoom,
+} from "~/lib/terminal-zoom-storage";
+import { useSettings } from "~/queries";
+
+export function useTerminalZoom(instanceId: string) {
+  const { data: settings } = useSettings();
+  const globalLevel = settings?.terminalZoomLevel ?? DEFAULT_TERMINAL_ZOOM_LEVEL;
+  const [override, setOverride] = useState<TerminalZoomLevel | null>(() =>
+    readTerminalInstanceZoom(instanceId),
+  );
+
+  const level = override ?? globalLevel;
+  const fontSize = useMemo(() => terminalFontSizeForLevel(level), [level]);
+
+  const setLevel = useCallback(
+    (next: TerminalZoomLevel) => {
+      writeTerminalInstanceZoom(instanceId, next);
+      setOverride(next);
+    },
+    [instanceId],
+  );
+
+  const zoomIn = useCallback(() => {
+    const next = stepTerminalZoomLevel(level, 1);
+    if (next !== null) setLevel(next);
+  }, [level, setLevel]);
+
+  const zoomOut = useCallback(() => {
+    const next = stepTerminalZoomLevel(level, -1);
+    if (next !== null) setLevel(next);
+  }, [level, setLevel]);
+
+  return {
+    level,
+    fontSize,
+    zoomIn,
+    zoomOut,
+    canZoomIn: stepTerminalZoomLevel(level, 1) !== null,
+    canZoomOut: stepTerminalZoomLevel(level, -1) !== null,
+  };
+}
+
+/** Listen for global Cmd+/Cmd- zoom events and apply only when this pane owns focus. */
+export function useTerminalPaneZoomShortcuts(
+  paneRef: RefObject<HTMLElement | null>,
+  zoomIn: () => void,
+  zoomOut: () => void,
+) {
+  useEffect(() => {
+    const onZoomIn = () => {
+      if (!paneRef.current?.contains(document.activeElement)) return;
+      zoomIn();
+    };
+    const onZoomOut = () => {
+      if (!paneRef.current?.contains(document.activeElement)) return;
+      zoomOut();
+    };
+    window.addEventListener(TERMINAL_ZOOM_IN_EVENT, onZoomIn);
+    window.addEventListener(TERMINAL_ZOOM_OUT_EVENT, onZoomOut);
+    return () => {
+      window.removeEventListener(TERMINAL_ZOOM_IN_EVENT, onZoomIn);
+      window.removeEventListener(TERMINAL_ZOOM_OUT_EVENT, onZoomOut);
+    };
+  }, [paneRef, zoomIn, zoomOut]);
+}

--- a/src/queries/git.ts
+++ b/src/queries/git.ts
@@ -103,6 +103,13 @@ export function useGitPush(projectId: string, worktreeId?: string | null) {
   });
 }
 
+export function useGitCreatePullRequest(projectId: string, worktreeId?: string | null) {
+  return useMutation({
+    mutationKey: [...gitKeys.all(projectId, worktreeId), "create-pr"] as const,
+    mutationFn: () => api.gitCreatePullRequest(projectId, worktreeId),
+  });
+}
+
 export function useDeleteProjectFile(projectId: string, worktreeId?: string | null) {
   const invalidate = useInvalidateGit(projectId, worktreeId);
   return useMutation({

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -2,6 +2,12 @@ import { queryOptions, useQuery } from "@tanstack/react-query";
 import { api, setApiToken } from "~/lib/api";
 import { getElectron } from "~/lib/electron";
 import { isWebDaytonaRuntime } from "~/lib/runtime";
+import {
+  readCachedGroups,
+  readCachedLicense,
+  readCachedProjects,
+  readCachedSettings,
+} from "~/lib/shell-query-cache";
 import type { LicenseState } from "~/shared/license";
 import { MAIN_WORKTREE_ID } from "~/shared/worktrees";
 
@@ -37,6 +43,7 @@ export const projectsQueryOptions = () =>
   queryOptions({
     queryKey: queryKeys.projects,
     queryFn: async () => (await api.listProjects()).projects,
+    placeholderData: readCachedProjects,
   });
 
 export const projectQueryOptions = (id: string) =>
@@ -49,6 +56,7 @@ export const groupsQueryOptions = () =>
   queryOptions({
     queryKey: queryKeys.groups,
     queryFn: async () => (await api.listGroups()).groups,
+    placeholderData: readCachedGroups,
   });
 
 export const tasksQueryOptions = (projectId: string, worktreeId?: string | null) =>
@@ -67,6 +75,7 @@ export const settingsQueryOptions = () =>
   queryOptions({
     queryKey: queryKeys.settings,
     queryFn: async () => api.getSettings(),
+    placeholderData: readCachedSettings,
   });
 
 // The api bearer token is fetched over Electron IPC, never HTTP — see
@@ -98,6 +107,7 @@ export const licenseQueryOptions = () =>
       }
       return (await api.getLicense()).license;
     },
+    placeholderData: readCachedLicense,
   });
 
 export const entitlementsQueryOptions = () =>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -5,6 +5,7 @@ import {
 import { routerWithQueryClient } from "@tanstack/react-router-with-query";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { CSSProperties } from "react";
+import { installShellQueryCache } from "~/lib/shell-query-cache";
 import { routeTree } from "./routeTree.gen";
 
 function AppErrorFallback({ reset }: ErrorComponentProps) {
@@ -89,6 +90,7 @@ export function getRouter() {
       },
     },
   });
+  installShellQueryCache(queryClient);
   const router = createTanStackRouter({
     routeTree,
     scrollRestoration: true,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -36,7 +36,7 @@ import {
   applyAccentColor,
   DEFAULT_ACCENT_COLOR,
 } from "~/lib/accent-colors";
-import { SettingsPanel, type SettingsPanelId } from "~/components/views/SettingsPanel";
+import { type SettingsPanelId } from "~/components/views/SettingsPanel";
 import { OPEN_SETTINGS_EVENT } from "~/lib/design-meta";
 
 /** Source of truth for which panel ids the OPEN_SETTINGS_EVENT handler will
@@ -45,6 +45,7 @@ import { OPEN_SETTINGS_EVENT } from "~/lib/design-meta";
 const SETTINGS_PANEL_IDS: readonly SettingsPanelId[] = [
   "general",
   "defaults",
+  "terminal",
   "theme",
   "license",
   "keybindings",
@@ -66,7 +67,13 @@ import {
   type AppNotification,
 } from "~/lib/session-notification-store";
 import { DiagramDialogHost } from "~/lib/use-diagram-events";
+import { isUserTerminalXtermFocused, isTerminalXtermFocused, terminalZoomStepFromKeyboard } from "~/lib/terminal-pane-helpers";
 import { useWarmCliAvailability } from "~/lib/cli-availability";
+import {
+  CLEAR_USER_TERMINAL_EVENT,
+  TERMINAL_ZOOM_IN_EVENT,
+  TERMINAL_ZOOM_OUT_EVENT,
+} from "~/lib/design-meta";
 import {
   LAUNCH_INTRO_CACHE_KEY,
   hasCachedLaunchIntroPreference,
@@ -197,12 +204,12 @@ function LaunchIntroOverlayController() {
 
 function Shell() {
   const router = useRouter();
-  const [activePanel, setActivePanel] = useState<"settings" | "usage" | null>(null);
-  const [settingsInitialPanel, setSettingsInitialPanel] =
-    useState<SettingsPanelId>("general");
+  const [activePanel, setActivePanel] = useState<"usage" | null>(null);
   const openSettings = (initial: SettingsPanelId = "general") => {
-    setSettingsInitialPanel(initial);
-    setActivePanel("settings");
+    void router.navigate({
+      to: "/settings",
+      search: { panel: initial },
+    });
   };
 
   // Leaf components (e.g. ShipFailedDialog) dispatch OPEN_SETTINGS_EVENT to
@@ -217,7 +224,7 @@ function Shell() {
     };
     window.addEventListener(OPEN_SETTINGS_EVENT, handler);
     return () => window.removeEventListener(OPEN_SETTINGS_EVENT, handler);
-  }, []);
+  }, [router]);
   useTheme();
   const { data: settings } = useSettings();
   const { data: projects } = useProjects();
@@ -313,7 +320,7 @@ function Shell() {
     !!projectId && terminalExpanded && !!activeFor(projectId);
   const crumbs: Crumb[] = projectMatch
     ? [{ label: "Project", node: <ProjectPicker projectId={projectMatch[1]} /> }]
-    : activePanel === "settings"
+    : path === "/settings"
       ? [{ label: "Settings" }]
       : activePanel === "usage"
         ? [{ label: "Usage" }]
@@ -396,11 +403,30 @@ function Shell() {
   useHotkey(
     "terminal.expandToggle",
     () => {
+      if (userTerminalPanelOpen && isUserTerminalXtermFocused()) {
+        window.dispatchEvent(new Event(CLEAR_USER_TERMINAL_EVENT));
+        return;
+      }
       if (projectId && activeFor(projectId)) toggleTerminalExpanded();
     },
     { capture: true },
   );
   useHotkey("nav.toggle", goHome);
+  // Cmd/Ctrl + =/- zoom the focused terminal; otherwise leave browser zoom alone.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const direction = terminalZoomStepFromKeyboard(e);
+      if (direction === null) return;
+      if (!isTerminalXtermFocused()) return;
+      e.preventDefault();
+      e.stopPropagation();
+      window.dispatchEvent(
+        new Event(direction === 1 ? TERMINAL_ZOOM_IN_EVENT : TERMINAL_ZOOM_OUT_EVENT),
+      );
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, []);
   // Cmd/Ctrl + [ / ] / T are non-rebindable terminal-focused shortcuts.
   // Capture phase: a focused xterm textarea swallows these on bubble.
   useEffect(() => {
@@ -488,11 +514,15 @@ function Shell() {
               <Btn
                 variant="ghost"
                 icon="settings"
-                onClick={() =>
-                  setActivePanel(activePanel === "settings" ? null : "settings")
-                }
-                aria-label={activePanel === "settings" ? "Close settings" : "Open settings"}
-                title={activePanel === "settings" ? "Close settings" : "Open settings"}
+                onClick={() => {
+                  if (path === "/settings") {
+                    goHome();
+                    return;
+                  }
+                  void router.navigate({ to: "/settings" });
+                }}
+                aria-label={path === "/settings" ? "Close settings" : "Open settings"}
+                title={path === "/settings" ? "Close settings" : "Open settings"}
               />
             </>
           }
@@ -534,9 +564,6 @@ function Shell() {
           </div>
           <UserTerminalPanel />
         </div>
-        {activePanel === "settings" && (
-          <SettingsPanel onBack={closePanel} initialPanel={settingsInitialPanel} />
-        )}
         {activePanel === "usage" && <UsagePanel onBack={closePanel} />}
         <Toaster
           position="bottom-right"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute, useRouter } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { Btn } from "~/components/ui/Btn";
 import { CardFrame } from "~/components/ui/CardFrame";
+import { ConfirmDialog } from "~/components/ui/ConfirmDialog";
 import { Icon } from "~/components/ui/Icon";
 import { HotkeyTooltip } from "~/components/ui/Tooltip";
 import { useHotkey } from "~/lib/use-hotkey";
@@ -11,11 +13,13 @@ import { Section } from "~/components/ui/Section";
 import { EmptyState } from "~/components/ui/EmptyState";
 import { CursorGlow } from "~/components/ui/CursorGlow";
 import { ProjectCard } from "~/components/views/ProjectCard";
+import { ProjectDialog } from "~/components/views/ProjectDialog";
 import { ProjectsDashboardViewToggle } from "~/components/views/ProjectsDashboardViewToggle";
 import { ProjectsTable } from "~/components/views/ProjectsTable";
 import { GroupsDialog } from "~/components/views/GroupsDialog";
 import { LaunchKitDialog } from "~/components/views/LaunchKitDialog";
 import { useAddProject } from "~/lib/add-project-store";
+import { useTerminals } from "~/lib/terminal-store";
 import { api, type AppSettings } from "~/lib/api";
 import {
   readCachedProjectsDashboardView,
@@ -40,6 +44,7 @@ import {
   DEFAULT_PROJECTS_DASHBOARD_VIEW,
   type ProjectsDashboardView,
 } from "~/shared/ui-preferences";
+import type { Group } from "~/db/schema";
 
 export const Route = createFileRoute("/")({
   component: MissionControlPage,
@@ -66,6 +71,9 @@ function MissionControlPage() {
   const [search, setSearch] = useState("");
   const [showGroups, setShowGroups] = useState(false);
   const [showLaunchKit, setShowLaunchKit] = useState(false);
+  const [editingProject, setEditingProject] = useState<ProjectWithCounts | null>(null);
+  const [removingProject, setRemovingProject] = useState<ProjectWithCounts | null>(null);
+  const [removingProjectId, setRemovingProjectId] = useState<string | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
   const { data: settings } = useSettings();
   const settingsLoaded = settings !== undefined;
@@ -73,6 +81,7 @@ function MissionControlPage() {
   const [dashboardView, setDashboardView] = useState<ProjectsDashboardView>(() =>
     readCachedProjectsDashboardView() ?? DEFAULT_PROJECTS_DASHBOARD_VIEW,
   );
+  const terminals = useTerminals();
   const { setProject: setActiveUserTerminalProject } = useUserTerminals();
   const { open: openAddProject } = useAddProject();
 
@@ -123,9 +132,24 @@ function MissionControlPage() {
     () => queryClient.invalidateQueries({ queryKey: queryKeys.projects }),
     [queryClient]
   );
+  const invalidateProject = useCallback(
+    (id: string) => queryClient.invalidateQueries({ queryKey: queryKeys.project(id) }),
+    [queryClient]
+  );
   const invalidateGroups = useCallback(
     () => queryClient.invalidateQueries({ queryKey: queryKeys.groups }),
     [queryClient]
+  );
+  const createGroupForSelection = useCallback(
+    async (name: string) => {
+      const { group } = await api.createGroup({ name });
+      queryClient.setQueryData<Group[]>(queryKeys.groups, (current) =>
+        current ? [...current, group] : [group],
+      );
+      await invalidateGroups();
+      return group;
+    },
+    [invalidateGroups, queryClient],
   );
 
   useServerEvents(
@@ -172,11 +196,36 @@ function MissionControlPage() {
   const open = (id: string) => router.navigate({ to: "/projects/$id", params: { id } });
   const togglePin = async (id: string) => {
     await api.togglePin(id);
-    await invalidateProjects();
+    await Promise.all([invalidateProjects(), invalidateProject(id)]);
+  };
+  const removeProject = async () => {
+    if (!removingProject || removingProjectId) return;
+    const projectId = removingProject.id;
+    setRemovingProjectId(projectId);
+    try {
+      await terminals.closeForProject(projectId);
+      await api.deleteProject(projectId);
+      setRemovingProject(null);
+      await Promise.all([invalidateProjects(), invalidateProject(projectId)]);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Could not remove project");
+    } finally {
+      setRemovingProjectId(null);
+    }
   };
   const canUseLaunchKit =
     (!!license && isAcademyTier(license)) || !!launchKitAccess.data?.hasAccess;
   const hostedRuntime = entitlements?.hosted.enabled ? entitlements.remoteRuntime : null;
+  const renderProjectCard = (project: ProjectWithCounts) => (
+    <ProjectCard
+      key={project.id}
+      project={project}
+      onOpen={() => open(project.id)}
+      onEdit={() => setEditingProject(project)}
+      onRemove={() => setRemovingProject(project)}
+      onTogglePin={togglePin}
+    />
+  );
 
   return (
     <>
@@ -349,14 +398,7 @@ function MissionControlPage() {
               labelSize={13}
             >
               <div style={{ display: "grid", gridTemplateColumns: gridCols, gap: 14 }}>
-                {pinned.map((p) => (
-                  <ProjectCard
-                    key={p.id}
-                    project={p}
-                    onOpen={() => open(p.id)}
-                    onTogglePin={togglePin}
-                  />
-                ))}
+                {pinned.map(renderProjectCard)}
               </div>
             </Section>
           )}
@@ -372,14 +414,7 @@ function MissionControlPage() {
               labelSize={13}
             >
               <div style={{ display: "grid", gridTemplateColumns: gridCols, gap: 14 }}>
-                {gp.map((p) => (
-                  <ProjectCard
-                    key={p.id}
-                    project={p}
-                    onOpen={() => open(p.id)}
-                    onTogglePin={togglePin}
-                  />
-                ))}
+                {gp.map(renderProjectCard)}
               </div>
             </Section>
           ))}
@@ -393,14 +428,7 @@ function MissionControlPage() {
               labelSize={13}
             >
               <div style={{ display: "grid", gridTemplateColumns: gridCols, gap: 14 }}>
-                {ungrouped.map((p) => (
-                  <ProjectCard
-                    key={p.id}
-                    project={p}
-                    onOpen={() => open(p.id)}
-                    onTogglePin={togglePin}
-                  />
-                ))}
+                {ungrouped.map(renderProjectCard)}
               </div>
             </Section>
           )}
@@ -435,8 +463,7 @@ function MissionControlPage() {
         projects={projects}
         onClose={() => setShowGroups(false)}
         onAdd={async (name) => {
-          await api.createGroup({ name });
-          await invalidateGroups();
+          await createGroupForSelection(name);
         }}
         onRemove={async (id) => {
           await api.deleteGroup(id);
@@ -445,6 +472,10 @@ function MissionControlPage() {
         onRename={async (id, name) => {
           await api.updateGroup(id, { name });
           await invalidateGroups();
+        }}
+        onProjectGroupChange={async (projectId, groupId) => {
+          await api.updateProject(projectId, { groupId });
+          await Promise.all([invalidateProjects(), invalidateProject(projectId)]);
         }}
       />
       <LaunchKitDialog
@@ -456,6 +487,40 @@ function MissionControlPage() {
           void router.navigate({ to: "/projects/$id", params: { id: projectId } });
         }}
       />
+      {editingProject && (
+        <ProjectDialog
+          open
+          project={editingProject}
+          groups={groups}
+          onCreateGroup={createGroupForSelection}
+          onClose={() => setEditingProject(null)}
+          onSave={async (data) => {
+            const projectId = editingProject.id;
+            await api.updateProject(projectId, data);
+            setEditingProject(null);
+            await Promise.all([invalidateProjects(), invalidateProject(projectId)]);
+          }}
+        />
+      )}
+      <ConfirmDialog
+        open={removingProject !== null}
+        onClose={() => {
+          if (!removingProjectId) setRemovingProject(null);
+        }}
+        onConfirm={removeProject}
+        title="Remove project"
+        confirmLabel="Remove"
+        icon="trash"
+        loading={removingProjectId !== null}
+        width={460}
+      >
+        <div style={{ fontSize: 13, color: "var(--text)", marginBottom: 8 }}>
+          Remove &ldquo;{removingProject?.name}&rdquo; from MissionControl?
+        </div>
+        <div style={{ fontSize: 12, color: "var(--text-dim)" }}>
+          This only unlinks the project — the files at {removingProject?.path} are not touched.
+        </div>
+      </ConfirmDialog>
     </>
   );
 }

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -74,6 +74,11 @@ import { useWorktreesEnabled } from "~/lib/use-worktrees-enabled";
 import { useGitStatus } from "~/queries/git";
 import { GitDiffView } from "~/components/views/GitDiffView";
 import { CommitPushButton } from "~/components/views/CommitPushButton";
+import {
+  CreatePullRequestDialog,
+  CreatePullRequestMenuItem,
+  useCreatePullRequestAction,
+} from "~/components/views/CreatePullRequestButton";
 import { HeaderActions } from "~/components/ui/HeaderActionsSlot";
 import { InstallDiagramSkillMenuItem } from "~/components/views/InstallDiagramSkillMenuItem";
 import { InstallDiagramSkillModal } from "~/components/views/InstallDiagramSkillModal";
@@ -88,7 +93,7 @@ import {
   readPendingSessionOpen,
   type PendingSessionOpen,
 } from "~/lib/session-notification-store";
-import type { Task, TaskStatus } from "~/db/schema";
+import type { Group, Task, TaskStatus } from "~/db/schema";
 import type { ProjectPathStatus } from "~/shared/projects";
 import type { WorktreeInfo } from "~/shared/worktrees";
 import { MAIN_WORKTREE_ID, worktreeScopeKey } from "~/shared/worktrees";
@@ -346,6 +351,12 @@ function ProjectPage() {
   const { data: entitlements } = useEntitlements();
   const { data: gitStatus } = useGitStatus(id, selectedWorktreeId, {
     enabled: projectPathUsable,
+  });
+  const createPullRequest = useCreatePullRequestAction({
+    projectId: id,
+    worktreeId: selectedWorktreeId,
+    branch: gitStatus?.branch,
+    projectPathUsable,
   });
   const { open: showDiffView, toggle: toggleDiffView, close: closeDiffView } =
     useGitDiffViewOpen(id);
@@ -608,6 +619,21 @@ function ProjectPage() {
   const invalidateProjects = useCallback(
     () => queryClient.invalidateQueries({ queryKey: queryKeys.projects }),
     [queryClient]
+  );
+  const invalidateGroups = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: queryKeys.groups }),
+    [queryClient],
+  );
+  const createGroupForSelection = useCallback(
+    async (name: string) => {
+      const { group } = await api.createGroup({ name });
+      queryClient.setQueryData<Group[]>(queryKeys.groups, (current) =>
+        current ? [...current, group] : [group],
+      );
+      await invalidateGroups();
+      return group;
+    },
+    [invalidateGroups, queryClient],
   );
   const refresh = useCallback(async () => {
     await Promise.all([invalidateProject(), invalidateTasks(), invalidateProjects()]);
@@ -1357,6 +1383,16 @@ function ProjectPage() {
         }
         onStop={stopLaunch}
       />
+      <span
+        aria-hidden
+        style={{
+          width: 1,
+          height: 24,
+          background: "var(--border)",
+          margin: "0 2px 0 4px",
+          flexShrink: 0,
+        }}
+      />
       {worktreesEnabled && (
         <>
           <WorktreeToggleGroup
@@ -1366,6 +1402,7 @@ function ProjectPage() {
             projectId={project.id}
             onSelect={selectWorktree}
             onDeleteSelected={() => setConfirmDeleteWorktree(true)}
+            mainBranchLabel={gitStatus?.branch}
             maxWidth="min(420px, 34vw)"
           />
           <span
@@ -1568,17 +1605,20 @@ function ProjectPage() {
                   Reveal in Finder
                 </Btn>
                 {project.githubUrl && (
-                  <Btn
-                    variant="ghost"
-                    icon="github"
-                    onClick={() => {
-                      setOverflowOpen(false);
-                      window.open(project.githubUrl!, "_blank", "noreferrer");
-                    }}
-                    style={{ justifyContent: "flex-start" }}
-                  >
-                    Open GitHub
-                  </Btn>
+                  <>
+                    <MenuSeparator />
+                    <Btn
+                      variant="ghost"
+                      icon="github"
+                      onClick={() => {
+                        setOverflowOpen(false);
+                        window.open(project.githubUrl!, "_blank", "noreferrer");
+                      }}
+                      style={{ justifyContent: "flex-start" }}
+                    >
+                      Open GitHub
+                    </Btn>
+                  </>
                 )}
                 <HotkeyTooltip action="git.diff">
                   <Btn
@@ -1591,11 +1631,11 @@ function ProjectPage() {
                     disabled={projectPathBlocked}
                     style={{ justifyContent: "flex-start" }}
                     title={(() => {
-                      const b = gitStatus?.branch ?? project.branch ?? DEFAULT_BRANCH;
+                      const b = gitStatus?.branch ?? "…";
                       if (gitStatus && gitStatus.changedCount > 0) {
                         return `Branch ${b} · ${gitStatus.changedCount} changed file${gitStatus.changedCount === 1 ? "" : "s"}`;
                       }
-                      return `Branch ${b}`;
+                      return gitStatus ? `Branch ${b}` : "Checking branch…";
                     })()}
                   >
                     <span style={{ flex: 1, textAlign: "left" }}>
@@ -1609,6 +1649,13 @@ function ProjectPage() {
                     </span>
                   </Btn>
                 </HotkeyTooltip>
+                <CreatePullRequestMenuItem
+                  onSelect={() => {
+                    setOverflowOpen(false);
+                    void createPullRequest.onCreate();
+                  }}
+                  busy={createPullRequest.busy}
+                />
                 <MenuSeparator />
                 <Btn
                   variant="ghost"
@@ -1669,7 +1716,7 @@ function ProjectPage() {
             }}
           >
             <ProjectGitStatusButton
-              branch={gitStatus?.branch ?? project.branch ?? DEFAULT_BRANCH}
+              branch={gitStatus?.branch}
               changedCount={gitStatus?.changedCount}
               onClick={onToggleDiffView}
               disabled={projectPathBlocked}
@@ -2033,6 +2080,7 @@ function ProjectPage() {
         open={showEdit}
         project={project}
         groups={groups}
+        onCreateGroup={createGroupForSelection}
         onClose={() => setShowEdit(false)}
         onSave={async (data) => {
           await api.updateProject(project.id, data);
@@ -2052,6 +2100,11 @@ function ProjectPage() {
         projectRoot={selectedWorktreePath || project.path}
         relPath={openFileRel}
         onClose={() => setOpenFileRel(null)}
+      />
+
+      <CreatePullRequestDialog
+        state={createPullRequest.dialog}
+        onClose={createPullRequest.closeDialog}
       />
 
       <InstallDiagramSkillModal
@@ -2184,6 +2237,7 @@ function WorktreeToggleGroup({
   projectId,
   onSelect,
   onDeleteSelected,
+  mainBranchLabel,
   maxWidth = 420,
 }: {
   worktrees: WorktreeInfo[];
@@ -2192,6 +2246,8 @@ function WorktreeToggleGroup({
   projectId: string;
   onSelect: (id: string) => void;
   onDeleteSelected?: (worktree: WorktreeInfo) => void;
+  /** Live git branch for the main worktree — shown instead of the "main" id. */
+  mainBranchLabel?: string | null;
   maxWidth?: number | string;
 }) {
   const items = worktrees.length > 0 ? worktrees : [];
@@ -2214,6 +2270,9 @@ function WorktreeToggleGroup({
         const selected = worktree.id === selectedId;
         const running = runningKeys.has(worktreeScopeKey(projectId, worktree.isMain ? null : worktree.id));
         const canDelete = selected && !worktree.isMain && !!onDeleteSelected;
+        const label = worktree.isMain
+          ? mainBranchLabel?.trim() || "…"
+          : worktree.name;
         return (
           <div
             key={worktree.id}
@@ -2261,10 +2320,14 @@ function WorktreeToggleGroup({
                 const next = items[(currentIndex + direction + items.length) % items.length];
                 if (next) onSelect(next.id);
               }}
-              aria-label={`Switch to worktree ${worktree.name}`}
+              aria-label={`Switch to worktree ${worktree.isMain ? label : worktree.name}`}
               aria-checked={selected}
               tabIndex={selected ? 0 : -1}
-              title={worktree.path}
+              title={
+                worktree.isMain
+                  ? `${worktree.path}${mainBranchLabel ? ` · branch ${mainBranchLabel}` : ""}`
+                  : worktree.path
+              }
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -2279,7 +2342,7 @@ function WorktreeToggleGroup({
                 cursor: "pointer",
               }}
             >
-              {worktree.name}
+              {label}
             </button>
             {canDelete && (
               <button
@@ -2319,11 +2382,12 @@ function ProjectGitStatusButton({
   onClick,
   disabled = false,
 }: {
-  branch: string;
+  branch: string | undefined;
   changedCount: number | undefined;
   onClick: () => void;
   disabled?: boolean;
 }) {
+  const branchLabel = branch?.trim() || "…";
   const changedLabel =
     disabled
       ? "Unavailable"
@@ -2334,8 +2398,8 @@ function ProjectGitStatusButton({
     disabled
       ? "Review Changes unavailable until the project folder is valid"
       : changedCount === undefined
-      ? `Open Review Changes · branch ${branch}`
-      : `Toggle Review Changes · ${changedCount} changed file${changedCount === 1 ? "" : "s"} · branch ${branch}`;
+      ? `Open Review Changes · branch ${branchLabel}`
+      : `Toggle Review Changes · ${changedCount} changed file${changedCount === 1 ? "" : "s"} · branch ${branchLabel}`;
 
   return (
     <HotkeyTooltip action="git.diff" label={title}>
@@ -2346,8 +2410,24 @@ function ProjectGitStatusButton({
         disabled={disabled}
         aria-label={title}
         className="mc-btn-attached-right"
-        style={{ fontFamily: "var(--mono)", maxWidth: 320, minWidth: 0 }}
+        style={{ fontFamily: "var(--mono)", maxWidth: 360, minWidth: 0 }}
       >
+        <span
+          style={{
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            color: "var(--text)",
+            flexShrink: 1,
+          }}
+          title={branchLabel}
+        >
+          {branchLabel}
+        </span>
+        <span aria-hidden style={{ color: "var(--text-faint)", flexShrink: 0 }}>
+          ·
+        </span>
         <span
           style={{
             color: changedCount && changedCount > 0 ? "var(--accent)" : "var(--text-dim)",

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,0 +1,36 @@
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { z } from "zod";
+import { SettingsPanel, type SettingsPanelId } from "~/components/views/SettingsPanel";
+
+const settingsSearchSchema = z.object({
+  panel: z
+    .enum([
+      "general",
+      "defaults",
+      "terminal",
+      "theme",
+      "beta",
+      "license",
+      "keybindings",
+      "session-debug",
+      "terms",
+    ])
+    .optional(),
+});
+
+export const Route = createFileRoute("/settings")({
+  validateSearch: settingsSearchSchema,
+  component: SettingsRoutePage,
+});
+
+function SettingsRoutePage() {
+  const router = useRouter();
+  const { panel } = Route.useSearch();
+
+  return (
+    <SettingsPanel
+      onBack={() => router.navigate({ to: "/" })}
+      initialPanel={(panel ?? "terminal") as SettingsPanelId}
+    />
+  );
+}

--- a/src/server/__tests__/api-auth.test.ts
+++ b/src/server/__tests__/api-auth.test.ts
@@ -63,6 +63,7 @@ const PROTECTED_ROUTES: ReadonlyArray<{ method: string; pathname: string }> = [
   { method: "POST", pathname: "/api/projects/abc/git/stage" },
   { method: "POST", pathname: "/api/projects/abc/git/commit" },
   { method: "POST", pathname: "/api/projects/abc/git/push" },
+  { method: "POST", pathname: "/api/projects/abc/git/create-pr" },
   // User terminals
   { method: "GET", pathname: "/api/projects/abc/user-terminals" },
   { method: "POST", pathname: "/api/projects/abc/user-terminals" },

--- a/src/server/__tests__/settings-api.test.ts
+++ b/src/server/__tests__/settings-api.test.ts
@@ -59,7 +59,25 @@ describe("settings API", () => {
     expect(await jsonBody(response!)).toMatchObject({
       automaticUpdateDownloadsEnabled: false,
       automaticUpdateInstallOnQuitEnabled: false,
+      terminalZoomLevel: 0,
     });
+  });
+
+  it("persists the default terminal zoom level", async () => {
+    const update = await handleApiRequest(
+      authedRequest("http://localhost/api/settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ terminalZoomLevel: 2 }),
+      }),
+    );
+    const read = await handleApiRequest(
+      authedRequest("http://localhost/api/settings"),
+    );
+
+    expect(update?.status).toBe(200);
+    expect(await jsonBody(update!)).toMatchObject({ terminalZoomLevel: 2 });
+    expect(await jsonBody(read!)).toMatchObject({ terminalZoomLevel: 2 });
   });
 
   it("persists the mouse gradient preference", async () => {

--- a/src/server/api-router.ts
+++ b/src/server/api-router.ts
@@ -427,6 +427,7 @@ async function dispatch(
     if (action === "unstage" && method === "POST") return gitController.unstage(id, request);
     if (action === "commit" && method === "POST") return gitController.commit(id, request);
     if (action === "push" && method === "POST") return gitController.push(id, request);
+    if (action === "create-pr" && method === "POST") return gitController.createPr(id, request);
   }
   m = pathname.match(PROJECT_USER_TERMINALS_PATH);
   if (m) {

--- a/src/server/controllers/git.controller.ts
+++ b/src/server/controllers/git.controller.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
   commit as gitCommit,
+  createPullRequest as gitCreatePullRequest,
   getGitDiff,
   getGitStatus,
   gitErrorPayload,
@@ -114,6 +115,18 @@ export async function push(rawId: string, request: Request): Promise<Response> {
   if (!body.ok) return body.response;
   try {
     return json(await gitPush(parsed.data, body.data.worktreeId ?? null));
+  } catch (e) {
+    return handleDomainError(e) ?? asGitErrorResponse(e);
+  }
+}
+
+export async function createPr(rawId: string, request: Request): Promise<Response> {
+  const parsed = idParam.safeParse(rawId);
+  if (!parsed.success) return notFound();
+  const body = await parseJsonBody(request, z.object({ worktreeId: z.string().nullable().optional() }));
+  if (!body.ok) return body.response;
+  try {
+    return json(await gitCreatePullRequest(parsed.data, body.data.worktreeId ?? null));
   } catch (e) {
     return handleDomainError(e) ?? asGitErrorResponse(e);
   }

--- a/src/server/controllers/settings.controller.ts
+++ b/src/server/controllers/settings.controller.ts
@@ -26,6 +26,12 @@ import {
   normalizeProjectsDashboardView,
   normalizeSelectedWorktreeByProject,
 } from "~/shared/ui-preferences";
+import {
+  DEFAULT_TERMINAL_ZOOM_LEVEL,
+  TERMINAL_ZOOM_MAX,
+  TERMINAL_ZOOM_MIN,
+  normalizeTerminalZoomLevel,
+} from "~/shared/terminal-zoom";
 import { json, parseJsonBody } from "./_helpers";
 
 const COMMIT_CLI_SETTING_KEY = "commit_cli";
@@ -33,6 +39,7 @@ const GIT_DIFF_CHANGED_FILES_VIEW_KEY = "git_diff_changed_files_view";
 const GIT_DIFF_CHANGED_FILES_WIDTH_KEY = "git_diff_changed_files_width";
 const SELECTED_WORKTREE_BY_PROJECT_KEY = "selected_worktree_by_project";
 const PROJECTS_DASHBOARD_VIEW_KEY = "projects_dashboard_view";
+const TERMINAL_ZOOM_LEVEL_KEY = "terminal_zoom_level";
 
 // The api bearer token is intentionally NOT delivered over HTTP. It is only
 // readable through the Electron IPC channel `settings:getToken`, so a page
@@ -62,6 +69,7 @@ const updateSettingsBody = z
     projectsDashboardView: z.enum(PROJECTS_DASHBOARD_VIEWS).nullable(),
     selectedWorktreeByProject: z.record(z.string(), z.string()).nullable(),
     commitCli: z.union([z.enum(COMMIT_CLI_VALUES), z.null()]),
+    terminalZoomLevel: z.number().int().min(TERMINAL_ZOOM_MIN).max(TERMINAL_ZOOM_MAX),
   })
   .partial();
 
@@ -97,6 +105,10 @@ function getSelectedWorktreeByProjectSetting() {
   }
 }
 
+function getTerminalZoomLevelSetting() {
+  return normalizeTerminalZoomLevel(getSetting(TERMINAL_ZOOM_LEVEL_KEY)) ?? DEFAULT_TERMINAL_ZOOM_LEVEL;
+}
+
 function settingsPayload() {
   return {
     agentSystemBannerDisabled: getBooleanSetting("agent_system_banner_disabled"),
@@ -123,6 +135,7 @@ function settingsPayload() {
     projectsDashboardView: getProjectsDashboardViewSetting(),
     selectedWorktreeByProject: getSelectedWorktreeByProjectSetting(),
     commitCli: getCommitCliSetting(),
+    terminalZoomLevel: getTerminalZoomLevelSetting(),
   };
 }
 
@@ -210,6 +223,9 @@ export async function update(request: Request): Promise<Response> {
     } else {
       setSetting(COMMIT_CLI_SETTING_KEY, body.commitCli);
     }
+  }
+  if (body.terminalZoomLevel !== undefined) {
+    setSetting(TERMINAL_ZOOM_LEVEL_KEY, String(body.terminalZoomLevel));
   }
   return json(settingsPayload());
 }

--- a/src/server/services/git.ts
+++ b/src/server/services/git.ts
@@ -7,10 +7,15 @@ import {
   runCommitCli,
 } from "./commit-cli";
 import { COMMIT_CLI_LABEL, type CommitCli } from "~/shared/commit-cli";
+import { DEFAULT_BRANCH } from "~/shared/domain";
+import { buildGithubCompareUrl } from "~/shared/github-pr";
+import { detectGithubUrl } from "./projects";
 import { resolveProjectWorktreeCwd } from "./worktrees";
 
 const GIT_TIMEOUT_MS = 15_000;
 const PUSH_TIMEOUT_MS = 30_000;
+const GH_TIMEOUT_MS = 30_000;
+const PR_BASE_BRANCH = DEFAULT_BRANCH;
 /** Cap diff bodies so a giant lockfile diff can't lock the renderer. */
 const DIFF_MAX_BYTES = 2 * 1024 * 1024;
 const DIFF_MAX_LINES = 50_000;
@@ -126,6 +131,60 @@ function runGit(
       });
     });
   });
+}
+
+async function countCommitsBetween(
+  cwd: string,
+  fromRef: string,
+  toRef: string,
+): Promise<number | null> {
+  const r = await runGit(cwd, ["rev-list", "--count", `${fromRef}..${toRef}`]);
+  if (r.code !== 0) return null;
+  const n = parseInt(r.stdout.trim(), 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+async function resolveBaseRef(cwd: string, base: string): Promise<string | null> {
+  for (const ref of [base, `origin/${base}`]) {
+    const r = await runGit(cwd, ["rev-parse", "--verify", ref]);
+    if (r.code === 0 && r.stdout.trim()) return ref;
+  }
+  return null;
+}
+
+async function countCommitsAheadOfBase(cwd: string, base: string): Promise<number | null> {
+  const baseRef = await resolveBaseRef(cwd, base);
+  if (!baseRef) return null;
+  return countCommitsBetween(cwd, baseRef, "HEAD");
+}
+
+async function workingTreeDirty(cwd: string): Promise<boolean> {
+  const r = await runGit(cwd, ["status", "--porcelain"]);
+  return r.code === 0 && r.stdout.trim().length > 0;
+}
+
+async function remoteBranchExists(cwd: string, branch: string): Promise<boolean> {
+  const r = await runGit(cwd, ["ls-remote", "--heads", "origin", branch]);
+  return r.code === 0 && r.stdout.trim().length > 0;
+}
+
+function assertPullRequestHasCommits(opts: {
+  branch: string;
+  baseBranch: string;
+  aheadOfBase: number | null;
+  dirty: boolean;
+}): void {
+  const { branch, baseBranch, aheadOfBase, dirty } = opts;
+  if (aheadOfBase === null) return;
+  if (aheadOfBase > 0) return;
+  if (dirty) {
+    throw new GitError(
+      `Branch "${branch}" has no commits ahead of ${baseBranch} yet. Accept your changes in Review Changes, then use Ship to commit and push before opening a pull request.`,
+    );
+  }
+  throw new GitError(
+    `Branch "${branch}" has no commits ahead of ${baseBranch}. Commit your work with Ship before opening a pull request.`,
+  );
 }
 
 async function gitOk(cwd: string, args: string[], timeoutMs?: number): Promise<string> {
@@ -407,6 +466,16 @@ export type PushResult =
   | { kind: "pushed"; setUpstream: boolean; output: string }
   | { kind: "nothing-to-push" };
 
+export type CreatePullRequestResult =
+  | { kind: "created"; url: string }
+  | { kind: "exists"; url: string }
+  | {
+      kind: "gh-missing";
+      compareUrl: string;
+      branch: string;
+      baseBranch: string;
+    };
+
 export async function push(projectId: string, worktreeId?: string | null): Promise<PushResult> {
   const cwd = projectCwd(projectId, worktreeId);
   // If an upstream is configured and there are no unpushed commits, surface
@@ -454,6 +523,151 @@ export async function push(projectId: string, worktreeId?: string | null): Promi
     );
   }
   return { kind: "pushed", setUpstream: true, output: combineStreams(second) };
+}
+
+function runGh(
+  cwd: string,
+  args: string[],
+  options: { timeoutMs?: number } = {},
+): Promise<RunGitResult> {
+  const { timeoutMs = GH_TIMEOUT_MS } = options;
+  return new Promise((resolve, reject) => {
+    const child = spawn("gh", args, {
+      cwd,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const outChunks: Buffer[] = [];
+    const errChunks: Buffer[] = [];
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new GitError(`gh ${args[0]} timed out`));
+    }, timeoutMs);
+    child.stdout.on("data", (d: Buffer) => outChunks.push(d));
+    child.stderr.on("data", (d: Buffer) => errChunks.push(d));
+    child.on("error", (e: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      if (e.code === "ENOENT") {
+        resolve({ stdout: "", stderr: e.message, code: 127 });
+        return;
+      }
+      reject(e);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({
+        stdout: Buffer.concat(outChunks).toString("utf8"),
+        stderr: Buffer.concat(errChunks).toString("utf8"),
+        code: code ?? 1,
+      });
+    });
+  });
+}
+
+async function ghOk(cwd: string, args: string[], timeoutMs?: number): Promise<string> {
+  const r = await runGh(cwd, args, { timeoutMs });
+  if (r.code !== 0) {
+    throw new GitError(`gh ${args[0]} failed`, r.stderr.trim() || `exit ${r.code}`);
+  }
+  return r.stdout;
+}
+
+function parseGhUrl(stdout: string): string | null {
+  const match = stdout.match(/https:\/\/github\.com\/[^\s]+/);
+  return match?.[0]?.replace(/[)\].,]+$/, "") ?? null;
+}
+
+async function isGhInstalled(cwd: string): Promise<boolean> {
+  const r = await runGh(cwd, ["--version"]);
+  return r.code === 0;
+}
+
+async function existingPullRequestUrl(cwd: string, branch: string): Promise<string | null> {
+  const r = await runGh(cwd, ["pr", "view", "--head", branch, "--json", "url", "-q", ".url"]);
+  if (r.code !== 0) return null;
+  const url = r.stdout.trim();
+  return url.startsWith("https://") ? url : null;
+}
+
+export async function createPullRequest(
+  projectId: string,
+  worktreeId?: string | null,
+): Promise<CreatePullRequestResult> {
+  const cwd = projectCwd(projectId, worktreeId);
+  const branch = (await gitOk(cwd, ["rev-parse", "--abbrev-ref", "HEAD"])).trim();
+  if (!branch || branch === "HEAD") {
+    throw new GitError("cannot create pull request from detached HEAD");
+  }
+  if (branch === PR_BASE_BRANCH) {
+    throw new GitError(`already on ${PR_BASE_BRANCH}; switch to a feature branch first`);
+  }
+
+  const githubUrl = detectGithubUrl(cwd);
+  if (!githubUrl) {
+    throw new GitError("could not detect a GitHub origin for this repository");
+  }
+  const compareUrl = buildGithubCompareUrl(githubUrl, PR_BASE_BRANCH, branch);
+
+  if (!(await isGhInstalled(cwd))) {
+    return {
+      kind: "gh-missing",
+      compareUrl,
+      branch,
+      baseBranch: PR_BASE_BRANCH,
+    };
+  }
+
+  const [aheadOfBase, dirty] = await Promise.all([
+    countCommitsAheadOfBase(cwd, PR_BASE_BRANCH),
+    workingTreeDirty(cwd),
+  ]);
+  assertPullRequestHasCommits({
+    branch,
+    baseBranch: PR_BASE_BRANCH,
+    aheadOfBase,
+    dirty,
+  });
+
+  const existing = await existingPullRequestUrl(cwd, branch);
+  if (existing) {
+    return { kind: "exists", url: existing };
+  }
+
+  // Publish any local commits before asking gh to open the PR.
+  try {
+    await push(projectId, worktreeId);
+  } catch (e) {
+    throw e instanceof GitError ? e : new GitError("git push failed before creating pull request");
+  }
+
+  if (!(await remoteBranchExists(cwd, branch))) {
+    throw new GitError(
+      `Branch "${branch}" is not on origin yet. Use Ship to commit and push your changes, then try creating the pull request again.`,
+    );
+  }
+
+  const created = await runGh(
+    cwd,
+    ["pr", "create", "--base", PR_BASE_BRANCH, "--fill"],
+    { timeoutMs: GH_TIMEOUT_MS },
+  );
+  if (created.code !== 0) {
+    const stderr = created.stderr.trim();
+    const alreadyExists =
+      /already exists/i.test(stderr) ||
+      /A pull request for .+ already exists/i.test(stderr);
+    if (alreadyExists) {
+      const url = (await existingPullRequestUrl(cwd, branch)) ?? parseGhUrl(created.stdout);
+      if (url) return { kind: "exists", url };
+    }
+    throw new GitError("gh pr create failed", stderr || `exit ${created.code}`);
+  }
+
+  const url = parseGhUrl(created.stdout) ?? (await existingPullRequestUrl(cwd, branch));
+  if (!url) {
+    throw new GitError("pull request was created but no URL was returned");
+  }
+  return { kind: "created", url };
 }
 
 function combineStreams(r: RunGitResult): string {

--- a/src/shared/__tests__/github-pr.test.ts
+++ b/src/shared/__tests__/github-pr.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildGithubCompareUrl, normalizeGithubRepoUrl } from "../github-pr";
+
+describe("normalizeGithubRepoUrl", () => {
+  it("strips .git suffix and trailing slash", () => {
+    expect(normalizeGithubRepoUrl("https://github.com/acme/widget.git/")).toBe(
+      "https://github.com/acme/widget",
+    );
+  });
+});
+
+describe("buildGithubCompareUrl", () => {
+  it("builds a compare URL with expand=1", () => {
+    expect(buildGithubCompareUrl("https://github.com/acme/widget.git", "main", "feature/foo")).toBe(
+      "https://github.com/acme/widget/compare/main...feature%2Ffoo?expand=1",
+    );
+  });
+});

--- a/src/shared/electron-contract.ts
+++ b/src/shared/electron-contract.ts
@@ -168,9 +168,9 @@ export type ElectronBridge = {
       commands: string[];
       ports?: number[];
     }) => Promise<LaunchProcessKillResult>;
-    onData: (cb: (msg: { ptyId: string; data: string }) => void) => () => void;
+    onData: (cb: (msg: { ptyId: string; data: string; seq: number }) => void) => () => void;
     onExit: (cb: (msg: { ptyId: string; exitCode: number; signal?: number }) => void) => () => void;
-    replay: (ptyId: string) => Promise<string>;
+    replay: (ptyId: string) => Promise<{ data: string; nextSeq: number }>;
   };
   onSwipe: (cb: (direction: "left" | "right" | "up" | "down") => void) => () => void;
   onCloseIntent: (cb: () => void) => () => void;

--- a/src/shared/github-pr.ts
+++ b/src/shared/github-pr.ts
@@ -1,0 +1,16 @@
+/** Normalize a GitHub repo URL to https://github.com/owner/repo (no .git). */
+export function normalizeGithubRepoUrl(githubUrl: string): string {
+  return githubUrl.trim().replace(/\/$/, "").replace(/\.git$/, "");
+}
+
+/** Build a GitHub compare URL that opens the "Open a pull request" form. */
+export function buildGithubCompareUrl(
+  githubUrl: string,
+  baseBranch: string,
+  headBranch: string,
+): string {
+  const repo = normalizeGithubRepoUrl(githubUrl);
+  const base = encodeURIComponent(baseBranch.trim());
+  const head = encodeURIComponent(headBranch.trim());
+  return `${repo}/compare/${base}...${head}?expand=1`;
+}

--- a/src/shared/terminal-zoom.ts
+++ b/src/shared/terminal-zoom.ts
@@ -1,0 +1,45 @@
+import { TERMINAL_FONT_SIZE } from "~/lib/terminal-options";
+
+export const TERMINAL_ZOOM_LEVELS = [-2, -1, 0, 1, 2] as const;
+export type TerminalZoomLevel = (typeof TERMINAL_ZOOM_LEVELS)[number];
+
+export const DEFAULT_TERMINAL_ZOOM_LEVEL: TerminalZoomLevel = 0;
+export const TERMINAL_ZOOM_MIN = -2;
+export const TERMINAL_ZOOM_MAX = 2;
+export const TERMINAL_ZOOM_STEP_PX = 2;
+
+export const TERMINAL_ZOOM_LABELS: Record<TerminalZoomLevel, string> = {
+  [-2]: "Smallest (-2)",
+  [-1]: "Smaller (-1)",
+  0: "Default",
+  1: "Larger (+1)",
+  2: "Largest (+2)",
+};
+
+export function normalizeTerminalZoomLevel(value: unknown): TerminalZoomLevel | null {
+  const raw = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  if (!Number.isFinite(raw)) return null;
+  const rounded = Math.round(raw);
+  if (rounded < TERMINAL_ZOOM_MIN || rounded > TERMINAL_ZOOM_MAX) return null;
+  return rounded as TerminalZoomLevel;
+}
+
+export function terminalFontSizeForLevel(level: TerminalZoomLevel): number {
+  return TERMINAL_FONT_SIZE + level * TERMINAL_ZOOM_STEP_PX;
+}
+
+export function clampTerminalZoomLevel(level: number): TerminalZoomLevel {
+  return Math.max(
+    TERMINAL_ZOOM_MIN,
+    Math.min(TERMINAL_ZOOM_MAX, Math.round(level)),
+  ) as TerminalZoomLevel;
+}
+
+export function stepTerminalZoomLevel(
+  level: TerminalZoomLevel,
+  delta: 1 | -1,
+): TerminalZoomLevel | null {
+  const next = level + delta;
+  if (next < TERMINAL_ZOOM_MIN || next > TERMINAL_ZOOM_MAX) return null;
+  return next as TerminalZoomLevel;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -137,6 +137,20 @@ body {
   z-index: 1;
 }
 
+.auth-pending-project-rail {
+  width: 0;
+  flex-shrink: 0;
+  border-right: 1px solid transparent;
+}
+
+[data-has-pinned-projects="true"] .auth-pending-project-rail {
+  width: 96px;
+}
+
+[data-minimal="true"][data-has-pinned-projects="true"] .auth-pending-project-rail {
+  width: 72px;
+}
+
 button {
   font-family: inherit;
   color: inherit;

--- a/update-email-v0.30-v0.36.txt
+++ b/update-email-v0.30-v0.36.txt
@@ -1,0 +1,78 @@
+Subject: Mission Control update — faster agents, diagrams, OpenCode, and a better projects dashboard
+
+Preview text: v0.31–v0.36: agent startup speed, multi-diagram viewer, OpenCode support, keyboard shortcuts, and reliability fixes.
+
+---
+
+Hi,
+
+Mission Control has shipped a lot since v0.30. Here’s what matters most.
+
+FASTER DAY-TO-DAY WORK (v0.36)
+- Agent startup is noticeably snappier — terminal sessions pre-warm in the background, new tasks appear optimistically while creation finishes, and xterm loads ahead of time.
+- Git diff is embedded in the project workspace, so you can review changes without leaving the project view.
+
+DIAGRAMS (v0.31 → v0.36)
+- Built-in diagram workflow — agents can render Mermaid diagrams in-app; the diagram skill auto-installs when an agent terminal starts.
+- Multiple diagrams per task with a tabbed viewer and in-app notifications when a diagram is ready (no duplicate popups or missed alerts).
+
+MORE AGENT & SHIP OPTIONS (v0.31–v0.36)
+- OpenCode is a first-class agent CLI, with terminal rendering tuned for Mission Control.
+- Ship/commit can use OpenCode alongside Claude, Codex, and Cursor Agent.
+- Cursor CLI hooks capture terminal prompts and help generate task titles automatically.
+- Minimum CLI version checks block outdated agent CLIs with a clear “update required” dialog.
+- Codex/Cursor session resume picks up where you left off.
+
+PROJECTS & NAVIGATION (v0.36)
+- Projects dashboard table view — sort columns and drag project paths to reorganize faster.
+
+SETTINGS & POLISH (v0.32, v0.36)
+- UI preferences and auto-update controls persist in the desktop app (download/install on your schedule).
+- Keyboard shortcut system — grouped keybindings, consistent Kbd display, and Electron shortcut reading.
+
+RELIABILITY FIXES (worth knowing)
+- macOS packaged app startup fixes (server entry + asar bundling).
+- Windows & SQLite dev/runtime startup fixes.
+- Hosted projects now surface cleanup status on project routes.
+- Commit CLI detection respects your session PATH (fewer “CLI not found” false negatives).
+
+---
+
+Recommended action: Update to v0.36.0 (Settings → Updates, or grab the latest release).
+
+Questions or feedback? Reply to this email — we read everything.
+
+— The Mission Control team
+
+---
+
+CHANGELOG (v0.30 → v0.36)
+
+0.36.0
+- Faster agent startup (warm terminals, optimistic tasks)
+- Multi-diagram viewer + notification center
+- Projects table view with sorting and path drag
+- Keybinding groups and shortcut display
+- OpenCode in Ship commit flow
+- Cursor CLI hooks and title generation
+- Inline git diff in project workspace
+
+0.35.0
+- Windows and native SQLite startup fixes
+
+0.34.0
+- macOS packaged app server entry fix
+
+0.33.0
+- Security dependency patch (lodash-es)
+
+0.32.0
+- OpenCode agent CLI
+- Persisted UI preferences
+- Auto-update settings
+
+0.31.0
+- Diagram skill and in-app viewer
+- Agent CLI version gate
+- Codex/Cursor session resume
+- Beta settings page

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,6 @@ export default defineConfig({
   },
   ssr: {
     external: ["better-sqlite3", "node-pty"],
-    noExternal: ["@xterm/xterm", "@xterm/addon-fit"],
+    noExternal: ["@xterm/xterm", "@xterm/addon-fit", "@xterm/addon-web-links"],
   },
 });


### PR DESCRIPTION
- Add per-pane terminal zoom (Cmd +/-, header buttons) with global default in Terminal settings page
- Add Create Pull Request action that runs gh pr create with branch/commit safety checks and fallback compare URL
- Migrate Settings to its own /settings route and replace ad-hoc panel state
- Add sequence-based PTY replay so reattached terminals don't drop or duplicate output
- Expand Groups dialog to manage project membership and add typeahead group picker in ProjectDialog
- Cache shell queries (projects, groups, settings, license) in localStorage for instant cold-start render
- Add Cmd/Ctrl+Click link handling in xterm via WebLinksAddon and openExternal
- Add project card context menu (Edit, Remove) and unify pin button styling
