### PR TITLE
feat(terminal): Cmd/Ctrl + scroll wheel to zoom the session under the pointer

### DIFF
--- a/src/components/views/TerminalPane.tsx
+++ b/src/components/views/TerminalPane.tsx
@@ -32,7 +32,11 @@ import {
   getTerminalColorScheme,
   watchTerminalColorScheme,
 } from "~/lib/terminal-options";
-import { useTerminalZoom, useTerminalPaneZoomShortcuts } from "~/lib/use-terminal-zoom";
+import {
+  useTerminalZoom,
+  useTerminalPaneZoomShortcuts,
+  useTerminalPaneWheelZoom,
+} from "~/lib/use-terminal-zoom";
 import { useHotkey } from "~/lib/use-hotkey";
 import { SandboxCloneOfferBanner } from "~/components/views/SandboxCloneOfferBanner";
 import { TerminalZoomControls } from "~/components/views/TerminalZoomControls";
@@ -147,6 +151,7 @@ export function TerminalPane({
     canZoomOut,
   } = useTerminalZoom(descriptor.taskId);
   useTerminalPaneZoomShortcuts(paneRef, zoomIn, zoomOut);
+  useTerminalPaneWheelZoom(paneRef, zoomIn, zoomOut);
 
   const activeRuntimeScopeId = project.activeRuntimeScopeId ?? LOCAL_SCOPE_ID;
   const { data: liveTasks } = useTasks(

--- a/src/lib/use-terminal-zoom.ts
+++ b/src/lib/use-terminal-zoom.ts
@@ -76,3 +76,50 @@ export function useTerminalPaneZoomShortcuts(
     };
   }, [paneRef, zoomIn, zoomOut]);
 }
+
+// Wheel delta (px) that must accumulate before stepping one zoom level. Keeps a
+// single flick/scroll from blasting through all five levels at once, and matches
+// the discrete feel of the +/- buttons rather than a continuous zoom.
+const WHEEL_ZOOM_STEP_THRESHOLD = 40;
+
+/**
+ * Cmd/Ctrl + mouse wheel over this pane zooms the terminal: scroll up to zoom in,
+ * scroll down to zoom out. Scoped to the pane the pointer is over (not focus), so
+ * it works even before clicking into the terminal, and each pane zooms independently.
+ */
+export function useTerminalPaneWheelZoom(
+  paneRef: RefObject<HTMLElement | null>,
+  zoomIn: () => void,
+  zoomOut: () => void,
+) {
+  useEffect(() => {
+    const pane = paneRef.current;
+    if (!pane) return;
+
+    let accumulated = 0;
+    const onWheel = (event: WheelEvent) => {
+      // metaKey is Cmd on macOS; ctrlKey covers Windows/Linux and trackpad pinch.
+      if (!event.metaKey && !event.ctrlKey) return;
+      // Suppress the browser's own zoom and stop xterm from also scrolling its
+      // scrollback on the same gesture (we run in capture, before xterm).
+      event.preventDefault();
+      event.stopPropagation();
+      // Reset if the scroll direction flips, so up-then-down feels responsive.
+      if (Math.sign(event.deltaY) !== Math.sign(accumulated)) accumulated = 0;
+      accumulated += event.deltaY;
+      while (accumulated <= -WHEEL_ZOOM_STEP_THRESHOLD) {
+        accumulated += WHEEL_ZOOM_STEP_THRESHOLD;
+        zoomIn(); // scroll up (deltaY < 0) → larger
+      }
+      while (accumulated >= WHEEL_ZOOM_STEP_THRESHOLD) {
+        accumulated -= WHEEL_ZOOM_STEP_THRESHOLD;
+        zoomOut(); // scroll down (deltaY > 0) → smaller
+      }
+    };
+
+    // Capture phase + non-passive so we intercept before xterm's own wheel
+    // handler and preventDefault() can block the native browser zoom.
+    pane.addEventListener("wheel", onWheel, { passive: false, capture: true });
+    return () => pane.removeEventListener("wheel", onWheel, { capture: true });
+  }, [paneRef, zoomIn, zoomOut]);
+}


### PR DESCRIPTION
## What

Hover a session terminal and hold **Cmd** (macOS) or **Ctrl** (Windows/Linux) while scrolling to zoom it — scroll up to zoom in, scroll down to zoom out.

## Why

The app already supports per-session zoom via the toolbar `+`/`−` buttons and the `Cmd +` / `Cmd −` shortcuts. Cmd+scroll is a natural, discoverable gesture for the same action, matching how editors/terminals commonly zoom.

## How

- New `useTerminalPaneWheelZoom` hook (in `src/lib/use-terminal-zoom.ts`) reusing the existing `useTerminalZoom` state, so levels stay clamped to `-2..+2` and persist per session.
- Capture-phase, non-passive `wheel` listener that `preventDefault()`s the browser's native zoom and stops xterm from scrolling its scrollback on the same gesture.
- Wheel delta is accumulated (40px per step) so one flick steps a single zoom level at a time instead of jumping across all five; a direction flip resets the accumulator for responsiveness.
- Scoped to the pane under the pointer (via `paneRef`), so it works before clicking into the terminal, and each session zooms independently.
- Wired into `TerminalPane` alongside the existing keyboard-shortcut hook.

Without the modifier held, normal terminal scrollback is unaffected.

## Testing

- `tsc --noEmit` passes for the changed files.
- Manual: `pnpm dev`, hover a session, hold Cmd and scroll up/down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)