### PR TITLE
fix(ember): theme the Recall toast per theme + add learned-notification toggle

### DIFF
--- a/src/components/views/GeneralSettingsPage.tsx
+++ b/src/components/views/GeneralSettingsPage.tsx
@@ -123,6 +123,7 @@ export function GeneralSettingsPage() {
     recallInjectBriefEnabled: settings?.recallInjectBriefEnabled ?? true,
     recallCodeGraphEnabled: settings?.recallCodeGraphEnabled ?? true,
     recallProactiveRecallEnabled: settings?.recallProactiveRecallEnabled ?? true,
+    recallLearnedToastEnabled: settings?.recallLearnedToastEnabled ?? true,
     ...queryClient.getQueryData<AppSettings>(queryKeys.settings),
     worktreesEnabled:
       queryClient.getQueryData<AppSettings>(queryKeys.settings)?.worktreesEnabled ??

--- a/src/components/views/RecallSettings.tsx
+++ b/src/components/views/RecallSettings.tsx
@@ -18,6 +18,7 @@ type RecallSettingsPatch = Partial<
     | "recallInjectBriefEnabled"
     | "recallCodeGraphEnabled"
     | "recallProactiveRecallEnabled"
+    | "recallLearnedToastEnabled"
   >
 >;
 
@@ -38,6 +39,7 @@ export function RecallSettings() {
   const injectBrief = settings?.recallInjectBriefEnabled ?? true;
   const codeGraph = settings?.recallCodeGraphEnabled ?? true;
   const proactiveRecall = settings?.recallProactiveRecallEnabled ?? true;
+  const learnedToast = settings?.recallLearnedToastEnabled ?? true;
 
   const [updating, setUpdating] = useState(false);
   const inFlight = useRef(false);
@@ -100,6 +102,14 @@ export function RecallSettings() {
                 checked={autoCapture}
                 disabled={updating || !engineEnabled}
                 onChange={(next) => void update({ recallAutoCaptureEnabled: next })}
+              />
+              <ToggleRow
+                title="Notify when memories are learned"
+                description="Show a “Learned N memories from this session” toast after auto-capture, with a shortcut to review them. Turn off to capture silently."
+                label="Notify when memories are learned"
+                checked={learnedToast}
+                disabled={updating || !autoCapture}
+                onChange={(next) => void update({ recallLearnedToastEnabled: next })}
               />
               <ToggleRow
                 title="Allow agents to write memories"

--- a/src/components/views/TerminalSettingsPage.tsx
+++ b/src/components/views/TerminalSettingsPage.tsx
@@ -67,6 +67,7 @@ export function TerminalSettingsPage() {
     recallInjectBriefEnabled: settings?.recallInjectBriefEnabled ?? true,
     recallCodeGraphEnabled: settings?.recallCodeGraphEnabled ?? true,
     recallProactiveRecallEnabled: settings?.recallProactiveRecallEnabled ?? true,
+    recallLearnedToastEnabled: settings?.recallLearnedToastEnabled ?? true,
     ...queryClient.getQueryData<AppSettings>(queryKeys.settings),
     ...patch,
   });

--- a/src/components/views/ThemeSettingsPage.tsx
+++ b/src/components/views/ThemeSettingsPage.tsx
@@ -76,6 +76,7 @@ export function ThemeSettingsPage() {
     recallInjectBriefEnabled: settings?.recallInjectBriefEnabled ?? true,
     recallCodeGraphEnabled: settings?.recallCodeGraphEnabled ?? true,
     recallProactiveRecallEnabled: settings?.recallProactiveRecallEnabled ?? true,
+    recallLearnedToastEnabled: settings?.recallLearnedToastEnabled ?? true,
     ...queryClient.getQueryData<AppSettings>(queryKeys.settings),
     worktreesEnabled:
       queryClient.getQueryData<AppSettings>(queryKeys.settings)?.worktreesEnabled ??

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -148,6 +148,8 @@ export type AppSettings = {
   recallCodeGraphEnabled: boolean;
   /** Whether each turn gets relevant memories + graph hits injected proactively. */
   recallProactiveRecallEnabled: boolean;
+  /** Whether the "Learned N memories from this session" toast fires after auto-capture. */
+  recallLearnedToastEnabled: boolean;
 };
 
 export class ApiError extends Error {
@@ -600,6 +602,7 @@ export const api = {
         | "recallInjectBriefEnabled"
         | "recallCodeGraphEnabled"
         | "recallProactiveRecallEnabled"
+        | "recallLearnedToastEnabled"
       >
     >,
   ) =>

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -2003,7 +2003,7 @@ function ProjectPage() {
             void queryClient.invalidateQueries({ queryKey: queryKeys.projectMemory(id) });
             // Non-blocking review nudge for silent auto-capture (D3): deep-links
             // into the Recall panel's Recently-learned filter for bulk keep/edit.
-            if (e.type === "memory:learned") {
+            if (e.type === "memory:learned" && (settings?.recallLearnedToastEnabled ?? true)) {
               const count = typeof e.count === "number" ? e.count : 0;
               if (count > 0) {
                 toast.success(
@@ -2023,7 +2023,7 @@ function ProjectPage() {
           }
         }
       },
-      [id, invalidateThisProjectTasks, invalidateProject, invalidateProjects, invalidateWorktrees, queryClient]
+      [id, invalidateThisProjectTasks, invalidateProject, invalidateProjects, invalidateWorktrees, queryClient, settings?.recallLearnedToastEnabled]
     )
   );
 

--- a/src/server/__tests__/settings-api.test.ts
+++ b/src/server/__tests__/settings-api.test.ts
@@ -115,6 +115,7 @@ describe("settings API", () => {
       recallInjectBriefEnabled: false,
       recallCodeGraphEnabled: false,
       recallProactiveRecallEnabled: false,
+      recallLearnedToastEnabled: false,
     });
   });
 
@@ -144,6 +145,7 @@ describe("settings API", () => {
       recallInjectBriefEnabled: false,
       recallCodeGraphEnabled: false,
       recallProactiveRecallEnabled: false,
+      recallLearnedToastEnabled: false,
     });
 
     const reenabled = await handleApiRequest(
@@ -163,6 +165,7 @@ describe("settings API", () => {
       recallInjectBriefEnabled: true,
       recallCodeGraphEnabled: true,
       recallProactiveRecallEnabled: true,
+      recallLearnedToastEnabled: true,
     });
   });
 

--- a/src/server/controllers/settings.controller.ts
+++ b/src/server/controllers/settings.controller.ts
@@ -152,6 +152,7 @@ const updateSettingsBody = z
     recallInjectBriefEnabled: z.boolean(),
     recallCodeGraphEnabled: z.boolean(),
     recallProactiveRecallEnabled: z.boolean(),
+    recallLearnedToastEnabled: z.boolean(),
   })
   .partial();
 
@@ -298,6 +299,7 @@ function recallSettingsPayload() {
     recallInjectBriefEnabled: recall.injectBriefEnabled,
     recallCodeGraphEnabled: recall.codeGraphEnabled,
     recallProactiveRecallEnabled: recall.proactiveRecallEnabled,
+    recallLearnedToastEnabled: recall.learnedToastEnabled,
   };
 }
 
@@ -455,6 +457,7 @@ export async function update(request: Request): Promise<Response> {
     injectBriefEnabled: body.recallInjectBriefEnabled,
     codeGraphEnabled: body.recallCodeGraphEnabled,
     proactiveRecallEnabled: body.recallProactiveRecallEnabled,
+    learnedToastEnabled: body.recallLearnedToastEnabled,
   });
   return json(settingsPayload());
 }

--- a/src/server/services/recall-settings.ts
+++ b/src/server/services/recall-settings.ts
@@ -28,6 +28,7 @@ const AGENT_WRITE_ENABLED_KEY = "recall_agent_write_enabled";
 const INJECT_BRIEF_ENABLED_KEY = "recall_inject_brief_enabled";
 const CODE_GRAPH_ENABLED_KEY = "recall_code_graph_enabled";
 const PROACTIVE_RECALL_ENABLED_KEY = "recall_proactive_recall_enabled";
+const LEARNED_TOAST_ENABLED_KEY = "recall_learned_toast_enabled";
 
 // The harness fallback mirrors session creation: use the app's configured
 // default agent when Recall's own harness hasn't been set explicitly.
@@ -58,6 +59,8 @@ export interface RecallSettings {
   codeGraphEnabled: boolean;
   /** Whether each turn gets relevant memories + graph hits injected (UserPromptSubmit). */
   proactiveRecallEnabled: boolean;
+  /** Whether the "Learned N memories from this session" toast fires after auto-capture. */
+  learnedToastEnabled: boolean;
 }
 
 function getEngineHarness(): AiRuntimeHarness {
@@ -83,6 +86,7 @@ export function readRecallSettings(): RecallSettings {
     injectBriefEnabled: enabled && getBooleanSetting(INJECT_BRIEF_ENABLED_KEY, true),
     codeGraphEnabled: enabled && getBooleanSetting(CODE_GRAPH_ENABLED_KEY, true),
     proactiveRecallEnabled: enabled && getBooleanSetting(PROACTIVE_RECALL_ENABLED_KEY, true),
+    learnedToastEnabled: enabled && getBooleanSetting(LEARNED_TOAST_ENABLED_KEY, true),
   };
 }
 
@@ -114,6 +118,9 @@ export function writeRecallSettings(patch: Partial<RecallSettings>): void {
   }
   if (patch.proactiveRecallEnabled !== undefined) {
     setBooleanSetting(PROACTIVE_RECALL_ENABLED_KEY, patch.proactiveRecallEnabled);
+  }
+  if (patch.learnedToastEnabled !== undefined) {
+    setBooleanSetting(LEARNED_TOAST_ENABLED_KEY, patch.learnedToastEnabled);
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -538,7 +538,7 @@ select,
   width: 100%;
   max-width: 100%;
   min-height: 64px;
-  padding: 14px 96px 14px 16px;
+  padding: 14px 52px 14px 16px;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -665,15 +665,77 @@ select,
 .mc-toast-close-btn {
   position: absolute;
   top: 50%;
-  right: 12px;
+  right: 14px;
   transform: translateY(-50%);
   flex-shrink: 0;
   z-index: 1;
 }
 
+/* Themed close button: a round chip tinted to the toast tone so it reads as
+   part of the frame, replacing the gray mc-btn-ghost pill that clashed with
+   the colored toast. Scoped to .mc-toast-panel so tone-less custom toasts keep
+   their own close styling.
+
+   The full class chain (.mc-toast-close-btn.mc-btn-ghost) is intentional: it
+   lifts specificity to (0,4,0) so this wins over the minimal/noir/ember
+   `[data-minimal] .mc-btn-ghost.mc-btn-sm` rules (0,3,0) further down the
+   sheet, which would otherwise repaint the chip as a flat gray button in those
+   themes. Keep it tone-tinted in every theme. */
+.mc-toast-panel [data-close-button].mc-toast-close-btn.mc-btn-ghost {
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  min-height: 24px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--mc-toast-tone) 42%, transparent);
+  background: color-mix(in srgb, var(--mc-toast-tone) 14%, transparent);
+  color: color-mix(in srgb, var(--mc-toast-tone) 78%, var(--text));
+  filter: none;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+/* Kill the mc-btn-ghost gray frame image so only the tinted chip shows. */
+.mc-toast-panel [data-close-button].mc-toast-close-btn.mc-btn-ghost::before {
+  content: none;
+}
+
+.mc-toast-panel [data-close-button].mc-toast-close-btn.mc-btn-ghost:hover {
+  background: color-mix(in srgb, var(--mc-toast-tone) 24%, transparent);
+  border-color: color-mix(in srgb, var(--mc-toast-tone) 58%, transparent);
+  color: color-mix(in srgb, var(--mc-toast-tone) 88%, white);
+}
+
 .mc-toast-panel:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--mc-toast-tone) 82%, white);
   outline-offset: 3px;
+}
+
+/* Minimal / noir / ember explicitly drop all painted chrome (their cards are
+   flat hairlines), so the painted pixel-frame toast is out of place there.
+   Flatten it to a tone-tinted hairline panel that matches those themes — the
+   icon badge, action, and close chip already track --mc-toast-tone, so they
+   carry over unchanged. Painted themes keep the border-image frame above. */
+[data-minimal="true"] .mc-toast-panel {
+  padding: 14px 48px 14px 16px;
+  border: 1px solid color-mix(in srgb, var(--mc-toast-tone) 40%, var(--border-strong)) !important;
+  border-image: none !important;
+  border-radius: var(--mm-radius) !important;
+  background: color-mix(in srgb, var(--surface-1) 90%, var(--mc-toast-tone) 10%);
+  filter: none;
+  box-shadow:
+    0 1px 0 rgb(255 255 255 / 4%) inset,
+    0 10px 30px rgb(0 0 0 / 42%),
+    0 0 0 1px color-mix(in srgb, var(--mc-toast-tone) 12%, transparent);
+}
+
+/* Ember squares every corner. Must stay after the minimal rule to win the
+   shared-specificity tie (ember sets both data-minimal and data-ember). */
+[data-ember="true"] .mc-toast-panel {
+  border-radius: 0 !important;
 }
 
 /* Custom toasts render their own CardFrame; strip the outer Sonner shell frame. */


### PR DESCRIPTION
Retargeted to `main`: the Recall + ember/noir themes this builds on already shipped upstream via PR #28, so `main` is now the correct base.

## Problem
The "Learned N memories from this session" toast rendered its close button with the generic `mc-btn-ghost` gray pixel-frame — a dark pill that clashed with the tone-colored toast in every theme.

## Toast theming (`src/styles.css`)
- **Close button** retoned to a round chip tinted with `--mc-toast-tone`, matching the accent across all 14 accent colors + success/error. Selector specificity lifted to `(0,4,0)` so it wins over the minimal/noir/ember `.mc-btn-ghost` rules that would otherwise repaint it flat gray.
- **Spacing** — trimmed the oversized right padding (`96px → 52px`) that squished the title into 4 lines and left a dead gap before the close button.
- **Flat themes** — Minimal, Noir, and Ember drop all painted chrome, so the pixel-frame toast was the one painted element left. Flattened it to a tone-tinted hairline panel honoring each theme's radius (Ember squares the corners). Painted light/dark keep the pixel frame.

Verified all six theme combinations (Painted dark/light/accent, Minimal, Noir, Ember) render a clean tone-tinted circular close button.

## New setting — "Notify when memories are learned" (Settings → Recall)
- Toggles the auto-capture toast; off = capture silently. Defaults **on**, gated by the Recall master switch like the other sub-flags.
- Threaded through `recall-settings` storage, the settings controller schema, the `AppSettings` client type, the Recall settings UI, and the three duplicated settings-page defaults blocks. The `memory:learned` toast in `projects.$id.tsx` now respects it.

## Verification
- `pnpm typecheck` — clean
- `vitest` settings + hooks API tests — 63 passed (extended master-switch assertions to cover the new flag)
- `eslint` on all changed files — clean
