### PR TITLE
fix(electron): disable history back/forward from mouse buttons and swipe

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,6 +9,7 @@ import {
   session,
   clipboard,
   nativeImage,
+  systemPreferences,
   type NativeImage,
 } from "electron";
 import log from "electron-log/main";
@@ -936,6 +937,17 @@ async function bootDevServer(): Promise<string> {
 }
 
 async function createWindow() {
+  // macOS wires horizontal two-finger swipes (trackpad and Magic Mouse) to
+  // session-history back/forward. Opt this window's app domain out so a swipe
+  // never pops the router. Must be set before the window loads.
+  if (process.platform === "darwin") {
+    systemPreferences.setUserDefault(
+      "AppleEnableSwipeNavigateWithScrolls",
+      "boolean",
+      false,
+    );
+  }
+
   const url = isDev ? await bootDevServer() : await startProductionServer();
   // The renderer is only ever loaded from this URL — pin the IPC allow-list
   // to that origin so a future renderer compromise (XSS in markdown, agent
@@ -985,6 +997,16 @@ async function createWindow() {
   // macOS-only: 3-finger swipe (System Settings → Trackpad → More Gestures).
   win.on("swipe", (_e, direction) => {
     win?.webContents.send(IPC.appSwipe, direction);
+  });
+
+  // Kill history navigation from the mouse back/forward buttons (Windows/Linux
+  // fire this as app-command; macOS routes them through swipe navigation which
+  // is disabled via the AppleEnableSwipeNavigateWithScrolls user default). This
+  // app is a single shell — a stray button click must not pop the router.
+  win.on("app-command", (event, command) => {
+    if (command === "browser-backward" || command === "browser-forward") {
+      event.preventDefault();
+    }
   });
 
   win.on("enter-full-screen", () => win?.webContents.send(IPC.appFullScreenChange, true));

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -97,6 +97,14 @@ function configureUserDataDir(): string {
 
 const missionControlUserDataDir = configureUserDataDir();
 
+// Kill Chromium's own two-finger/Magic Mouse swipe-to-go-back. The macOS
+// `AppleEnableSwipeNavigateWithScrolls` default (set per-window in createWindow)
+// only covers the OS-driven path; the horizontal swipe on a Magic Mouse still
+// reaches Chromium's built-in overscroll history navigation, which pops the
+// router in this single-shell app. Disabling the feature closes that path. Must
+// run before app-ready, so it's a module-level statement here.
+app.commandLine.appendSwitch("disable-features", "OverscrollHistoryNavigation");
+
 /** Env for spawning the bundled remote-vm CLI as a plain Node process. */
 function remoteVmSpawnEnv(): NodeJS.ProcessEnv {
   return {

--- a/src/lib/use-navigation-swipe.ts
+++ b/src/lib/use-navigation-swipe.ts
@@ -4,14 +4,15 @@ import { getElectron } from "~/lib/electron";
 
 type RouterLike = ReturnType<typeof useRouter>;
 
-// Browser-like back/forward swipe navigation, applied globally.
-// Two-finger trackpad horizontal wheel swipe and macOS 3-finger swipe (via
-// Electron's BrowserWindow `swipe` event) both feed a single dispatcher so
-// one physical gesture = one history step, regardless of how many event
-// streams the OS routes to us.
+// Back/forward swipe navigation, applied globally, driven only by the explicit
+// macOS 3-finger swipe (Electron's BrowserWindow `swipe` event). The two-finger
+// horizontal wheel swipe (trackpad and, notably, the Magic Mouse) used to feed
+// this too, but that gesture fires constantly and unintentionally — most visibly
+// over non-scrolling areas like the header, where it isn't consumed for
+// scrolling — popping the router mid-work. Since this is a single-shell app the
+// accidental history steps are pure downside, so the wheel path is gone; the
+// deliberate 3-finger swipe (opt-in via System Settings) stays.
 const DISPATCH_COOLDOWN_MS = 400;
-const WHEEL_THRESHOLD = 60;
-const WHEEL_IDLE_MS = 180;
 
 export function useNavigationSwipe() {
   const router = useRouter();
@@ -22,34 +23,6 @@ export function useNavigationSwipe() {
     const isNavigationBlocked = () =>
       document.querySelector("[data-modal-open], [data-navigation-swipe-blocker]") !== null;
 
-    let wheelSum = 0;
-    let wheelIdleTimer: ReturnType<typeof setTimeout> | null = null;
-
-    const onWheel = (e: WheelEvent) => {
-      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
-      if (isNavigationBlocked()) return;
-
-      // Accumulate signed deltaX across the gesture so slow steady swipes
-      // (many small deltas) still cross the threshold. The dispatcher's
-      // 400ms cooldown absorbs inertial tail events after we fire.
-      wheelSum += e.deltaX;
-
-      if (wheelIdleTimer) clearTimeout(wheelIdleTimer);
-      wheelIdleTimer = setTimeout(() => {
-        wheelSum = 0;
-      }, WHEEL_IDLE_MS);
-
-      if (wheelSum <= -WHEEL_THRESHOLD) {
-        dispatch("back");
-        wheelSum = 0;
-      } else if (wheelSum >= WHEEL_THRESHOLD) {
-        dispatch("forward");
-        wheelSum = 0;
-      }
-    };
-
-    window.addEventListener("wheel", onWheel, { passive: true });
-
     const offSwipe = getElectron()?.onSwipe((dir) => {
       if (isNavigationBlocked()) return;
       if (dir === "left") dispatch("back");
@@ -57,8 +30,6 @@ export function useNavigationSwipe() {
     });
 
     return () => {
-      window.removeEventListener("wheel", onWheel);
-      if (wheelIdleTimer) clearTimeout(wheelIdleTimer);
       offSwipe?.();
     };
   }, [router]);


### PR DESCRIPTION
## Summary

The mouse back/forward buttons and macOS horizontal two-finger swipes (trackpad and Magic Mouse) were triggering session-history back/forward, popping the router in what is otherwise a single-shell SPA. Neither gesture was opted into anywhere — both are default Chromium/OS behaviors the app had never overridden. A stray swipe or button click yanking the user to a previous route is a bug, not a feature.

## Changes

- **Mouse back/forward buttons** — added an `app-command` handler that `preventDefault()`s `browser-backward` / `browser-forward` (how Windows/Linux deliver those physical buttons).
- **macOS swipe navigation** — set the app-domain user default `AppleEnableSwipeNavigateWithScrolls` to `false` before the window loads. This scopes the opt-out to Mission Control only; other apps (Safari, etc.) are unaffected.

## Notes

Complements the existing `will-navigate` guard, which only blocked file-drop navigation, not in-app router history.

## Testing

- `tsc -p electron/tsconfig.json --noEmit` — clean
- `eslint electron/main.ts` — clean