### PR TITLE
fix(session-grid): normalize fr track weights so rows always fill

### DIFF
--- a/src/components/views/SessionGrid.tsx
+++ b/src/components/views/SessionGrid.tsx
@@ -175,6 +175,19 @@ function meanWeight(sizes: number[]): number {
   return total > 0 ? total / sizes.length : 1;
 }
 
+/** Build a `grid-template` track list (`minmax(0, Nfr)…`) from relative weights,
+ *  normalized so the weights always sum to at least the track count. CSS grid
+ *  floors the flex-factor sum at 1, so a track list summing below 1 — e.g. a lone
+ *  survivor cell left with a 0.9fr weight after its row-mate is removed — only
+ *  fills that fraction of the container, leaving a gap. Scaling every weight by
+ *  count/total keeps each track's relative size but guarantees they fill. */
+export function frTracks(weights: number[]): string {
+  if (weights.length === 0) return "";
+  const total = weights.reduce((a, b) => a + b, 0);
+  const scale = total > 0 ? weights.length / total : 1;
+  return weights.map((w) => `minmax(0, ${w * scale}fr)`).join(" ");
+}
+
 /** A fresh scope with no saved layout seeds this near-square shape (mirrors the
  *  old auto-grid: `ceil(√n)` columns per row) so the first paint doesn't jump. */
 function chunkIntoRows(ids: string[]): GridLayout {
@@ -1992,8 +2005,7 @@ export function SessionGrid({
           minWidth: 0,
           display: "grid",
           gridTemplateColumns: "minmax(0, 1fr)",
-          gridTemplateRows:
-            viewRows.map((r) => `minmax(0, ${r.fr}fr)`).join(" ") || "minmax(0, 1fr)",
+          gridTemplateRows: frTracks(viewRows.map((r) => r.fr)) || "minmax(0, 1fr)",
           gap: gridGap,
           padding: gridPad,
           overflow: "hidden",
@@ -2005,7 +2017,7 @@ export function SessionGrid({
             data-grid-row={String(ri)}
             style={{
               display: "grid",
-              gridTemplateColumns: row.cells.map((c) => `minmax(0, ${c.fr}fr)`).join(" "),
+              gridTemplateColumns: frTracks(row.cells.map((c) => c.fr)),
               gap: gridGap,
               minWidth: 0,
               minHeight: 0,

--- a/src/components/views/__tests__/session-grid-tracks.test.ts
+++ b/src/components/views/__tests__/session-grid-tracks.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { frTracks } from "../SessionGrid";
+
+describe("frTracks", () => {
+  it("expands a lone sub-1 weight to a full 1fr track", () => {
+    // A survivor cell keeps its resized weight after its row-mate is removed.
+    // CSS grid floors the flex-factor sum at 1, so a bare `0.909fr` track would
+    // only take ~91% of the row and leave a gap — normalizing fixes it.
+    expect(frTracks([0.909346])).toBe("minmax(0, 1fr)");
+  });
+
+  it("fills the row when the weights sum below 1", () => {
+    expect(frTracks([0.4, 0.4])).toBe("minmax(0, 1fr) minmax(0, 1fr)");
+  });
+
+  it("preserves relative column sizes when the weights already fill", () => {
+    expect(frTracks([0.909, 1.091])).toBe("minmax(0, 0.909fr) minmax(0, 1.091fr)");
+  });
+
+  it("keeps equal columns equal", () => {
+    expect(frTracks([1, 1, 1])).toBe(
+      "minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr)",
+    );
+  });
+
+  it("returns an empty string for no tracks", () => {
+    expect(frTracks([])).toBe("");
+  });
+});


### PR DESCRIPTION
## Problem

CSS grid floors the flex-factor sum at 1. When a resized cell ends up alone in a row (e.g. its row-mate is closed) with a leftover weight like `0.9fr`, the track list sums below 1 and the row only fills ~90% of the container, leaving a visible gap.

## Fix

Route row and column templates through a new `frTracks()` helper that normalizes weights by `count/total` — relative sizes are preserved, but the sum is guaranteed to be at least the track count, so tracks always fill.

## Testing

- 5 new unit tests in `src/components/views/__tests__/session-grid-tracks.test.ts` covering the lone-survivor case, sub-1 sums, already-filling weights, equal columns, and empty input
- `tsc --noEmit` and eslint clean