### PR TITLE
feat(theme): live theme thumbnails, surface tint, and clean light mode

### DIFF
--- a/electron/ipc-channels.ts
+++ b/electron/ipc-channels.ts
@@ -20,6 +20,7 @@ export const IPC = {
   appExitFocusMode: "app:exitFocusMode",
   appGetFocusMode: "app:getFocusMode",
   appSetFocusModeAlwaysOnTop: "app:setFocusModeAlwaysOnTop",
+  appSetBackgroundColor: "app:setBackgroundColor",
   cliCheck: "cli:check",
   ptySpawn: "pty:spawn",
   ptyWrite: "pty:write",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -177,7 +177,7 @@ const MAIN_WINDOW_DEFAULT_WIDTH = 1440;
 const MAIN_WINDOW_DEFAULT_HEIGHT = 900;
 const MAIN_WINDOW_MIN_WIDTH = 1024;
 const MAIN_WINDOW_MIN_HEIGHT = 640;
-const TRAFFIC_LIGHT_POSITION_DARWIN = { x: 48, y: 16 } as const;
+const TRAFFIC_LIGHT_POSITION_DARWIN = { x: 20, y: 16 } as const;
 
 // Native window background — tracks the renderer's dark/light theme so the
 // window frame (launch flash, resize gutters, overscroll) never shows the

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -179,11 +179,41 @@ const MAIN_WINDOW_MIN_WIDTH = 1024;
 const MAIN_WINDOW_MIN_HEIGHT = 640;
 const TRAFFIC_LIGHT_POSITION_DARWIN = { x: 48, y: 16 } as const;
 
+// Native window background — tracks the renderer's dark/light theme so the
+// window frame (launch flash, resize gutters, overscroll) never shows the
+// wrong ground. The renderer pushes updates via IPC.appSetBackgroundColor;
+// the last value is persisted so the next launch paints right from frame one.
+const WINDOW_BACKGROUND_DEFAULT = "#000000";
+const WINDOW_BACKGROUND_HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
 augmentProcessEnv();
 
 let win: BrowserWindow | null = null;
 let serverProcess: ChildProcess | null = null;
 let runtimePort: number | null = null;
+
+function windowBackgroundFile(): string {
+  return path.join(missionControlUserDataDir, ".window-bg");
+}
+
+function readPersistedWindowBackground(): string {
+  try {
+    const raw = fs.readFileSync(windowBackgroundFile(), "utf8").trim();
+    if (WINDOW_BACKGROUND_HEX_RE.test(raw)) return raw;
+  } catch {
+    /* first launch or unreadable — fall back to dark */
+  }
+  return WINDOW_BACKGROUND_DEFAULT;
+}
+
+function persistWindowBackground(color: string): void {
+  try {
+    fs.mkdirSync(path.dirname(windowBackgroundFile()), { recursive: true });
+    fs.writeFileSync(windowBackgroundFile(), color, "utf8");
+  } catch {
+    /* non-fatal: only costs a wrong-colored first frame next launch */
+  }
+}
 
 function pickPort(startPort: number): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -967,7 +997,7 @@ async function createWindow() {
     height: MAIN_WINDOW_DEFAULT_HEIGHT,
     minWidth: MAIN_WINDOW_MIN_WIDTH,
     minHeight: MAIN_WINDOW_MIN_HEIGHT,
-    backgroundColor: "#000000",
+    backgroundColor: readPersistedWindowBackground(),
     titleBarStyle: process.platform === "darwin" ? "hiddenInset" : "default",
     trafficLightPosition:
       process.platform === "darwin" ? TRAFFIC_LIGHT_POSITION_DARWIN : undefined,
@@ -1359,6 +1389,16 @@ safeHandle(IPC.appGetUserName, () => {
   } catch {}
   const username = os.userInfo().username;
   return { source: "os" as const, fullName: username, firstName: username };
+});
+
+safeHandle(IPC.appSetBackgroundColor, (event, color: string) => {
+  if (typeof color !== "string" || !WINDOW_BACKGROUND_HEX_RE.test(color)) {
+    return { ok: false as const, error: "invalid-color" };
+  }
+  const target = BrowserWindow.fromWebContents(event.sender) ?? win;
+  if (target && !target.isDestroyed()) target.setBackgroundColor(color);
+  persistWindowBackground(color);
+  return { ok: true as const };
 });
 
 safeHandle(IPC.appReload, (event) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -330,6 +330,8 @@ const electronAPI = {
     ipcRenderer.invoke(IPC.appGetUserName),
   reload: (): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke(IPC.appReload),
+  setWindowBackgroundColor: (color: string): Promise<{ ok: true } | { ok: false; error: string }> =>
+    ipcRenderer.invoke(IPC.appSetBackgroundColor, color),
   notifications: {
     getPermission: (): Promise<"granted" | "unsupported"> =>
       ipcRenderer.invoke(IPC.notificationsGetPermission),

--- a/electron/pty-manager.ts
+++ b/electron/pty-manager.ts
@@ -512,6 +512,16 @@ export function registerPtyHandlers(
         env.MC_API_TOKEN = mcEnv.token;
         env.MC_THEME = opts.missionControlTheme === "light" ? "light" : "dark";
       }
+      // Mirror Mission Control's light/dark to the agent's own UI. COLORFGBG is
+      // the terminal-background hint Claude Code (and other COLORFGBG-aware TUIs)
+      // read to auto-pick a theme: the trailing number is the background color
+      // index — 15 (white) reads as light, 0 (black) as dark. This only takes
+      // effect when the agent's own theme is set to "auto"; an explicit
+      // light/dark in the agent's config wins. Overrides any COLORFGBG inherited
+      // from the launching shell so the session matches the app, not the host.
+      if (plan.mode === "agent") {
+        env.COLORFGBG = opts.missionControlTheme === "light" ? "0;15" : "15;0";
+      }
       applyAgentPtyEnv(env, opts.agent);
 
       // Recall — inject the project's Session Brief into the agent's auto-load

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -52,6 +52,7 @@ export type IconName =
   | "mic";
 
 export function Icon({ name, size = 14, style }: { name: IconName; size?: number; style?: CSSProperties }) {
+  const iconStyle: CSSProperties = { display: "block", flexShrink: 0, ...style };
   const common = {
     width: size,
     height: size,
@@ -61,15 +62,17 @@ export function Icon({ name, size = 14, style }: { name: IconName; size?: number
     strokeWidth: 1.4,
     strokeLinecap: "round" as const,
     strokeLinejoin: "round" as const,
-    style,
+    // display: block removes the inline-SVG baseline gap so icons sit on the
+    // true vertical center of adjacent text inside flex buttons.
+    style: iconStyle,
   };
   switch (name) {
     case "plus":
       return <svg {...common}><path d="M8 3v10M3 8h10" /></svg>;
     case "pin":
-      return <TiPinOutline size={size} style={style} />;
+      return <TiPinOutline size={size} style={iconStyle} />;
     case "pin-fill":
-      return <TiPin size={size} style={style} />;
+      return <TiPin size={size} style={iconStyle} />;
     case "search":
       return (
         <svg {...common}>
@@ -162,7 +165,7 @@ export function Icon({ name, size = 14, style }: { name: IconName; size?: number
           strokeWidth={2}
           strokeLinecap="round"
           strokeLinejoin="round"
-          style={style}
+          style={iconStyle}
         >
           <path d="M9.67 2h4.66l.55 3.05c.43.18.83.41 1.2.69l2.91-1.04 2.33 4.04-2.36 2.01a7.7 7.7 0 010 1.5l2.36 2.01-2.33 4.04-2.91-1.04c-.37.28-.77.51-1.2.69L14.33 21H9.67l-.55-3.05a6.88 6.88 0 01-1.2-.69L5.01 18.3l-2.33-4.04 2.36-2.01a7.7 7.7 0 010-1.5L2.68 8.74 5.01 4.7l2.91 1.04c.37-.28.77-.51 1.2-.69L9.67 2z" />
           <circle cx="12" cy="12" r="3" />
@@ -224,7 +227,7 @@ export function Icon({ name, size = 14, style }: { name: IconName; size?: number
         </svg>
       );
     case "pencil":
-      return <Pencil size={size} strokeWidth={1.8} absoluteStrokeWidth style={style} />;
+      return <Pencil size={size} strokeWidth={1.8} absoluteStrokeWidth style={iconStyle} />;
     case "eye":
       return (
         <svg {...common}>

--- a/src/components/ui/ProjectStatusBadge.tsx
+++ b/src/components/ui/ProjectStatusBadge.tsx
@@ -15,6 +15,8 @@ export function ProjectStatusBadge({ activity }: { activity: ProjectActivityStat
     <span
       title={label}
       aria-label={label}
+      className="mc-project-status-badge"
+      data-active={active || undefined}
       style={{
         flexShrink: 0,
         display: "inline-flex",
@@ -23,8 +25,6 @@ export function ProjectStatusBadge({ activity }: { activity: ProjectActivityStat
         height: 18,
         padding: "0 7px",
         borderRadius: 999,
-        border: `1px solid ${active ? "var(--accent-border)" : "var(--border)"}`,
-        background: active ? "var(--accent-faint)" : "var(--surface-0)",
         color: active ? "var(--accent)" : "var(--text-faint)",
         fontFamily: "var(--mono)",
         fontSize: 10,

--- a/src/components/ui/StatusDot.tsx
+++ b/src/components/ui/StatusDot.tsx
@@ -24,14 +24,13 @@ export function StatusPill({ status, count }: { status: TaskStatus; count?: numb
   const meta = STATUS_META[status];
   return (
     <span
+      className="mc-status-pill"
       style={{
         display: "inline-flex",
         alignItems: "center",
         gap: 6,
         padding: "2px 8px 2px 7px",
         borderRadius: 999,
-        background: "var(--surface-2)",
-        border: "1px solid var(--border)",
         fontFamily: "var(--mono)",
         fontSize: 11,
         color: "var(--text-dim)",

--- a/src/components/views/AccentColorPicker.tsx
+++ b/src/components/views/AccentColorPicker.tsx
@@ -34,7 +34,7 @@ export function AccentColorGrid({
     >
       {ACCENT_COLORS.map((color) =>
         minimal ? (
-          <MinimalThemeCard
+          <FlatThemeCard
             key={color.id}
             color={color}
             selected={color.id === selected}
@@ -53,7 +53,7 @@ export function AccentColorGrid({
   );
 }
 
-function MinimalThemeCard({
+function FlatThemeCard({
   color,
   selected,
   onSelect,

--- a/src/components/views/CommitPushButton.tsx
+++ b/src/components/views/CommitPushButton.tsx
@@ -258,15 +258,19 @@ export function CommitPushButton({
         <span
           style={{
             marginLeft: 6,
-            padding: "0 6px",
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            boxSizing: "border-box",
+            padding: "0 5px",
+            height: 16,
+            minWidth: 16,
             borderRadius: 999,
             background: splitTrailing ? "rgba(0,0,0,0.35)" : "var(--surface-2)",
             color: splitTrailing ? "#ffffff" : "var(--text)",
             fontFamily: "var(--mono)",
             fontSize: 10,
-            lineHeight: "16px",
-            minWidth: 16,
-            textAlign: "center",
+            lineHeight: 1,
           }}
         >
           {aheadCount}

--- a/src/components/views/GeneralSettingsPage.tsx
+++ b/src/components/views/GeneralSettingsPage.tsx
@@ -23,6 +23,7 @@ import {
   writeCachedLaunchIntroEnabled,
 } from "~/lib/launch-intro";
 import { DEFAULT_TERMINAL_ZOOM_LEVEL } from "~/shared/terminal-zoom";
+import { DEFAULT_SURFACE_TINT } from "~/shared/surface-tint";
 import {
   readOsNotificationPermission,
   requestOsNotificationPermission,
@@ -87,6 +88,7 @@ export function GeneralSettingsPage() {
     agentSystemBannerDisabled: settings?.agentSystemBannerDisabled ?? false,
     accentColor: settings?.accentColor ?? DEFAULT_ACCENT_COLOR,
     themeStyle: settings?.themeStyle ?? "painted",
+    surfaceTint: settings?.surfaceTint ?? DEFAULT_SURFACE_TINT,
     minimalTheme: settings?.minimalTheme ?? false,
     themeChosen: settings?.themeChosen ?? false,
     mouseGradientDisabled: settings?.mouseGradientDisabled ?? false,

--- a/src/components/views/ProjectBar.tsx
+++ b/src/components/views/ProjectBar.tsx
@@ -430,15 +430,14 @@ export function ProjectBar({ disabled = false }: { disabled?: boolean }) {
               e.stopPropagation();
               setMenu({ x: e.clientX, y: e.clientY, id: project.id, name: project.name });
             }}
+            className="mc-pinned-tile"
             style={{
               position: "relative",
               width: hasStatusDots ? ITEM_WIDTH : IDLE_ITEM_WIDTH,
               height: ITEM_HEIGHT,
               flexShrink: 0,
               padding: hasStatusDots ? "4px 6px 4px 14px" : 4,
-              border: "1px solid transparent",
               borderRadius: ITEM_RADIUS,
-              background: "transparent",
               zIndex: isActive ? 3 : 1,
               cursor: reorderSaving ? "default" : isDragging ? "grabbing" : "grab",
               opacity: isDragging ? 0.55 : 1,
@@ -449,7 +448,6 @@ export function ProjectBar({ disabled = false }: { disabled?: boolean }) {
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              transition: "border-color 0.15s",
             }}
           >
             {statusDots.length > 0 && (

--- a/src/components/views/SessionGrid.tsx
+++ b/src/components/views/SessionGrid.tsx
@@ -621,12 +621,12 @@ export function SessionGrid({
   const userTerminals = useUserTerminals();
   const { bindings } = useKeybindings();
   const { data: settings } = useSettings();
-  // Ember lays panes out flush + square: no gap between cells, no outer
-  // padding. Every other theme keeps the spacious 8px grid. Fall back to the
-  // cached style so first paint matches before settings hydrate. The divider
-  // hit-area (HANDLE_HIT) stays a grabbable 8px, centred on the 0-width seam.
+  // The flat theme lays panes out flush + square: no gap between cells, no
+  // outer padding. Painted keeps the spacious 8px grid. Fall back to the cached
+  // style so first paint matches before settings hydrate. The divider hit-area
+  // (HANDLE_HIT) stays a grabbable 8px, centred on the 0-width seam.
   const flushLayout =
-    (settings?.themeStyle ?? readCachedThemeStyle()) === "ember";
+    (settings?.themeStyle ?? readCachedThemeStyle()) === "flat";
   const gridGap = flushLayout ? 0 : GRID_GAP;
   const gridPad = flushLayout ? 0 : GRID_PADDING;
   const [expandedTaskId, setExpandedTaskId] = useState<string | null>(null);

--- a/src/components/views/TerminalSettingsPage.tsx
+++ b/src/components/views/TerminalSettingsPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "~/shared/terminal-zoom";
 import { emptyVoiceCommandAliases } from "~/shared/voice-command-aliases";
 import { DEFAULT_SESSION_HEADER_BUTTON_VISIBILITY } from "~/shared/session-header-buttons";
+import { DEFAULT_SURFACE_TINT } from "~/shared/surface-tint";
 
 export function TerminalSettingsPage() {
   const queryClient = useQueryClient();
@@ -28,6 +29,7 @@ export function TerminalSettingsPage() {
     agentSystemBannerDisabled: settings?.agentSystemBannerDisabled ?? false,
     accentColor: settings?.accentColor ?? DEFAULT_ACCENT_COLOR,
     themeStyle: settings?.themeStyle ?? "painted",
+    surfaceTint: settings?.surfaceTint ?? DEFAULT_SURFACE_TINT,
     minimalTheme: settings?.minimalTheme ?? false,
     themeChosen: settings?.themeChosen ?? false,
     mouseGradientDisabled: settings?.mouseGradientDisabled ?? false,

--- a/src/components/views/ThemeOnboardingOverlay.tsx
+++ b/src/components/views/ThemeOnboardingOverlay.tsx
@@ -6,14 +6,15 @@ import { CardFrame } from "~/components/ui/CardFrame";
 import { Icon } from "~/components/ui/Icon";
 import { KbdCombo } from "~/components/ui/Kbd";
 import { AccentColorGrid } from "~/components/views/AccentColorPicker";
+import { ThemeStylePreview } from "~/components/views/ThemeStylePreview";
 import {
   ACCENT_CACHE_KEY,
   applyAccentColor,
   DEFAULT_ACCENT_COLOR,
-  getAccentColor,
   isAccentColorId,
   type AccentColorId,
 } from "~/lib/accent-colors";
+import { readCachedSurfaceTint } from "~/lib/surface-tint";
 import {
   applyThemeStyle,
   readCachedThemeStyle,
@@ -317,7 +318,6 @@ function StyleChoiceCard({
   selected: boolean;
   onSelect: () => void;
 }) {
-  const accent = getAccentColor(accentId);
   return (
     <button
       type="button"
@@ -359,7 +359,11 @@ function StyleChoiceCard({
           <Icon name="check" size={12} />
         </span>
       )}
-      <StylePreviewChip accent={accent} stylePreview={stylePreview} />
+      <ThemeStylePreview
+        style={stylePreview}
+        accentId={accentId}
+        tint={readCachedSurfaceTint()}
+      />
       <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         <span
           style={{
@@ -377,91 +381,5 @@ function StyleChoiceCard({
         </span>
       </div>
     </button>
-  );
-}
-
-/**
- * A small "Action" chip previewing the chrome each style renders: painted
- * (border-image), minimal (flat accent fill), noir (flat near-black with a
- * hairline accent outline).
- */
-function StylePreviewChip({
-  accent,
-  stylePreview,
-}: {
-  accent: ReturnType<typeof getAccentColor>;
-  stylePreview: ThemeStyle;
-}) {
-  const accentRgba = (a: number) => `rgba(${accent.rgb}, ${a})`;
-  const buttonBorder = `url("/borders/button_filled_${accent.id}.png")`;
-  return (
-    <span
-      aria-hidden
-      style={
-        stylePreview === "minimal"
-          ? {
-              display: "inline-flex",
-              alignSelf: "flex-start",
-              padding: "6px 14px",
-              fontFamily: "var(--mono)",
-              fontSize: 11,
-              fontWeight: 600,
-              color: "#fff",
-              borderRadius: "var(--mm-radius-sm, 5px)",
-              background: accent.value,
-            }
-          : stylePreview === "noir"
-            ? {
-                boxSizing: "border-box",
-                display: "inline-flex",
-                alignSelf: "flex-start",
-                padding: "6px 14px",
-                fontFamily: "var(--mono)",
-                fontSize: 11,
-                fontWeight: 600,
-                color: accent.value,
-                borderRadius: "var(--mm-radius-sm, 4px)",
-                border: `1px solid ${accentRgba(0.55)}`,
-                background: "#0f0f12",
-              }
-            : stylePreview === "ember"
-              ? {
-                  // Warm, square, solid accent border — the ember mood.
-                  boxSizing: "border-box",
-                  display: "inline-flex",
-                  alignSelf: "flex-start",
-                  padding: "6px 14px",
-                  fontFamily: "var(--mono)",
-                  fontSize: 11,
-                  fontWeight: 600,
-                  color: accent.value,
-                  borderRadius: 0,
-                  border: `1px solid ${accentRgba(0.7)}`,
-                  background: "#1b1610",
-                }
-            : {
-                boxSizing: "border-box",
-                display: "inline-flex",
-                alignSelf: "flex-start",
-                padding: "6px 12px",
-                fontFamily: "var(--mono)",
-                fontSize: 11,
-                fontWeight: 600,
-                color: "#fff",
-                borderStyle: "solid",
-                borderColor: "transparent",
-                borderWidth: 12,
-                borderImageSource: buttonBorder,
-                borderImageSlice: "48",
-                borderImageWidth: "12px",
-                borderImageRepeat: "stretch",
-                background: accentRgba(0.18),
-                backgroundClip: "padding-box",
-                textShadow: `0 0 8px ${accentRgba(0.6)}`,
-              }
-      }
-    >
-      Action
-    </span>
   );
 }

--- a/src/components/views/ThemeOnboardingOverlay.tsx
+++ b/src/components/views/ThemeOnboardingOverlay.tsx
@@ -89,13 +89,13 @@ function ThemeOnboardingOverlay({ onDone }: { onDone: () => void }) {
     applyAccentColor(next);
   }, []);
 
-  // Picking a style live-applies it instantly. Ember is built around its warm
-  // terracotta accent, so selecting it defaults the swatch there (the user can
-  // still pick another color afterward).
+  // Picking a style live-applies it instantly. The flat theme is built around
+  // its warm terracotta accent, so selecting it defaults the swatch there (the
+  // user can still pick another color afterward).
   const selectStyle = useCallback((next: ThemeStyle) => {
     setStyle(next);
     applyThemeStyle(next);
-    if (next === "ember") {
+    if (next === "flat") {
       setColor("terracotta");
       applyAccentColor("terracotta");
     }
@@ -216,35 +216,19 @@ function ThemeOnboardingOverlay({ onDone }: { onDone: () => void }) {
           >
             <StyleChoiceCard
               title="Painted"
-              description="Pixel-art borders and shell imagery. The full Mission Control look."
+              description="Pixel-art borders and shell imagery. The full Mission Control look. Dark only."
               accentId={color}
               stylePreview="painted"
               selected={style === "painted"}
               onSelect={() => selectStyle("painted")}
             />
             <StyleChoiceCard
-              title="Minimal"
-              description="Clean CSS borders. Lighter on the eyes and faster to render."
+              title="Flat"
+              description="Warm sepia, edge-to-edge square panes, and a clearer bundled mono. The focused session glows. Dark or light."
               accentId={color}
-              stylePreview="minimal"
-              selected={style === "minimal"}
-              onSelect={() => selectStyle("minimal")}
-            />
-            <StyleChoiceCard
-              title="Noir"
-              description="Flat near-black with hairline dividers. Borders only where they mean something."
-              accentId={color}
-              stylePreview="noir"
-              selected={style === "noir"}
-              onSelect={() => selectStyle("noir")}
-            />
-            <StyleChoiceCard
-              title="Ember"
-              description="Warm sepia, edge-to-edge square panes, and a clearer bundled mono. The focused session glows."
-              accentId={color}
-              stylePreview="ember"
-              selected={style === "ember"}
-              onSelect={() => selectStyle("ember")}
+              stylePreview="flat"
+              selected={style === "flat"}
+              onSelect={() => selectStyle("flat")}
             />
           </div>
         </section>

--- a/src/components/views/ThemeSettingsPage.tsx
+++ b/src/components/views/ThemeSettingsPage.tsx
@@ -17,6 +17,7 @@ import {
   type SurfaceTint,
 } from "~/shared/surface-tint";
 import { applySurfaceTint } from "~/lib/surface-tint";
+import { useTheme, type Theme } from "~/lib/use-theme";
 import { queryKeys, useSettings } from "~/queries";
 import {
   hasCachedLaunchIntroPreference,
@@ -29,6 +30,7 @@ import { DEFAULT_SESSION_HEADER_BUTTON_VISIBILITY } from "~/shared/session-heade
 export function ThemeSettingsPage() {
   const queryClient = useQueryClient();
   const { data: settings } = useSettings();
+  const { theme, set: setTheme } = useTheme();
   const accentColor = settings?.accentColor ?? DEFAULT_ACCENT_COLOR;
   const themeStyle = settings?.themeStyle ?? DEFAULT_THEME_STYLE;
   const surfaceTint = settings?.surfaceTint ?? DEFAULT_SURFACE_TINT;
@@ -113,11 +115,11 @@ export function ThemeSettingsPage() {
 
   const setThemeStyle = async (next: ThemeStyle) => {
     const previous = queryClient.getQueryData<AppSettings>(queryKeys.settings);
-    // Ember is built around its warm terracotta accent (sampled from the
-    // reference) — default it out of the box; the user can still pick any
+    // The flat theme is built around its warm terracotta accent (sampled from
+    // the reference) — default it out of the box; the user can still pick any
     // accent afterward and it sticks.
     const nextAccent =
-      next === "ember" && accentColor !== "terracotta"
+      next === "flat" && accentColor !== "terracotta"
         ? ("terracotta" as AccentColorId)
         : accentColor;
     if (nextAccent !== accentColor) applyAccentColor(nextAccent);
@@ -160,7 +162,7 @@ export function ThemeSettingsPage() {
   return (
     <SettingsSection
       title="Theme"
-      subtitle="Pick the chrome Mission Control wears: painted pixel art, clean minimal, flat noir, or warm ember."
+      subtitle="Pick the chrome Mission Control wears: painted pixel art or the warm, flat Ember look — the latter in dark or light."
       headingLevel="h1"
     >
       <Field label="Theme style">
@@ -171,6 +173,11 @@ export function ThemeSettingsPage() {
           onChange={setThemeStyle}
         />
       </Field>
+      {themeStyle === "flat" && (
+        <Field label="Appearance">
+          <DarkLightToggle theme={theme} onChange={setTheme} />
+        </Field>
+      )}
       <Field label="Accent color">
         <AccentColorGrid
           minimal={minimalTheme}
@@ -193,25 +200,13 @@ const THEME_STYLE_OPTIONS: Array<{
   {
     value: "painted",
     label: "Painted",
-    description: "Pixel-art borders and shell imagery. The full Mission Control look.",
+    description: "Pixel-art borders and shell imagery. The full Mission Control look. Dark only.",
   },
   {
-    value: "minimal",
-    label: "Minimal",
+    value: "flat",
+    label: "Flat",
     description:
-      "Clean CSS borders and textured cards. Lighter on the eyes, faster to render.",
-  },
-  {
-    value: "noir",
-    label: "Noir",
-    description:
-      "Flat near-black surfaces with hairline dividers. Borders only where they mean something.",
-  },
-  {
-    value: "ember",
-    label: "Ember",
-    description:
-      "Warm sepia near-black with edge-to-edge square panes and a clearer bundled mono. The focused session glows.",
+      "Warm sepia near-black with edge-to-edge square panes and a clearer bundled mono. The focused session glows. Supports dark and light.",
   },
 ];
 
@@ -313,6 +308,76 @@ function ThemeStyleGrid({
   );
 }
 
+const DARK_LIGHT_OPTIONS: Record<Theme, { label: string; description: string }> = {
+  dark: { label: "Dark", description: "Deep near-black ground — the default." },
+  light: { label: "Light", description: "Warm-paper surfaces for bright rooms." },
+};
+
+/** Dark/light switch — only rendered for the flat theme (painted is dark-only).
+ *  Preference lives in localStorage via useTheme, not server settings. */
+function DarkLightToggle({
+  theme,
+  onChange,
+}: {
+  theme: Theme;
+  onChange: (next: Theme) => void;
+}) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const active = DARK_LIGHT_OPTIONS[theme];
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 16,
+        padding: "12px 14px",
+        background: "var(--surface-0)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--mm-radius, 7px)",
+      }}
+    >
+      <div>
+        <div
+          id={titleId}
+          style={{ fontSize: 13, fontWeight: 600, color: "var(--text)", marginBottom: 3 }}
+        >
+          {active.label}
+        </div>
+        <div
+          id={descriptionId}
+          style={{ fontSize: 12, color: "var(--text-dim)", lineHeight: 1.45 }}
+        >
+          {active.description}
+        </div>
+      </div>
+      <div
+        role="radiogroup"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        style={{
+          display: "inline-flex",
+          padding: 2,
+          background: "var(--surface-1)",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--mm-radius, 7px)",
+          flexShrink: 0,
+        }}
+      >
+        {(["dark", "light"] as const).map((value) => (
+          <ModeOption
+            key={value}
+            label={DARK_LIGHT_OPTIONS[value].label}
+            selected={theme === value}
+            onSelect={() => onChange(value)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 const SURFACE_TINT_OPTIONS: Record<SurfaceTint, { label: string; description: string }> = {
   off: {
     label: "Off",
@@ -325,6 +390,11 @@ const SURFACE_TINT_OPTIONS: Record<SurfaceTint, { label: string; description: st
   vivid: {
     label: "Vivid",
     description: "A clearly visible accent wash across the whole app.",
+  },
+  intense: {
+    label: "Intense",
+    description:
+      "Warm-charcoal ground — the old Ember look. Best on a warm accent like Terracotta.",
   },
 };
 

--- a/src/components/views/ThemeSettingsPage.tsx
+++ b/src/components/views/ThemeSettingsPage.tsx
@@ -170,6 +170,7 @@ export function ThemeSettingsPage() {
           style={themeStyle}
           accentColor={accentColor}
           surfaceTint={surfaceTint}
+          theme={theme}
           onChange={setThemeStyle}
         />
       </Field>
@@ -214,11 +215,13 @@ function ThemeStyleGrid({
   style,
   accentColor,
   surfaceTint,
+  theme,
   onChange,
 }: {
   style: ThemeStyle;
   accentColor: AccentColorId;
   surfaceTint: SurfaceTint;
+  theme: Theme;
   onChange: (next: ThemeStyle) => void;
 }) {
   const labelId = useId();
@@ -239,6 +242,22 @@ function ThemeStyleGrid({
       </span>
       {THEME_STYLE_OPTIONS.map((option) => {
         const selected = style === option.value;
+        const isPainted = option.value === "painted";
+        // The painted card always wears dark pixel-art chrome — even while the
+        // app is in light mode (painted is dark-only) — so its labels take fixed
+        // light-on-dark ink rather than the theme's --text, which would be
+        // near-black and unreadable on the dark frame. The flat card's chrome
+        // follows the theme, so its labels use the theme vars.
+        const labelColor = isPainted
+          ? selected
+            ? "#e8e6df"
+            : "rgba(232, 230, 223, 0.6)"
+          : selected
+            ? "var(--text)"
+            : "var(--text-dim)";
+        const descColor = isPainted
+          ? "rgba(232, 230, 223, 0.4)"
+          : "var(--text-faint)";
         // Each card wears its own theme's chrome: the painted card gets the
         // pixel-art panel frame (the CardFrame recipe, inlined so the
         // [data-minimal] flattening rules can't strip it when the flat theme
@@ -318,19 +337,20 @@ function ThemeStyleGrid({
               style={option.value}
               accentId={accentColor}
               tint={surfaceTint}
+              theme={theme}
             />
             <span style={{ display: "flex", flexDirection: "column", gap: 3 }}>
               <span
                 style={{
                   fontSize: 13,
                   fontWeight: 600,
-                  color: selected ? "var(--text)" : "var(--text-dim)",
+                  color: labelColor,
                 }}
               >
                 {option.label}
               </span>
               <span
-                style={{ fontSize: 11.5, lineHeight: 1.45, color: "var(--text-faint)" }}
+                style={{ fontSize: 11.5, lineHeight: 1.45, color: descColor }}
               >
                 {option.description}
               </span>

--- a/src/components/views/ThemeSettingsPage.tsx
+++ b/src/components/views/ThemeSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import { useId, type CSSProperties } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Field, SettingsSection } from "~/components/views/SettingsParts";
 import { AccentColorGrid } from "~/components/views/AccentColorPicker";
@@ -228,7 +228,9 @@ function ThemeStyleGrid({
       aria-labelledby={labelId}
       style={{
         display: "grid",
-        gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+        // Cap card width so the 16:10 previews stay thumbnail-sized on wide
+        // windows instead of stretching to fill the settings column.
+        gridTemplateColumns: "repeat(auto-fit, minmax(180px, 280px))",
         gap: 12,
       }}
     >
@@ -237,6 +239,42 @@ function ThemeStyleGrid({
       </span>
       {THEME_STYLE_OPTIONS.map((option) => {
         const selected = style === option.value;
+        // Each card wears its own theme's chrome: the painted card gets the
+        // pixel-art panel frame (the CardFrame recipe, inlined so the
+        // [data-minimal] flattening rules can't strip it when the flat theme
+        // is active), the flat card stays a hairline surface.
+        const paintedFrame = selected
+          ? "var(--mc-panel-focused-image)"
+          : "var(--mc-panel-image)";
+        const cardChrome: CSSProperties =
+          option.value === "painted"
+            ? {
+                // 16px frame + 0 padding = same 16px content inset as the
+                // flat card (1px border + 15px padding), so both previews
+                // render at the same size.
+                padding: 0,
+                backgroundColor: "transparent",
+                backgroundClip: "padding-box",
+                backgroundImage: `linear-gradient(rgba(3, 6, 8, 0.15), rgba(3, 6, 8, 0.15)), ${paintedFrame}`,
+                backgroundPosition: "0% 0%, 39.0625% 39.0625%",
+                backgroundSize: "auto, 200% 200%",
+                backgroundRepeat: "repeat, no-repeat",
+                borderStyle: "solid",
+                borderColor: "transparent",
+                borderWidth: 16,
+                borderImageSource: paintedFrame,
+                borderImageSlice: 48,
+                borderImageWidth: "16px",
+                borderImageRepeat: "stretch",
+                borderRadius: 0,
+              }
+            : {
+                padding: 15,
+                background: "var(--surface-1)",
+                border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
+                borderRadius: "var(--mm-radius-lg, 10px)",
+                boxShadow: selected ? "0 0 0 1px var(--accent) inset" : "none",
+              };
         return (
           <button
             key={option.value}
@@ -249,14 +287,10 @@ function ThemeStyleGrid({
               display: "flex",
               flexDirection: "column",
               gap: 10,
-              padding: 10,
               cursor: "pointer",
               textAlign: "left",
-              background: "var(--surface-1)",
-              border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
-              borderRadius: "var(--mm-radius-lg, 10px)",
-              boxShadow: selected ? "0 0 0 1px var(--accent) inset" : "none",
               transition: "border-color 0.15s, box-shadow 0.15s",
+              ...cardChrome,
             }}
           >
             {selected && (
@@ -310,7 +344,7 @@ function ThemeStyleGrid({
 
 const DARK_LIGHT_OPTIONS: Record<Theme, { label: string; description: string }> = {
   dark: { label: "Dark", description: "Deep near-black ground — the default." },
-  light: { label: "Light", description: "Warm-paper surfaces for bright rooms." },
+  light: { label: "Light", description: "Clean white surfaces for bright rooms." },
 };
 
 /** Dark/light switch — only rendered for the flat theme (painted is dark-only).

--- a/src/components/views/ThemeSettingsPage.tsx
+++ b/src/components/views/ThemeSettingsPage.tsx
@@ -2,6 +2,8 @@ import { useId } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Field, SettingsSection } from "~/components/views/SettingsParts";
 import { AccentColorGrid } from "~/components/views/AccentColorPicker";
+import { ThemeStylePreview } from "~/components/views/ThemeStylePreview";
+import { Icon } from "~/components/ui/Icon";
 import {
   applyAccentColor,
   DEFAULT_ACCENT_COLOR,
@@ -9,6 +11,12 @@ import {
 } from "~/lib/accent-colors";
 import { api, type AppSettings } from "~/lib/api";
 import { DEFAULT_THEME_STYLE, type ThemeStyle } from "~/shared/theme-style";
+import {
+  DEFAULT_SURFACE_TINT,
+  SURFACE_TINTS,
+  type SurfaceTint,
+} from "~/shared/surface-tint";
+import { applySurfaceTint } from "~/lib/surface-tint";
 import { queryKeys, useSettings } from "~/queries";
 import {
   hasCachedLaunchIntroPreference,
@@ -23,6 +31,7 @@ export function ThemeSettingsPage() {
   const { data: settings } = useSettings();
   const accentColor = settings?.accentColor ?? DEFAULT_ACCENT_COLOR;
   const themeStyle = settings?.themeStyle ?? DEFAULT_THEME_STYLE;
+  const surfaceTint = settings?.surfaceTint ?? DEFAULT_SURFACE_TINT;
   const minimalTheme = settings?.minimalTheme ?? false;
   const launchOverlayEnabled = typeof settings?.launchOverlayEnabled === "boolean"
     ? settings.launchOverlayEnabled
@@ -31,11 +40,14 @@ export function ThemeSettingsPage() {
       : false;
 
   const optimisticSettings = (
-    patch: Partial<Pick<AppSettings, "accentColor" | "themeStyle" | "minimalTheme">>,
+    patch: Partial<
+      Pick<AppSettings, "accentColor" | "themeStyle" | "surfaceTint" | "minimalTheme">
+    >,
   ): AppSettings => ({
     agentSystemBannerDisabled: settings?.agentSystemBannerDisabled ?? false,
     accentColor,
     themeStyle,
+    surfaceTint,
     minimalTheme,
     // Every patch through here writes a theme setting, which marks it chosen.
     themeChosen: true,
@@ -128,6 +140,23 @@ export function ThemeSettingsPage() {
     }
   };
 
+  const setSurfaceTint = async (next: SurfaceTint) => {
+    applySurfaceTint(next);
+    const previous = queryClient.getQueryData<AppSettings>(queryKeys.settings);
+    const optimistic = optimisticSettings({ surfaceTint: next });
+    queryClient.setQueryData(queryKeys.settings, optimistic);
+    try {
+      const updated = await api.updateSettings({ surfaceTint: next });
+      queryClient.setQueryData(queryKeys.settings, { ...optimistic, ...updated });
+    } catch (error) {
+      if (previous) {
+        queryClient.setQueryData(queryKeys.settings, previous);
+        applySurfaceTint(previous.surfaceTint ?? DEFAULT_SURFACE_TINT);
+      }
+      throw error;
+    }
+  };
+
   return (
     <SettingsSection
       title="Theme"
@@ -135,7 +164,12 @@ export function ThemeSettingsPage() {
       headingLevel="h1"
     >
       <Field label="Theme style">
-        <ThemeStyleToggle style={themeStyle} onChange={setThemeStyle} />
+        <ThemeStyleGrid
+          style={themeStyle}
+          accentColor={accentColor}
+          surfaceTint={surfaceTint}
+          onChange={setThemeStyle}
+        />
       </Field>
       <Field label="Accent color">
         <AccentColorGrid
@@ -143,6 +177,9 @@ export function ThemeSettingsPage() {
           selected={accentColor}
           onSelect={setAccentColor}
         />
+      </Field>
+      <Field label="Surface tint">
+        <SurfaceTintToggle tint={surfaceTint} onChange={setSurfaceTint} />
       </Field>
     </SettingsSection>
   );
@@ -178,17 +215,129 @@ const THEME_STYLE_OPTIONS: Array<{
   },
 ];
 
-function ThemeStyleToggle({
+function ThemeStyleGrid({
   style,
+  accentColor,
+  surfaceTint,
   onChange,
 }: {
   style: ThemeStyle;
+  accentColor: AccentColorId;
+  surfaceTint: SurfaceTint;
   onChange: (next: ThemeStyle) => void;
+}) {
+  const labelId = useId();
+  return (
+    <div
+      role="radiogroup"
+      aria-labelledby={labelId}
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+        gap: 12,
+      }}
+    >
+      <span id={labelId} style={{ display: "none" }}>
+        Theme style
+      </span>
+      {THEME_STYLE_OPTIONS.map((option) => {
+        const selected = style === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(option.value)}
+            style={{
+              position: "relative",
+              display: "flex",
+              flexDirection: "column",
+              gap: 10,
+              padding: 10,
+              cursor: "pointer",
+              textAlign: "left",
+              background: "var(--surface-1)",
+              border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
+              borderRadius: "var(--mm-radius-lg, 10px)",
+              boxShadow: selected ? "0 0 0 1px var(--accent) inset" : "none",
+              transition: "border-color 0.15s, box-shadow 0.15s",
+            }}
+          >
+            {selected && (
+              <span
+                aria-hidden
+                style={{
+                  position: "absolute",
+                  top: 8,
+                  right: 8,
+                  zIndex: 1,
+                  width: 18,
+                  height: 18,
+                  borderRadius: 999,
+                  background: "var(--accent)",
+                  color: "var(--mm-on-accent, #fff)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <Icon name="check" size={11} />
+              </span>
+            )}
+            <ThemeStylePreview
+              style={option.value}
+              accentId={accentColor}
+              tint={surfaceTint}
+            />
+            <span style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+              <span
+                style={{
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: selected ? "var(--text)" : "var(--text-dim)",
+                }}
+              >
+                {option.label}
+              </span>
+              <span
+                style={{ fontSize: 11.5, lineHeight: 1.45, color: "var(--text-faint)" }}
+              >
+                {option.description}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+const SURFACE_TINT_OPTIONS: Record<SurfaceTint, { label: string; description: string }> = {
+  off: {
+    label: "Off",
+    description: "Surfaces keep each style's exact base palette.",
+  },
+  subtle: {
+    label: "Subtle",
+    description: "A whisper of your accent in backgrounds, bars and sessions.",
+  },
+  vivid: {
+    label: "Vivid",
+    description: "A clearly visible accent wash across the whole app.",
+  },
+};
+
+function SurfaceTintToggle({
+  tint,
+  onChange,
+}: {
+  tint: SurfaceTint;
+  onChange: (next: SurfaceTint) => void;
 }) {
   const titleId = useId();
   const descriptionId = useId();
-  const active = THEME_STYLE_OPTIONS.find((option) => option.value === style)
-    ?? THEME_STYLE_OPTIONS[0]!;
+  const active = SURFACE_TINT_OPTIONS[tint];
   return (
     <div
       style={{
@@ -234,12 +383,12 @@ function ThemeStyleToggle({
           flexShrink: 0,
         }}
       >
-        {THEME_STYLE_OPTIONS.map((option) => (
+        {SURFACE_TINTS.map((value) => (
           <ModeOption
-            key={option.value}
-            label={option.label}
-            selected={style === option.value}
-            onSelect={() => onChange(option.value)}
+            key={value}
+            label={SURFACE_TINT_OPTIONS[value].label}
+            selected={tint === value}
+            onSelect={() => onChange(value)}
           />
         ))}
       </div>

--- a/src/components/views/ThemeStylePreview.tsx
+++ b/src/components/views/ThemeStylePreview.tsx
@@ -11,9 +11,9 @@ import type { SurfaceTint } from "~/shared/surface-tint";
  * and the first-launch onboarding overlay.
  *
  * Palette values are copied from the corresponding blocks in src/styles.css
- * (:root, [data-minimal], [data-noir], [data-ember]) — keep them in sync when
- * a palette is retuned. Tint percentages mirror the [data-tint] recipe blocks
- * at the bottom of styles.css.
+ * (:root for painted, [data-minimal] for flat) — keep them in sync when a
+ * palette is retuned. Tint percentages mirror the [data-tint] recipe blocks at
+ * the bottom of styles.css. The flat miniature shows its dark palette.
  */
 
 type StylePalette = {
@@ -26,10 +26,10 @@ type StylePalette = {
   border: string;
   textDim: string;
   textFaint: string;
-  /** Pane corner radius — ember is square, painted the roundest. */
+  /** Pane corner radius — flat is square, painted rounded. */
   radius: number;
   /** How the focused pane announces itself. */
-  focus: "painted" | "ring" | "hairline" | "solid";
+  focus: "painted" | "solid";
 };
 
 const STYLE_PALETTES: Record<ThemeStyle, StylePalette> = {
@@ -43,31 +43,11 @@ const STYLE_PALETTES: Record<ThemeStyle, StylePalette> = {
     radius: 6,
     focus: "painted",
   },
-  minimal: {
-    bg: "oklch(0.08 0.003 245)",
-    surface0: "oklch(0.115 0.004 245)",
-    surface1: "oklch(0.145 0.005 245)",
-    border: "oklch(0.62 0.010 245 / 0.16)",
-    textDim: "rgba(232, 230, 223, 0.6)",
-    textFaint: "rgba(232, 230, 223, 0.38)",
-    radius: 5,
-    focus: "ring",
-  },
-  noir: {
-    bg: "#0a0a0c",
-    surface0: "#0f0f12",
-    surface1: "#131317",
-    border: "rgba(255, 255, 255, 0.065)",
-    textDim: "rgba(233, 233, 236, 0.56)",
-    textFaint: "rgba(233, 233, 236, 0.33)",
-    radius: 4,
-    focus: "hairline",
-  },
-  ember: {
-    bg: "#242321",
-    surface0: "#2c2b28",
-    surface1: "#34322d",
-    border: "rgba(236, 224, 202, 0.15)",
+  flat: {
+    bg: "oklch(0.09 0.004 65)",
+    surface0: "oklch(0.125 0.005 65)",
+    surface1: "oklch(0.155 0.006 65)",
+    border: "rgba(236, 224, 202, 0.12)",
     textDim: "#c6bca8",
     textFaint: "#a89e8c",
     radius: 0,
@@ -76,12 +56,10 @@ const STYLE_PALETTES: Record<ThemeStyle, StylePalette> = {
 };
 
 // Mirrors the [data-tint] recipes in styles.css: [lo, md] percentages per
-// style × level (hi isn't needed — the mock has no raised chrome).
+// theme × level (hi isn't needed — the mock has no raised chrome).
 const TINT_RECIPES: Record<ThemeStyle, Record<SurfaceTint, [number, number]>> = {
-  painted: { off: [0, 0], subtle: [2.5, 3.5], vivid: [7, 9] },
-  minimal: { off: [0, 0], subtle: [2.5, 3.5], vivid: [7, 9] },
-  noir: { off: [0, 0], subtle: [1.5, 2], vivid: [4, 5.5] },
-  ember: { off: [0, 0], subtle: [3, 4], vivid: [7, 9] },
+  painted: { off: [0, 0], subtle: [2.5, 3.5], vivid: [7, 9], intense: [13, 16] },
+  flat: { off: [0, 0], subtle: [2.5, 3.5], vivid: [7, 9], intense: [13, 16] },
 };
 
 function mix(accent: string, pct: number, base: string): string {
@@ -100,10 +78,23 @@ export function ThemeStylePreview({
 }) {
   const accent = getAccentColor(accentId);
   const palette = STYLE_PALETTES[style];
-  const [lo, md] = TINT_RECIPES[style][tint];
-  const bg = mix(accent.value, lo, palette.bg);
-  const surface0 = mix(accent.value, md, palette.surface0);
-  const surface1 = mix(accent.value, md, palette.surface1);
+  // Flat + Intense re-binds the ground to the old Ember warm-charcoal ladder
+  // (see [data-minimal][data-theme="dark"][data-tint="intense"] in styles.css)
+  // rather than washing the near-black base — mirror that here so the miniature
+  // matches. A whisper of accent, matching the CSS recipe.
+  const flatIntense = style === "flat" && tint === "intense";
+  const base = flatIntense
+    ? { bg: "#242321", surface0: "#2c2b28", surface1: "#34322d", lo: 4, md: 5 }
+    : {
+        bg: palette.bg,
+        surface0: palette.surface0,
+        surface1: palette.surface1,
+        lo: TINT_RECIPES[style][tint][0],
+        md: TINT_RECIPES[style][tint][1],
+      };
+  const bg = mix(accent.value, base.lo, base.bg);
+  const surface0 = mix(accent.value, base.md, base.surface0);
+  const surface1 = mix(accent.value, base.md, base.surface1);
   const accentRgba = (a: number) => `rgba(${accent.rgb}, ${a})`;
 
   const focusedPaneStyle: CSSProperties =
@@ -112,20 +103,10 @@ export function ThemeStylePreview({
           border: `2px solid ${accentRgba(0.8)}`,
           boxShadow: `0 0 10px ${accentRgba(0.4)}`,
         }
-      : palette.focus === "ring"
-        ? {
-            border: `1px solid ${accentRgba(0.75)}`,
-            boxShadow: `0 0 0 2px ${accentRgba(0.22)}`,
-          }
-        : palette.focus === "hairline"
-          ? {
-              border: `1px solid ${accentRgba(0.66)}`,
-              boxShadow: `0 0 8px ${accentRgba(0.12)}`,
-            }
-          : {
-              border: `1px solid ${accent.value}`,
-              boxShadow: `0 3px 8px rgba(0, 0, 0, 0.35)`,
-            };
+      : {
+          border: `1px solid ${accent.value}`,
+          boxShadow: `0 3px 8px rgba(0, 0, 0, 0.35)`,
+        };
 
   const pane = (focused: boolean, lines: number[]) => (
     <div

--- a/src/components/views/ThemeStylePreview.tsx
+++ b/src/components/views/ThemeStylePreview.tsx
@@ -1,0 +1,286 @@
+import type { CSSProperties } from "react";
+import { getAccentColor, type AccentColorId } from "~/lib/accent-colors";
+import type { ThemeStyle } from "~/shared/theme-style";
+import type { SurfaceTint } from "~/shared/surface-tint";
+
+/**
+ * Live-rendered miniature of the app (title bar, session grid with a focused
+ * pane, status bar) drawn with a style's real palette plus the currently
+ * selected accent and surface tint — so the user sees what each theme style
+ * does to the whole UI before committing. Shared by the Theme settings page
+ * and the first-launch onboarding overlay.
+ *
+ * Palette values are copied from the corresponding blocks in src/styles.css
+ * (:root, [data-minimal], [data-noir], [data-ember]) — keep them in sync when
+ * a palette is retuned. Tint percentages mirror the [data-tint] recipe blocks
+ * at the bottom of styles.css.
+ */
+
+type StylePalette = {
+  /** Page ground behind the panes. */
+  bg: string;
+  /** Session pane / card surface. */
+  surface0: string;
+  /** Header / status-bar surface. */
+  surface1: string;
+  border: string;
+  textDim: string;
+  textFaint: string;
+  /** Pane corner radius — ember is square, painted the roundest. */
+  radius: number;
+  /** How the focused pane announces itself. */
+  focus: "painted" | "ring" | "hairline" | "solid";
+};
+
+const STYLE_PALETTES: Record<ThemeStyle, StylePalette> = {
+  painted: {
+    bg: "#000000",
+    surface0: "#0e1013",
+    surface1: "#14171b",
+    border: "rgba(255, 255, 255, 0.06)",
+    textDim: "rgba(232, 230, 223, 0.6)",
+    textFaint: "rgba(232, 230, 223, 0.38)",
+    radius: 6,
+    focus: "painted",
+  },
+  minimal: {
+    bg: "oklch(0.08 0.003 245)",
+    surface0: "oklch(0.115 0.004 245)",
+    surface1: "oklch(0.145 0.005 245)",
+    border: "oklch(0.62 0.010 245 / 0.16)",
+    textDim: "rgba(232, 230, 223, 0.6)",
+    textFaint: "rgba(232, 230, 223, 0.38)",
+    radius: 5,
+    focus: "ring",
+  },
+  noir: {
+    bg: "#0a0a0c",
+    surface0: "#0f0f12",
+    surface1: "#131317",
+    border: "rgba(255, 255, 255, 0.065)",
+    textDim: "rgba(233, 233, 236, 0.56)",
+    textFaint: "rgba(233, 233, 236, 0.33)",
+    radius: 4,
+    focus: "hairline",
+  },
+  ember: {
+    bg: "#242321",
+    surface0: "#2c2b28",
+    surface1: "#34322d",
+    border: "rgba(236, 224, 202, 0.15)",
+    textDim: "#c6bca8",
+    textFaint: "#a89e8c",
+    radius: 0,
+    focus: "solid",
+  },
+};
+
+// Mirrors the [data-tint] recipes in styles.css: [lo, md] percentages per
+// style × level (hi isn't needed — the mock has no raised chrome).
+const TINT_RECIPES: Record<ThemeStyle, Record<SurfaceTint, [number, number]>> = {
+  painted: { off: [0, 0], subtle: [2.5, 3.5], vivid: [7, 9] },
+  minimal: { off: [0, 0], subtle: [2.5, 3.5], vivid: [7, 9] },
+  noir: { off: [0, 0], subtle: [1.5, 2], vivid: [4, 5.5] },
+  ember: { off: [0, 0], subtle: [3, 4], vivid: [7, 9] },
+};
+
+function mix(accent: string, pct: number, base: string): string {
+  if (pct <= 0) return base;
+  return `color-mix(in srgb, ${accent} ${pct}%, ${base})`;
+}
+
+export function ThemeStylePreview({
+  style,
+  accentId,
+  tint,
+}: {
+  style: ThemeStyle;
+  accentId: AccentColorId;
+  tint: SurfaceTint;
+}) {
+  const accent = getAccentColor(accentId);
+  const palette = STYLE_PALETTES[style];
+  const [lo, md] = TINT_RECIPES[style][tint];
+  const bg = mix(accent.value, lo, palette.bg);
+  const surface0 = mix(accent.value, md, palette.surface0);
+  const surface1 = mix(accent.value, md, palette.surface1);
+  const accentRgba = (a: number) => `rgba(${accent.rgb}, ${a})`;
+
+  const focusedPaneStyle: CSSProperties =
+    palette.focus === "painted"
+      ? {
+          border: `2px solid ${accentRgba(0.8)}`,
+          boxShadow: `0 0 10px ${accentRgba(0.4)}`,
+        }
+      : palette.focus === "ring"
+        ? {
+            border: `1px solid ${accentRgba(0.75)}`,
+            boxShadow: `0 0 0 2px ${accentRgba(0.22)}`,
+          }
+        : palette.focus === "hairline"
+          ? {
+              border: `1px solid ${accentRgba(0.66)}`,
+              boxShadow: `0 0 8px ${accentRgba(0.12)}`,
+            }
+          : {
+              border: `1px solid ${accent.value}`,
+              boxShadow: `0 3px 8px rgba(0, 0, 0, 0.35)`,
+            };
+
+  const pane = (focused: boolean, lines: number[]) => (
+    <div
+      style={{
+        flex: 1,
+        minWidth: 0,
+        display: "flex",
+        flexDirection: "column",
+        gap: 3,
+        padding: 5,
+        background: surface0,
+        border: `1px solid ${palette.border}`,
+        borderRadius: palette.radius,
+        ...(focused ? focusedPaneStyle : null),
+      }}
+    >
+      {/* Pane header: title stub + status dot (accent on the focused pane). */}
+      <div style={{ display: "flex", alignItems: "center", gap: 3 }}>
+        <span
+          style={{
+            width: "40%",
+            height: 3,
+            borderRadius: 2,
+            background: focused ? palette.textDim : palette.textFaint,
+          }}
+        />
+        <span
+          style={{
+            marginLeft: "auto",
+            width: 4,
+            height: 4,
+            borderRadius: 999,
+            background: focused ? accent.value : palette.textFaint,
+          }}
+        />
+      </div>
+      {/* Terminal line stubs; the focused pane shows an accent prompt line. */}
+      {lines.map((width, i) => (
+        <span
+          key={i}
+          style={{
+            width: `${width}%`,
+            height: 2,
+            borderRadius: 2,
+            background:
+              focused && i === lines.length - 1
+                ? accentRgba(0.85)
+                : palette.textFaint,
+          }}
+        />
+      ))}
+    </div>
+  );
+
+  return (
+    <div
+      aria-hidden
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        width: "100%",
+        aspectRatio: "16 / 10",
+        padding: 6,
+        background: bg,
+        border: `1px solid ${palette.border}`,
+        borderRadius: palette.radius + 2,
+        // Painted's shell frame, hinted as an accent-tinted outer edge.
+        ...(style === "painted"
+          ? { boxShadow: `inset 0 0 0 2px ${accentRgba(0.35)}` }
+          : null),
+      }}
+    >
+      {/* Title bar: traffic lights + an accent action chip on the right. */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 3,
+          padding: "3px 5px",
+          background: surface1,
+          border: `1px solid ${palette.border}`,
+          borderRadius: palette.radius,
+        }}
+      >
+        {[0, 1, 2].map((i) => (
+          <span
+            key={i}
+            style={{
+              width: 4,
+              height: 4,
+              borderRadius: 999,
+              background: palette.textFaint,
+            }}
+          />
+        ))}
+        <span
+          style={{
+            marginLeft: "auto",
+            width: 18,
+            height: 5,
+            borderRadius: palette.radius === 0 ? 0 : 2,
+            background: accent.value,
+          }}
+        />
+      </div>
+      {/* Session grid: 2×2 panes, top-left focused. */}
+      <div style={{ flex: 1, display: "flex", gap: 4, minHeight: 0 }}>
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 4 }}>
+          {pane(true, [70, 55, 62])}
+          {pane(false, [58, 44])}
+        </div>
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 4 }}>
+          {pane(false, [64, 50])}
+          {pane(false, [52, 66])}
+        </div>
+      </div>
+      {/* Status bar. */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 4,
+          padding: "2px 5px",
+          background: surface1,
+          border: `1px solid ${palette.border}`,
+          borderRadius: palette.radius,
+        }}
+      >
+        <span
+          style={{
+            width: 5,
+            height: 5,
+            borderRadius: 999,
+            background: accentRgba(0.9),
+          }}
+        />
+        <span
+          style={{
+            width: "30%",
+            height: 2,
+            borderRadius: 2,
+            background: palette.textFaint,
+          }}
+        />
+        <span
+          style={{
+            marginLeft: "auto",
+            width: "18%",
+            height: 2,
+            borderRadius: 2,
+            background: palette.textFaint,
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/views/ThemeStylePreview.tsx
+++ b/src/components/views/ThemeStylePreview.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties } from "react";
 import { getAccentColor, type AccentColorId } from "~/lib/accent-colors";
 import type { ThemeStyle } from "~/shared/theme-style";
 import type { SurfaceTint } from "~/shared/surface-tint";
+import type { Theme } from "~/lib/use-theme";
 
 /**
  * Live-rendered miniature of the app (title bar, session grid with a focused
@@ -13,7 +14,8 @@ import type { SurfaceTint } from "~/shared/surface-tint";
  * Palette values are copied from the corresponding blocks in src/styles.css
  * (:root for painted, [data-minimal] for flat) — keep them in sync when a
  * palette is retuned. Tint percentages mirror the [data-tint] recipe blocks at
- * the bottom of styles.css. The flat miniature shows its dark palette.
+ * the bottom of styles.css. Painted is dark-only; the flat miniature follows
+ * the current light/dark appearance ([data-minimal][data-theme="light"]).
  */
 
 type StylePalette = {
@@ -55,6 +57,20 @@ const STYLE_PALETTES: Record<ThemeStyle, StylePalette> = {
   },
 };
 
+// Flat's light appearance — mirrors [data-minimal][data-theme="light"] in
+// styles.css so the miniature matches the app when light mode is picked.
+// (Painted is dark-only, so it has no light variant.)
+const FLAT_LIGHT_PALETTE: StylePalette = {
+  bg: "#f4f4f6",
+  surface0: "#ffffff",
+  surface1: "#fafafb",
+  border: "rgba(18, 22, 33, 0.09)",
+  textDim: "rgba(23, 24, 28, 0.6)",
+  textFaint: "rgba(23, 24, 28, 0.4)",
+  radius: 0,
+  focus: "solid",
+};
+
 // Mirrors the [data-tint] recipes in styles.css: [lo, md] percentages per
 // theme × level (hi isn't needed — the mock has no raised chrome).
 const TINT_RECIPES: Record<ThemeStyle, Record<SurfaceTint, [number, number]>> = {
@@ -71,18 +87,24 @@ export function ThemeStylePreview({
   style,
   accentId,
   tint,
+  theme = "dark",
 }: {
   style: ThemeStyle;
   accentId: AccentColorId;
   tint: SurfaceTint;
+  /** Current light/dark appearance. Painted is dark-only; flat follows this. */
+  theme?: Theme;
 }) {
   const accent = getAccentColor(accentId);
-  const palette = STYLE_PALETTES[style];
-  // Flat + Intense re-binds the ground to the old Ember warm-charcoal ladder
-  // (see [data-minimal][data-theme="dark"][data-tint="intense"] in styles.css)
-  // rather than washing the near-black base — mirror that here so the miniature
-  // matches. A whisper of accent, matching the CSS recipe.
-  const flatIntense = style === "flat" && tint === "intense";
+  // Painted is dark-only; flat swaps to its paper palette in light mode.
+  const lightFlat = style === "flat" && theme === "light";
+  const palette = lightFlat ? FLAT_LIGHT_PALETTE : STYLE_PALETTES[style];
+  // Flat + Intense (DARK only) re-binds the ground to the Ember warm-charcoal
+  // ladder (see [data-minimal][data-theme="dark"][data-tint="intense"] in
+  // styles.css) rather than washing the near-black base — mirror that here so
+  // the miniature matches. Flat-light + Intense keeps its paper ground and
+  // takes the generic wash below. A whisper of accent, matching the CSS recipe.
+  const flatIntense = style === "flat" && tint === "intense" && theme === "dark";
   const base = flatIntense
     ? { bg: "#242321", surface0: "#2c2b28", surface1: "#34322d", lo: 4, md: 5 }
     : {
@@ -105,7 +127,9 @@ export function ThemeStylePreview({
         }
       : {
           border: `1px solid ${accent.value}`,
-          boxShadow: `0 3px 8px rgba(0, 0, 0, 0.35)`,
+          boxShadow: lightFlat
+            ? `0 2px 6px rgba(18, 22, 33, 0.14)`
+            : `0 3px 8px rgba(0, 0, 0, 0.35)`,
         };
 
   const pane = (focused: boolean, lines: number[]) => (

--- a/src/components/views/UserTerminalPanel.tsx
+++ b/src/components/views/UserTerminalPanel.tsx
@@ -261,14 +261,13 @@ export function UserTerminalPanel() {
                         : `Open terminal ${s.terminal.name}`
                     }
                     aria-pressed={panelOpen ? !hidden : undefined}
+                    className="mc-terminal-tab"
+                    data-active={active || undefined}
                     style={{
                       display: "inline-flex",
                       alignItems: "center",
                       gap: 6,
                       padding: "3px 9px",
-                      background: active ? "var(--surface-1)" : "transparent",
-                      border: `1px solid ${active ? "var(--accent)" : "var(--border)"}`,
-                      borderRadius: 4,
                       fontFamily: "var(--mono)",
                       fontSize: 11,
                       color: dimmed ? "var(--text-faint)" : "var(--text)",

--- a/src/lib/__tests__/surface-tint.test.ts
+++ b/src/lib/__tests__/surface-tint.test.ts
@@ -41,6 +41,7 @@ describe("surface-tint", () => {
     expect(isSurfaceTint("off")).toBe(true);
     expect(isSurfaceTint("subtle")).toBe(true);
     expect(isSurfaceTint("vivid")).toBe(true);
+    expect(isSurfaceTint("intense")).toBe(true);
     expect(isSurfaceTint("neon")).toBe(false);
     expect(isSurfaceTint(null)).toBe(false);
     expect(isSurfaceTint(1)).toBe(false);

--- a/src/lib/__tests__/surface-tint.test.ts
+++ b/src/lib/__tests__/surface-tint.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isSurfaceTint } from "~/shared/surface-tint";
+
+function mockWindowStorage() {
+  const store = new Map<string, string>();
+  const previousWindow = globalThis.window;
+
+  globalThis.window = {
+    localStorage: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+    },
+  } as unknown as Window & typeof globalThis;
+
+  return {
+    store,
+    restore() {
+      globalThis.window = previousWindow;
+    },
+  };
+}
+
+describe("surface-tint", () => {
+  let storage: ReturnType<typeof mockWindowStorage>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    storage = mockWindowStorage();
+  });
+
+  afterEach(() => {
+    storage.restore();
+  });
+
+  it("guards tint values", () => {
+    expect(isSurfaceTint("off")).toBe(true);
+    expect(isSurfaceTint("subtle")).toBe(true);
+    expect(isSurfaceTint("vivid")).toBe(true);
+    expect(isSurfaceTint("neon")).toBe(false);
+    expect(isSurfaceTint(null)).toBe(false);
+    expect(isSurfaceTint(1)).toBe(false);
+  });
+
+  it("reads subtle when no preference is cached", async () => {
+    const mod = await import("../surface-tint");
+    expect(mod.readCachedSurfaceTint()).toBe("subtle");
+  });
+
+  it("ignores an invalid cached tint", async () => {
+    const mod = await import("../surface-tint");
+    storage.store.set(mod.SURFACE_TINT_CACHE_KEY, "neon");
+    expect(mod.readCachedSurfaceTint()).toBe("subtle");
+  });
+
+  it("caches the applied tint", async () => {
+    const mod = await import("../surface-tint");
+    // In the node test env `document` is undefined, so applySurfaceTint only
+    // touches localStorage — exactly the branch we want to assert.
+    mod.applySurfaceTint("vivid");
+    expect(storage.store.get(mod.SURFACE_TINT_CACHE_KEY)).toBe("vivid");
+    expect(mod.readCachedSurfaceTint()).toBe("vivid");
+  });
+
+  it("caches off (attribute-less) explicitly", async () => {
+    const mod = await import("../surface-tint");
+    mod.applySurfaceTint("vivid");
+    mod.applySurfaceTint("off");
+    expect(storage.store.get(mod.SURFACE_TINT_CACHE_KEY)).toBe("off");
+    expect(mod.readCachedSurfaceTint()).toBe("off");
+  });
+});

--- a/src/lib/__tests__/terminal-options.test.ts
+++ b/src/lib/__tests__/terminal-options.test.ts
@@ -38,16 +38,16 @@ describe("terminal options", () => {
     expect(getTerminalColorScheme()).toBe("dark");
   });
 
-  it("swaps in the warm high-contrast ANSI ramp when ember is active", () => {
+  it("swaps in the warm high-contrast ANSI ramp when the flat theme is active (dark)", () => {
     vi.stubGlobal("document", {
       documentElement: {
-        getAttribute: (name: string) => (name === "data-ember" ? "true" : null),
+        getAttribute: (name: string) => (name === "data-minimal" ? "true" : null),
       },
     });
     try {
       const theme = createTerminalTheme();
       // brightBlack is what CLIs use for dim/secondary text — the stock
-      // #22262c is the same tone as ember's #2b2a27 ground (≈1.1:1).
+      // #22262c is the same tone as the flat theme's #2b2a27 ground (≈1.1:1).
       expect(theme).toMatchObject({
         background: "#2b2a27",
         foreground: "#e9e3d5",
@@ -60,7 +60,23 @@ describe("terminal options", () => {
     }
   });
 
-  it("keeps the stock dark ramp when ember is not active", () => {
+  it("uses the stock light ramp for the flat theme in light mode", () => {
+    vi.stubGlobal("document", {
+      documentElement: {
+        getAttribute: (name: string) => (name === "data-minimal" ? "true" : null),
+      },
+    });
+    try {
+      // Light overrides the warm dark ramp — flatDark requires colorScheme dark.
+      expect(createTerminalTheme({ colorScheme: "light" }).brightBlack).not.toBe(
+        "#8f8577",
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("keeps the stock dark ramp when the flat theme is not active", () => {
     expect(createTerminalTheme().brightBlack).toBe("#22262c");
   });
 

--- a/src/lib/__tests__/theme-style.test.ts
+++ b/src/lib/__tests__/theme-style.test.ts
@@ -41,10 +41,10 @@ describe("theme-style", () => {
     expect(mod.readCachedThemeStyle()).toBe("painted");
   });
 
-  it("falls back to the legacy minimal flag when only it is cached", async () => {
+  it("falls back to the legacy minimal flag (→ flat) when only it is cached", async () => {
     const mod = await import("../theme-style");
     storage.store.set(mod.MINIMAL_CACHE_KEY, "1");
-    expect(mod.readCachedThemeStyle()).toBe("minimal");
+    expect(mod.readCachedThemeStyle()).toBe("flat");
   });
 
   it("prefers the style cache over the legacy flag", async () => {
@@ -54,33 +54,33 @@ describe("theme-style", () => {
     expect(mod.readCachedThemeStyle()).toBe("painted");
   });
 
+  it("migrates a legacy cached style (minimal / noir / ember) to flat", async () => {
+    const mod = await import("../theme-style");
+    for (const legacy of ["minimal", "noir", "ember"]) {
+      storage.store.set(mod.THEME_STYLE_CACHE_KEY, legacy);
+      expect(mod.readCachedThemeStyle()).toBe("flat");
+    }
+  });
+
   it("ignores an invalid cached style", async () => {
     const mod = await import("../theme-style");
     storage.store.set(mod.THEME_STYLE_CACHE_KEY, "vaporwave");
     expect(mod.readCachedThemeStyle()).toBe("painted");
   });
 
-  it("caches noir and mirrors the legacy flag on", async () => {
+  it("caches flat and mirrors the legacy flag on", async () => {
     const mod = await import("../theme-style");
     // In the node test env `document` is undefined, so applyThemeStyle only
     // touches localStorage — exactly the branch we want to assert.
-    mod.applyThemeStyle("noir");
-    expect(storage.store.get(mod.THEME_STYLE_CACHE_KEY)).toBe("noir");
+    mod.applyThemeStyle("flat");
+    expect(storage.store.get(mod.THEME_STYLE_CACHE_KEY)).toBe("flat");
     expect(storage.store.get(mod.MINIMAL_CACHE_KEY)).toBe("1");
-    expect(mod.readCachedThemeStyle()).toBe("noir");
-  });
-
-  it("caches ember and mirrors the legacy flag on", async () => {
-    const mod = await import("../theme-style");
-    mod.applyThemeStyle("ember");
-    expect(storage.store.get(mod.THEME_STYLE_CACHE_KEY)).toBe("ember");
-    expect(storage.store.get(mod.MINIMAL_CACHE_KEY)).toBe("1");
-    expect(mod.readCachedThemeStyle()).toBe("ember");
+    expect(mod.readCachedThemeStyle()).toBe("flat");
   });
 
   it("caches painted and mirrors the legacy flag off", async () => {
     const mod = await import("../theme-style");
-    mod.applyThemeStyle("minimal");
+    mod.applyThemeStyle("flat");
     mod.applyThemeStyle("painted");
     expect(storage.store.get(mod.THEME_STYLE_CACHE_KEY)).toBe("painted");
     expect(storage.store.get(mod.MINIMAL_CACHE_KEY)).toBe("0");

--- a/src/lib/__tests__/use-theme.test.ts
+++ b/src/lib/__tests__/use-theme.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Exercises the dark/light preference logic without rendering the React hook
+// (the test env is node, no DOM renderer): readCachedTheme() and the way
+// applyThemeStyle reconciles `data-theme` — painted is always dark, the flat
+// theme honours the stored preference.
+
+function mockDom() {
+  const store = new Map<string, string>();
+  const attrs = new Map<string, string>();
+  const previousWindow = globalThis.window;
+
+  globalThis.window = {
+    localStorage: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+      removeItem: (key: string) => void store.delete(key),
+    },
+  } as unknown as Window & typeof globalThis;
+
+  vi.stubGlobal("document", {
+    documentElement: {
+      getAttribute: (name: string) => attrs.get(name) ?? null,
+      setAttribute: (name: string, value: string) => void attrs.set(name, value),
+      removeAttribute: (name: string) => void attrs.delete(name),
+    },
+  });
+
+  return {
+    store,
+    attrs,
+    restore() {
+      globalThis.window = previousWindow;
+      vi.unstubAllGlobals();
+    },
+  };
+}
+
+describe("use-theme + data-theme reconciliation", () => {
+  let dom: ReturnType<typeof mockDom>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    dom = mockDom();
+  });
+
+  afterEach(() => {
+    dom.restore();
+  });
+
+  it("defaults the cached theme to dark and reads a stored light preference", async () => {
+    const { readCachedTheme } = await import("../use-theme");
+    expect(readCachedTheme()).toBe("dark");
+    dom.store.set("mc.theme", "light");
+    expect(readCachedTheme()).toBe("light");
+  });
+
+  it("applies the stored light preference when the flat theme is selected", async () => {
+    dom.store.set("mc.theme", "light");
+    const { applyThemeStyle } = await import("../theme-style");
+    applyThemeStyle("flat");
+    expect(dom.attrs.get("data-minimal")).toBe("true");
+    expect(dom.attrs.get("data-theme")).toBe("light");
+  });
+
+  it("forces dark for the painted theme even with a stored light preference", async () => {
+    dom.store.set("mc.theme", "light");
+    const { applyThemeStyle } = await import("../theme-style");
+    applyThemeStyle("painted");
+    expect(dom.attrs.has("data-minimal")).toBe(false);
+    expect(dom.attrs.get("data-theme")).toBe("dark");
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,6 +33,7 @@ import type {
 } from "~/shared/ui-preferences";
 import type { TerminalZoomLevel } from "~/shared/terminal-zoom";
 import type { ThemeStyle } from "~/shared/theme-style";
+import type { SurfaceTint } from "~/shared/surface-tint";
 import type {
   MarkdownRefineRequest,
   MarkdownRefineResponse,
@@ -64,6 +65,8 @@ export type AppSettings = {
   accentColor: AccentColorId;
   /** Which chrome to render: painted (pixel art), minimal, or noir (flat). */
   themeStyle: ThemeStyle;
+  /** How much accent to mix into surface tokens (off / subtle / vivid). */
+  surfaceTint: SurfaceTint;
   /** Derived server-side: true when themeStyle renders clean CSS chrome. */
   minimalTheme: boolean;
   /**
@@ -567,6 +570,7 @@ export const api = {
         | "agentSystemBannerDisabled"
         | "accentColor"
         | "themeStyle"
+        | "surfaceTint"
         | "minimalTheme"
         | "mouseGradientDisabled"
         | "sessionFinishToastEnabled"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -63,7 +63,8 @@ import { pruneStoredSessionFinishNotifications } from "~/lib/session-notificatio
 export type AppSettings = {
   agentSystemBannerDisabled: boolean;
   accentColor: AccentColorId;
-  /** Which chrome to render: painted (pixel art), minimal, or noir (flat). */
+  /** Which chrome to render: painted (pixel art, dark-only) or flat (clean,
+   *  Ember character, supports dark/light). */
   themeStyle: ThemeStyle;
   /** How much accent to mix into surface tokens (off / subtle / vivid). */
   surfaceTint: SurfaceTint;

--- a/src/lib/session-warm-pool.ts
+++ b/src/lib/session-warm-pool.ts
@@ -41,6 +41,12 @@ export function sessionCreateSignature(payload: SessionCreatePayload, cwd: strin
     payload.branch,
     payload.skipPermissions ? "1" : "0",
     payload.bareSession ? "1" : "0",
+    // A warm slot pre-spawns the agent PTY with the theme captured at prepare
+    // time (COLORFGBG / MC_THEME). Include the theme so switching light/dark
+    // invalidates a slot warmed under the old theme — otherwise a new session
+    // would claim a stale-theme agent. On claim, takeSessionWarmSlot recomputes
+    // this fresh, so a theme mismatch falls through to a cold spawn.
+    getTerminalColorScheme(),
   ].join("\0");
 }
 

--- a/src/lib/surface-tint.ts
+++ b/src/lib/surface-tint.ts
@@ -1,0 +1,49 @@
+import {
+  DEFAULT_SURFACE_TINT,
+  isSurfaceTint,
+  type SurfaceTint,
+} from "~/shared/surface-tint";
+
+export type { SurfaceTint } from "~/shared/surface-tint";
+
+// Cache key shared with the pre-hydration script in __root.tsx so the next
+// launch can apply the user's tint before React mounts (no untinted flash).
+// Keep in sync with PRE_HYDRATION_THEME_SCRIPT.
+export const SURFACE_TINT_CACHE_KEY = "mc:surfaceTint";
+
+/** The cached tint preference, defaulting to subtle. */
+export function readCachedSurfaceTint(): SurfaceTint {
+  if (typeof window === "undefined") return DEFAULT_SURFACE_TINT;
+  try {
+    const value = window.localStorage.getItem(SURFACE_TINT_CACHE_KEY);
+    return isSurfaceTint(value) ? value : DEFAULT_SURFACE_TINT;
+  } catch {
+    return DEFAULT_SURFACE_TINT;
+  }
+}
+
+/**
+ * Apply a surface tint to the document and cache the choice so the
+ * pre-hydration script can restore it on the next launch.
+ *
+ * DOM contract: "off" is the absence of the attribute — every surface token
+ * computes to its style's exact base value. "subtle"/"vivid" set
+ * `data-tint`, which the per-style blocks in styles.css read to raise the
+ * accent percentage mixed into --bg/--surface-*\/--terminal-bg.
+ */
+export function applySurfaceTint(tint: SurfaceTint): void {
+  if (typeof document !== "undefined") {
+    const root = document.documentElement;
+    if (tint === "off") {
+      root.removeAttribute("data-tint");
+    } else {
+      root.setAttribute("data-tint", tint);
+    }
+  }
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(SURFACE_TINT_CACHE_KEY, tint);
+  } catch {
+    // ignore quota / privacy-mode errors
+  }
+}

--- a/src/lib/terminal-options.ts
+++ b/src/lib/terminal-options.ts
@@ -83,10 +83,13 @@ const EMBER_TERMINAL_THEME: TerminalTheme = {
   brightWhite: "#f7f2e7",
 };
 
-function isEmberActive(): boolean {
+// The flat theme (data-minimal) carries the warm sepia terminal ramp + bundled
+// JetBrains Mono face and fills the terminal to the pane edge. (In light mode
+// the flat theme uses the standard light ramp — see createTerminalTheme.)
+function isFlatActive(): boolean {
   return (
     typeof document !== "undefined" &&
-    document.documentElement.getAttribute("data-ember") === "true"
+    document.documentElement.getAttribute("data-minimal") === "true"
   );
 }
 
@@ -151,22 +154,22 @@ export function createTerminalTheme({
   colorScheme?: TerminalColorScheme;
   cursorColor?: string;
 } = {}): TerminalTheme {
-  const ember = colorScheme === "dark" && isEmberActive();
-  const base = ember
+  const flatDark = colorScheme === "dark" && isFlatActive();
+  const base = flatDark
     ? { ...TERMINAL_THEMES.dark, ...EMBER_TERMINAL_THEME }
     : TERMINAL_THEMES[colorScheme];
-  // Honor --terminal-bg from CSS — minimal mode mixes the accent into the
-  // ground at 10%, so the terminal carries a hint of the active theme.
+  // Honor --terminal-bg from CSS — the flat theme mixes the accent into the
+  // ground, so the terminal carries a hint of the active theme.
   const background = getCurrentTerminalBackground(base.background ?? "#050607");
   return {
     ...base,
     background,
     cursor: cursorColor,
-    // The accent selection wash needs more alpha on ember's mid-gray ground
-    // than on the near-black grounds to stay visible.
+    // The accent selection wash needs more alpha on the flat theme's mid-gray
+    // ground than on the near-black painted ground to stay visible.
     selectionBackground: withAlpha(
       getCurrentAccentColor(),
-      colorScheme === "light" ? 0.26 : ember ? 0.3 : 0.22
+      colorScheme === "light" ? 0.26 : flatDark ? 0.3 : 0.22
     ),
   };
 }
@@ -181,12 +184,14 @@ export function watchTerminalColorScheme(
   const styleFlags = () => {
     const root = document.documentElement;
     const minimal = root.getAttribute("data-minimal") === "true" ? "1" : "0";
-    const noir = root.getAttribute("data-noir") === "true" ? "1" : "0";
-    const ember = root.getAttribute("data-ember") === "true" ? "1" : "0";
-    return `${minimal}${noir}${ember}`;
+    // Surface tint feeds --terminal-bg (the flat theme mixes accent into the
+    // ground, and Intense re-binds it to the warm-charcoal ladder), so a tint
+    // change must re-theme the running terminal to match the chrome.
+    const tint = root.getAttribute("data-tint") ?? "off";
+    return `${minimal}:${tint}`;
   };
-  // Font is part of the key so switching to/from a theme with a bundled face
-  // (ember) re-fires and the consumer can restyle + refit the terminal.
+  // Font is part of the key so switching to/from the flat theme (which ships a
+  // bundled face) re-fires and the consumer can restyle + refit the terminal.
   const currentKey = () =>
     `${getTerminalColorScheme()}:${getCurrentAccentColor()}:${getCurrentTerminalFont()}:${styleFlags()}`;
   let previous = currentKey();
@@ -198,7 +203,7 @@ export function watchTerminalColorScheme(
   });
   observer.observe(document.documentElement, {
     attributes: true,
-    attributeFilter: ["data-theme", "data-minimal", "data-noir", "data-ember", "style"],
+    attributeFilter: ["data-theme", "data-minimal", "data-tint", "style"],
   });
   return () => observer.disconnect();
 }
@@ -275,11 +280,11 @@ function restoreTerminalViewport(
   term.scrollToLine?.(snapshot.viewportY);
 }
 
-// Ember lets the terminal fill to the pane edge. xterm's FitAddon always
-// reserves the scrollbar width — `overviewRuler?.width || 14` = 14px — on the
-// right when scrollback is on, even though xterm 6's scrollbar is an overlay
-// that needs no gutter. That reserved 14px is the visible strip between the
-// terminal text and the pane edge. In ember we recompute cols reserving 0 so
+// The flat theme lets the terminal fill to the pane edge. xterm's FitAddon
+// always reserves the scrollbar width — `overviewRuler?.width || 14` = 14px —
+// on the right when scrollback is on, even though xterm 6's scrollbar is an
+// overlay that needs no gutter. That reserved 14px is the visible strip between
+// the terminal text and the pane edge. In flat we recompute cols reserving 0 so
 // the content reaches the edge (the overlay scrollbar floats over the last
 // column when it appears, which is fine); every other theme keeps the addon's
 // default. Mirrors FitAddon.proposeDimensions via the same internals, with a
@@ -288,7 +293,7 @@ function fitFillingScrollbarGutter(
   term: { cols: number; rows: number } & ScrollPreservingTerminal,
   fit: { fit: () => void },
 ): void {
-  if (!isEmberActive()) {
+  if (!isFlatActive()) {
     fit.fit();
     return;
   }

--- a/src/lib/theme-style.ts
+++ b/src/lib/theme-style.ts
@@ -3,7 +3,7 @@ import {
   normalizeThemeStyle,
   type ThemeStyle,
 } from "~/shared/theme-style";
-import { readCachedTheme } from "~/lib/use-theme";
+import { readCachedTheme, syncWindowBackground } from "~/lib/use-theme";
 
 export { isCleanChromeStyle } from "~/shared/theme-style";
 export type { ThemeStyle } from "~/shared/theme-style";
@@ -54,6 +54,7 @@ export function applyThemeStyle(style: ThemeStyle): void {
       root.setAttribute("data-minimal", "true");
       root.setAttribute("data-theme", readCachedTheme());
     }
+    syncWindowBackground();
   }
   if (typeof window === "undefined") return;
   try {

--- a/src/lib/theme-style.ts
+++ b/src/lib/theme-style.ts
@@ -1,8 +1,9 @@
 import {
   DEFAULT_THEME_STYLE,
-  isThemeStyle,
+  normalizeThemeStyle,
   type ThemeStyle,
 } from "~/shared/theme-style";
+import { readCachedTheme } from "~/lib/use-theme";
 
 export { isCleanChromeStyle } from "~/shared/theme-style";
 export type { ThemeStyle } from "~/shared/theme-style";
@@ -16,14 +17,17 @@ export const THEME_STYLE_CACHE_KEY = "mc:themeStyle";
 // (an approximation of) the choice.
 export const MINIMAL_CACHE_KEY = "mc:minimal";
 
-/** The cached style preference, falling back to the legacy minimal flag. */
+/**
+ * The cached style preference, migrating any legacy value (minimal / noir /
+ * ember) to "flat" and falling back to the legacy minimal flag.
+ */
 export function readCachedThemeStyle(): ThemeStyle {
   if (typeof window === "undefined") return DEFAULT_THEME_STYLE;
   try {
     const value = window.localStorage.getItem(THEME_STYLE_CACHE_KEY);
-    if (isThemeStyle(value)) return value;
+    if (value !== null) return normalizeThemeStyle(value);
     return window.localStorage.getItem(MINIMAL_CACHE_KEY) === "1"
-      ? "minimal"
+      ? "flat"
       : DEFAULT_THEME_STYLE;
   } catch {
     return DEFAULT_THEME_STYLE;
@@ -34,28 +38,21 @@ export function readCachedThemeStyle(): ThemeStyle {
  * Apply a theme style to the document and cache the choice so the
  * pre-hydration script can restore it on the next launch.
  *
- * DOM contract: painted mode is the absence of every attribute. Minimal sets
- * `data-minimal`. Noir and ember set `data-minimal` too (both build on
- * minimal's clean-CSS chrome) and layer `data-noir` / `data-ember` on top for
- * their own flat palette, corners, and (ember) bundled font.
+ * DOM contract: painted mode is the absence of `data-minimal`; the flat theme
+ * sets `data-minimal="true"` (the attribute name is retained for cascade-churn
+ * reasons — read it as "the flat theme"). Also reconciles `data-theme`:
+ * painted is always dark, while flat honours the cached dark/light preference.
  */
 export function applyThemeStyle(style: ThemeStyle): void {
   if (typeof document !== "undefined") {
     const root = document.documentElement;
     if (style === "painted") {
       root.removeAttribute("data-minimal");
+      // Painted is dark-only; never let a stored light preference leak in.
+      root.setAttribute("data-theme", "dark");
     } else {
       root.setAttribute("data-minimal", "true");
-    }
-    if (style === "noir") {
-      root.setAttribute("data-noir", "true");
-    } else {
-      root.removeAttribute("data-noir");
-    }
-    if (style === "ember") {
-      root.setAttribute("data-ember", "true");
-    } else {
-      root.removeAttribute("data-ember");
+      root.setAttribute("data-theme", readCachedTheme());
     }
   }
   if (typeof window === "undefined") return;

--- a/src/lib/use-theme.ts
+++ b/src/lib/use-theme.ts
@@ -1,6 +1,24 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { getElectron } from "~/lib/electron";
+
 export type Theme = "dark" | "light";
+
+/** Native window grounds per theme — keep in sync with --bg in styles.css
+ *  (dark base / flat-light base) so resize gutters match the page. */
+const WINDOW_BACKGROUND: Record<Theme, string> = {
+  dark: "#000000",
+  light: "#f4f4f6",
+};
+
+/** Push the effective DOM theme's ground to the Electron window so the native
+ *  frame (launch flash, resize gutters) matches. No-op in the browser. */
+export function syncWindowBackground(): void {
+  if (typeof document === "undefined") return;
+  const effective: Theme =
+    document.documentElement.getAttribute("data-theme") === "light" ? "light" : "dark";
+  void getElectron()?.setWindowBackgroundColor?.(WINDOW_BACKGROUND[effective]);
+}
 
 const KEY = "mc.theme";
 
@@ -41,6 +59,7 @@ function applyTheme(theme: Theme): void {
     "data-theme",
     isFlatActive() ? theme : "dark",
   );
+  syncWindowBackground();
 }
 
 function persistTheme(theme: Theme): void {

--- a/src/lib/use-theme.ts
+++ b/src/lib/use-theme.ts
@@ -1,43 +1,93 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export type Theme = "dark" | "light";
 
 const KEY = "mc.theme";
 
+/** localStorage key for the dark/light preference. Shared with the
+ *  pre-hydration script in __root.tsx. */
+export const THEME_CACHE_KEY = KEY;
+
 /**
- * Theme hook that avoids React 19 hydration mismatches by NEVER rendering the
- * `data-theme` attribute via JSX on `<html>`. Instead we always SSR with the
- * default and mutate `document.documentElement` post-hydration.
+ * The cached dark/light preference (defaults to dark). Shared with
+ * `applyThemeStyle` and the pre-hydration script so the choice survives
+ * reloads with no flash. Note: only the flat theme honours "light"; painted is
+ * always dark (enforced when the DOM `data-theme` is reconciled).
+ */
+export function readCachedTheme(): Theme {
+  if (typeof window === "undefined") return "dark";
+  try {
+    return window.localStorage.getItem(KEY) === "light" ? "light" : "dark";
+  } catch {
+    return "dark";
+  }
+}
+
+/** The flat theme is the only one that supports light; it's marked by
+ *  `data-minimal` on <html> (set by applyThemeStyle / the pre-hydration
+ *  script). Painted has no such attribute and stays dark. */
+function isFlatActive(): boolean {
+  return (
+    typeof document !== "undefined" &&
+    document.documentElement.getAttribute("data-minimal") === "true"
+  );
+}
+
+/** Reconcile the DOM `data-theme` with the active style: painted is always
+ *  dark; flat reflects the preference. */
+function applyTheme(theme: Theme): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.setAttribute(
+    "data-theme",
+    isFlatActive() ? theme : "dark",
+  );
+}
+
+function persistTheme(theme: Theme): void {
+  try {
+    window.localStorage.setItem(KEY, theme);
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+
+/**
+ * Dark/light theme hook. Avoids React 19 hydration mismatches by NEVER
+ * rendering the `data-theme` attribute via JSX on `<html>`; instead it seeds
+ * from the default and mutates `document.documentElement` post-hydration.
+ *
+ * The preference is always persisted, but only takes visible effect under the
+ * flat theme — painted keeps `data-theme="dark"`. Switching back to flat
+ * restores the stored preference (see applyThemeStyle).
  */
 export function useTheme(): {
   theme: Theme;
   toggle: () => void;
   set: (t: Theme) => void;
 } {
-  const [theme, setTheme] = useState<Theme>("dark");
+  const [theme, setThemeState] = useState<Theme>("dark");
 
-  // Theme is intentionally locked to dark for now.
+  // Restore the cached preference on mount and reconcile the DOM.
   useEffect(() => {
-    try {
-      setTheme("dark");
-      document.documentElement.setAttribute("data-theme", "dark");
-      localStorage.setItem(KEY, "dark");
-    } catch {
-      /* localStorage unavailable */
-    }
+    const cached = readCachedTheme();
+    setThemeState(cached);
+    applyTheme(cached);
   }, []);
 
-  const set = (_t: Theme) => {
-    const next: Theme = "dark";
-    setTheme(next);
-    try {
-      document.documentElement.setAttribute("data-theme", next);
-      localStorage.setItem(KEY, next);
-    } catch {
-      /* swallow */
-    }
-  };
-  const toggle = () => set(theme === "dark" ? "light" : "dark");
+  const set = useCallback((next: Theme) => {
+    setThemeState(next);
+    persistTheme(next);
+    applyTheme(next);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setThemeState((prev) => {
+      const next: Theme = prev === "dark" ? "light" : "dark";
+      persistTheme(next);
+      applyTheme(next);
+      return next;
+    });
+  }, []);
 
   return { theme, toggle, set };
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -18,7 +18,7 @@ import { ConfirmDialog } from "~/components/ui/ConfirmDialog";
 import { useHotkey } from "~/lib/use-hotkey";
 import { KeybindingsProvider } from "~/lib/keybindings/store";
 import { useNavigationSwipe } from "~/lib/use-navigation-swipe";
-import { useTheme } from "~/lib/use-theme";
+import { THEME_CACHE_KEY, useTheme } from "~/lib/use-theme";
 import { TerminalProvider, useTerminals } from "~/lib/terminal-store";
 import {
   UserTerminalProvider,
@@ -111,21 +111,24 @@ const useThemeLayoutEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 // Pre-hydration script: runs synchronously in <head> before first paint so
-// theme state (`data-minimal`/`data-noir` + accent CSS vars) is in place
+// theme state (`data-minimal` + `data-theme` + accent CSS vars) is in place
 // before any CSS layout. Without this, the SSR'd HTML paints with default
-// (painted+orange) theme for one frame — every accent-tinted surface flashes
-// orange before React/useSettings hydrate. Mirrors `applyThemeStyle`
-// (src/lib/theme-style.ts), `applySurfaceTint` (src/lib/surface-tint.ts) and
-// `applyAccentColor` (src/lib/accent-colors.ts); keep them in sync.
+// (painted+orange, dark) theme for one frame — every accent-tinted surface
+// flashes before React/useSettings hydrate, and a flat-light user sees a dark
+// flash. Mirrors `applyThemeStyle` (src/lib/theme-style.ts), `useTheme`
+// (src/lib/use-theme.ts), `applySurfaceTint` (src/lib/surface-tint.ts) and
+// `applyAccentColor` (src/lib/accent-colors.ts); keep them in sync. Legacy
+// minimal/noir/ember styles collapse to flat here.
 const PRE_HYDRATION_THEME_SCRIPT = `(function(){try{
 var d=document.documentElement;
 var st=localStorage.getItem(${JSON.stringify(THEME_STYLE_CACHE_KEY)});
-if(st!=="painted"&&st!=="minimal"&&st!=="noir"&&st!=="ember"){st=localStorage.getItem(${JSON.stringify(MINIMAL_CACHE_KEY)})==="1"?"minimal":"painted";}
-if(st!=="painted"){d.setAttribute("data-minimal","true");}
-if(st==="noir"){d.setAttribute("data-noir","true");}
-if(st==="ember"){d.setAttribute("data-ember","true");}
+if(st!=="painted"&&st!=="flat"&&st!=="minimal"&&st!=="noir"&&st!=="ember"){st=localStorage.getItem(${JSON.stringify(MINIMAL_CACHE_KEY)})==="1"?"flat":"painted";}
+var flat=(st!=="painted");
+if(flat){d.setAttribute("data-minimal","true");}
+var th=localStorage.getItem(${JSON.stringify(THEME_CACHE_KEY)})==="light"?"light":"dark";
+d.setAttribute("data-theme",(flat&&th==="light")?"light":"dark");
 var tt=localStorage.getItem(${JSON.stringify(SURFACE_TINT_CACHE_KEY)});
-if(tt!=="off"){d.setAttribute("data-tint",tt==="vivid"?"vivid":"subtle");}
+if(tt==="subtle"||tt==="vivid"||tt==="intense"){d.setAttribute("data-tint",tt);}
 if(localStorage.getItem(${JSON.stringify(LAUNCH_INTRO_CACHE_KEY)})==="1"){d.setAttribute("data-launch-intro","true");}
 var t=${JSON.stringify(
   Object.fromEntries(ACCENT_COLORS.map((c) => [c.id, { v: c.value, r: c.rgb }])),

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -104,7 +104,7 @@ import { ThemeOnboardingGate } from "~/components/views/ThemeOnboardingOverlay";
 import "~/styles.css";
 
 const LAUNCH_OVERLAY_DURATION_MS = 2700;
-const MINIMAL_TOP_BAR_CONTENT_TOP_INSET = 10;
+const MINIMAL_TOP_BAR_CONTENT_TOP_INSET = 2;
 const MINIMAL_WINDOW_DRAG_LAYER_HEIGHT = 8;
 const WINDOW_DRAG_LAYER_Z_INDEX = 30;
 const useThemeLayoutEffect =
@@ -311,7 +311,7 @@ function Shell() {
   const cachedMinimal = readCachedThemeStyle() !== "painted";
   const effectiveMinimal = settings?.minimalTheme ?? cachedMinimal;
   // The top bar's leading inset applies in minimal mode.
-  const topBarLeadingInset = effectiveMinimal ? 130 : undefined;
+  const topBarLeadingInset = effectiveMinimal ? 88 : undefined;
   const topBarContentTopInset = effectiveMinimal
     ? MINIMAL_TOP_BAR_CONTENT_TOP_INSET
     : 0;

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -96,6 +96,10 @@ import {
   applyThemeStyle,
   readCachedThemeStyle,
 } from "~/lib/theme-style";
+import {
+  SURFACE_TINT_CACHE_KEY,
+  applySurfaceTint,
+} from "~/lib/surface-tint";
 import { ThemeOnboardingGate } from "~/components/views/ThemeOnboardingOverlay";
 import "~/styles.css";
 
@@ -111,8 +115,8 @@ const useThemeLayoutEffect =
 // before any CSS layout. Without this, the SSR'd HTML paints with default
 // (painted+orange) theme for one frame — every accent-tinted surface flashes
 // orange before React/useSettings hydrate. Mirrors `applyThemeStyle`
-// (src/lib/theme-style.ts) and `applyAccentColor` (src/lib/accent-colors.ts);
-// keep them in sync.
+// (src/lib/theme-style.ts), `applySurfaceTint` (src/lib/surface-tint.ts) and
+// `applyAccentColor` (src/lib/accent-colors.ts); keep them in sync.
 const PRE_HYDRATION_THEME_SCRIPT = `(function(){try{
 var d=document.documentElement;
 var st=localStorage.getItem(${JSON.stringify(THEME_STYLE_CACHE_KEY)});
@@ -120,6 +124,8 @@ if(st!=="painted"&&st!=="minimal"&&st!=="noir"&&st!=="ember"){st=localStorage.ge
 if(st!=="painted"){d.setAttribute("data-minimal","true");}
 if(st==="noir"){d.setAttribute("data-noir","true");}
 if(st==="ember"){d.setAttribute("data-ember","true");}
+var tt=localStorage.getItem(${JSON.stringify(SURFACE_TINT_CACHE_KEY)});
+if(tt!=="off"){d.setAttribute("data-tint",tt==="vivid"?"vivid":"subtle");}
 if(localStorage.getItem(${JSON.stringify(LAUNCH_INTRO_CACHE_KEY)})==="1"){d.setAttribute("data-launch-intro","true");}
 var t=${JSON.stringify(
   Object.fromEntries(ACCENT_COLORS.map((c) => [c.id, { v: c.value, r: c.rgb }])),
@@ -427,6 +433,13 @@ function Shell() {
     if (!themeStyle) return;
     applyThemeStyle(themeStyle);
   }, [themeStyle]);
+
+  const surfaceTint = settings?.surfaceTint;
+
+  useThemeLayoutEffect(() => {
+    if (!surfaceTint) return;
+    applySurfaceTint(surfaceTint);
+  }, [surfaceTint]);
 
   // Recompute + re-observe the workspace bounds whenever the workspace div is
   // (un)mounted. Focus mode early-returns above and tears down the whole #root

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -2901,6 +2901,7 @@ function ProjectPage() {
             <div
               role="group"
               aria-label="Review changes and commit"
+              className="mc-ship-group"
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -3716,11 +3717,11 @@ function SessionScopeToggle({
   showArchivedTab: boolean;
   onChange: (view: SessionView) => void;
 }) {
-  const segment = (selected: boolean): CSSProperties => ({
+  // Visual state (background/color/box-shadow + hover) lives in styles.css
+  // under .mc-session-scope-tab so unselected tabs get a hover treatment.
+  const segment: CSSProperties = {
     appearance: "none",
     border: 0,
-    background: selected ? "var(--surface-2)" : "transparent",
-    color: selected ? "var(--text)" : "var(--text-dim)",
     fontFamily: "var(--mono)",
     fontSize: 11,
     fontWeight: 600,
@@ -3732,10 +3733,7 @@ function SessionScopeToggle({
     display: "inline-flex",
     alignItems: "center",
     gap: 6,
-    boxShadow: selected
-      ? "inset 0 1px 0 rgba(255,255,255,0.05), 0 1px 2px rgba(0,0,0,0.3)"
-      : "none",
-  });
+  };
   const countStyle: CSSProperties = {
     color: "var(--text-faint)",
     fontVariantNumeric: "tabular-nums",
@@ -3758,14 +3756,13 @@ function SessionScopeToggle({
     <div
       role="radiogroup"
       aria-label="Show sessions by type"
+      className="mc-session-scope-toggle"
       style={{
         display: "inline-flex",
         alignItems: "center",
         gap: 2,
         padding: 3,
         borderRadius: 9,
-        background: "var(--surface-0)",
-        border: "1px solid var(--border)",
       }}
     >
       {tabs.map((tab) => {
@@ -3781,7 +3778,9 @@ function SessionScopeToggle({
             role="radio"
             aria-checked={selected}
             tabIndex={selected ? 0 : -1}
-            style={segment(selected)}
+            className="mc-session-scope-tab"
+            data-selected={selected || undefined}
+            style={segment}
             onClick={() => onChange(tab.view)}
             onKeyDown={(e) => {
               if (e.key === "ArrowRight" || e.key === "ArrowDown") {

--- a/src/server/__tests__/settings-api.test.ts
+++ b/src/server/__tests__/settings-api.test.ts
@@ -653,12 +653,12 @@ describe("settings API", () => {
     });
   });
 
-  it("persists the theme style and derives minimalTheme from it", async () => {
+  it("persists the flat theme style and derives minimalTheme from it", async () => {
     const update = await handleApiRequest(
       authedRequest("http://localhost/api/settings", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ themeStyle: "noir" }),
+        body: JSON.stringify({ themeStyle: "flat" }),
       }),
     );
     const read = await handleApiRequest(
@@ -667,36 +667,43 @@ describe("settings API", () => {
 
     expect(update?.status).toBe(200);
     expect(await jsonBody(update!)).toMatchObject({
-      themeStyle: "noir",
+      themeStyle: "flat",
       minimalTheme: true,
     });
     expect(await jsonBody(read!)).toMatchObject({
-      themeStyle: "noir",
+      themeStyle: "flat",
       minimalTheme: true,
     });
   });
 
-  it("persists the ember theme style and derives minimalTheme from it", async () => {
-    const update = await handleApiRequest(
-      authedRequest("http://localhost/api/settings", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ themeStyle: "ember" }),
-      }),
-    );
-    const read = await handleApiRequest(
-      authedRequest("http://localhost/api/settings"),
-    );
+  it("rejects a legacy theme style (noir / ember) on write", async () => {
+    for (const legacy of ["noir", "ember", "minimal"]) {
+      const response = await handleApiRequest(
+        authedRequest("http://localhost/api/settings", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ themeStyle: legacy }),
+        }),
+      );
+      expect(response?.status).toBe(400);
+    }
+  });
 
-    expect(update?.status).toBe(200);
-    expect(await jsonBody(update!)).toMatchObject({
-      themeStyle: "ember",
-      minimalTheme: true,
-    });
-    expect(await jsonBody(read!)).toMatchObject({
-      themeStyle: "ember",
-      minimalTheme: true,
-    });
+  it("migrates a legacy theme_style row (noir / ember / minimal) to flat on read", async () => {
+    for (const legacy of ["noir", "ember", "minimal"]) {
+      getDb().delete(appSettings).run();
+      getDb()
+        .insert(appSettings)
+        .values({ key: "theme_style", value: legacy })
+        .run();
+      const read = await handleApiRequest(
+        authedRequest("http://localhost/api/settings"),
+      );
+      expect(await jsonBody(read!)).toMatchObject({
+        themeStyle: "flat",
+        minimalTheme: true,
+      });
+    }
   });
 
   it("defaults the surface tint to subtle", async () => {
@@ -723,6 +730,23 @@ describe("settings API", () => {
     expect(update?.status).toBe(200);
     expect(await jsonBody(update!)).toMatchObject({ surfaceTint: "vivid" });
     expect(await jsonBody(read!)).toMatchObject({ surfaceTint: "vivid" });
+  });
+
+  it("persists the intense surface tint", async () => {
+    const update = await handleApiRequest(
+      authedRequest("http://localhost/api/settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ surfaceTint: "intense" }),
+      }),
+    );
+    const read = await handleApiRequest(
+      authedRequest("http://localhost/api/settings"),
+    );
+
+    expect(update?.status).toBe(200);
+    expect(await jsonBody(update!)).toMatchObject({ surfaceTint: "intense" });
+    expect(await jsonBody(read!)).toMatchObject({ surfaceTint: "intense" });
   });
 
   it("persists an explicit off surface tint", async () => {
@@ -820,7 +844,7 @@ describe("settings API", () => {
     expect(response?.status).toBe(400);
   });
 
-  it("maps an install that only stored the legacy minimal flag to the minimal style", async () => {
+  it("maps an install that only stored the legacy minimal flag to the flat style", async () => {
     // Simulate a database written by a build that predates theme_style.
     getDb().insert(appSettings).values({ key: "minimal_theme", value: "true" }).run();
 
@@ -829,19 +853,12 @@ describe("settings API", () => {
     );
 
     expect(await jsonBody(response!)).toMatchObject({
-      themeStyle: "minimal",
+      themeStyle: "flat",
       minimalTheme: true,
     });
   });
 
-  it("keeps noir when a legacy client re-sends minimalTheme: true", async () => {
-    await handleApiRequest(
-      authedRequest("http://localhost/api/settings", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ themeStyle: "noir" }),
-      }),
-    );
+  it("selects flat when a legacy client sends minimalTheme: true", async () => {
     const update = await handleApiRequest(
       authedRequest("http://localhost/api/settings", {
         method: "POST",
@@ -850,7 +867,10 @@ describe("settings API", () => {
       }),
     );
 
-    expect(await jsonBody(update!)).toMatchObject({ themeStyle: "noir" });
+    expect(await jsonBody(update!)).toMatchObject({
+      themeStyle: "flat",
+      minimalTheme: true,
+    });
   });
 
   it("returns to painted when a legacy client sends minimalTheme: false", async () => {
@@ -858,7 +878,7 @@ describe("settings API", () => {
       authedRequest("http://localhost/api/settings", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ themeStyle: "noir" }),
+        body: JSON.stringify({ themeStyle: "flat" }),
       }),
     );
     const update = await handleApiRequest(

--- a/src/server/__tests__/settings-api.test.ts
+++ b/src/server/__tests__/settings-api.test.ts
@@ -699,6 +699,60 @@ describe("settings API", () => {
     });
   });
 
+  it("defaults the surface tint to subtle", async () => {
+    const response = await handleApiRequest(
+      authedRequest("http://localhost/api/settings"),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(await jsonBody(response!)).toMatchObject({ surfaceTint: "subtle" });
+  });
+
+  it("persists the surface tint", async () => {
+    const update = await handleApiRequest(
+      authedRequest("http://localhost/api/settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ surfaceTint: "vivid" }),
+      }),
+    );
+    const read = await handleApiRequest(
+      authedRequest("http://localhost/api/settings"),
+    );
+
+    expect(update?.status).toBe(200);
+    expect(await jsonBody(update!)).toMatchObject({ surfaceTint: "vivid" });
+    expect(await jsonBody(read!)).toMatchObject({ surfaceTint: "vivid" });
+  });
+
+  it("persists an explicit off surface tint", async () => {
+    const update = await handleApiRequest(
+      authedRequest("http://localhost/api/settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ surfaceTint: "off" }),
+      }),
+    );
+    const read = await handleApiRequest(
+      authedRequest("http://localhost/api/settings"),
+    );
+
+    expect(update?.status).toBe(200);
+    expect(await jsonBody(read!)).toMatchObject({ surfaceTint: "off" });
+  });
+
+  it("rejects an invalid surface tint", async () => {
+    const update = await handleApiRequest(
+      authedRequest("http://localhost/api/settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ surfaceTint: "neon" }),
+      }),
+    );
+
+    expect(update?.status).toBe(400);
+  });
+
   it("reports no theme chosen on a fresh install", async () => {
     const response = await handleApiRequest(
       authedRequest("http://localhost/api/settings"),

--- a/src/server/controllers/settings.controller.ts
+++ b/src/server/controllers/settings.controller.ts
@@ -37,6 +37,11 @@ import {
 import { safeJsonParse } from "~/shared/safe-json";
 import { isThemeStyle, type ThemeStyle } from "~/shared/theme-style";
 import {
+  DEFAULT_SURFACE_TINT,
+  isSurfaceTint,
+  type SurfaceTint,
+} from "~/shared/surface-tint";
+import {
   DEFAULT_TERMINAL_ZOOM_LEVEL,
   TERMINAL_ZOOM_MAX,
   TERMINAL_ZOOM_MIN,
@@ -67,6 +72,7 @@ const TERMINAL_ZOOM_LEVEL_KEY = "terminal_zoom_level";
 const SESSION_HEADER_BUTTONS_KEY = "session_header_buttons";
 const THEME_STYLE_KEY = "theme_style";
 const MINIMAL_THEME_KEY = "minimal_theme";
+const SURFACE_TINT_KEY = "surface_tint";
 const VOICE_COMMAND_ALIASES_KEY = "voice_command_aliases";
 const CLAUDE_USAGE_LIMITS_ENABLED_KEY = "claude_usage_limits_enabled";
 const CLAUDE_USAGE_LIMITS_SHOW_SESSION_KEY = "claude_usage_limits_show_session";
@@ -108,6 +114,7 @@ const updateSettingsBody = z
     accentColor: z.string().refine(isAccentColorId, { message: "invalid accentColor" }),
     minimalTheme: z.boolean(),
     themeStyle: z.string().refine(isThemeStyle, { message: "invalid themeStyle" }),
+    surfaceTint: z.string().refine(isSurfaceTint, { message: "invalid surfaceTint" }),
     mouseGradientDisabled: z.boolean(),
     sessionFinishToastEnabled: z.boolean(),
     sessionFinishOsNotificationEnabled: z.boolean(),
@@ -166,6 +173,11 @@ function getThemeStyleSetting(): ThemeStyle {
   if (isThemeStyle(value)) return value;
   // Installs that predate theme_style only stored the minimal/painted toggle.
   return getBooleanSetting(MINIMAL_THEME_KEY) ? "minimal" : "painted";
+}
+
+function getSurfaceTintSetting(): SurfaceTint {
+  const value = getSetting(SURFACE_TINT_KEY);
+  return isSurfaceTint(value) ? value : DEFAULT_SURFACE_TINT;
 }
 
 function getCommitCliSetting(): CommitCli | null {
@@ -235,6 +247,7 @@ function settingsPayload() {
     agentSystemBannerDisabled: getBooleanSetting("agent_system_banner_disabled"),
     accentColor: getAccentColorSetting(),
     themeStyle,
+    surfaceTint: getSurfaceTintSetting(),
     // Derived: true whenever the style renders clean CSS chrome (minimal or
     // noir). Layout consumers key off this; the style picker reads themeStyle.
     minimalTheme: themeStyle !== "painted",
@@ -331,6 +344,9 @@ export async function update(request: Request): Promise<Response> {
     setSetting(THEME_STYLE_KEY, body.themeStyle);
     // Keep the legacy boolean in sync so a downgraded build restores the choice.
     setBooleanSetting(MINIMAL_THEME_KEY, body.themeStyle !== "painted");
+  }
+  if (body.surfaceTint !== undefined) {
+    setSetting(SURFACE_TINT_KEY, body.surfaceTint);
   }
   if (body.mouseGradientDisabled !== undefined) {
     setBooleanSetting("mouse_gradient_disabled", body.mouseGradientDisabled);

--- a/src/server/controllers/settings.controller.ts
+++ b/src/server/controllers/settings.controller.ts
@@ -35,7 +35,11 @@ import {
   normalizeSelectedWorktreeByProject,
 } from "~/shared/ui-preferences";
 import { safeJsonParse } from "~/shared/safe-json";
-import { isThemeStyle, type ThemeStyle } from "~/shared/theme-style";
+import {
+  isThemeStyle,
+  normalizeThemeStyle,
+  type ThemeStyle,
+} from "~/shared/theme-style";
 import {
   DEFAULT_SURFACE_TINT,
   isSurfaceTint,
@@ -170,9 +174,11 @@ function getAccentColorSetting(): AccentColorId {
 
 function getThemeStyleSetting(): ThemeStyle {
   const value = getSetting(THEME_STYLE_KEY);
-  if (isThemeStyle(value)) return value;
+  // Migrate on read: legacy rows stored "minimal" / "noir" / "ember", which all
+  // collapse to "flat"; anything unrecognized falls back to painted.
+  if (value !== null) return normalizeThemeStyle(value);
   // Installs that predate theme_style only stored the minimal/painted toggle.
-  return getBooleanSetting(MINIMAL_THEME_KEY) ? "minimal" : "painted";
+  return getBooleanSetting(MINIMAL_THEME_KEY) ? "flat" : "painted";
 }
 
 function getSurfaceTintSetting(): SurfaceTint {
@@ -248,8 +254,8 @@ function settingsPayload() {
     accentColor: getAccentColorSetting(),
     themeStyle,
     surfaceTint: getSurfaceTintSetting(),
-    // Derived: true whenever the style renders clean CSS chrome (minimal or
-    // noir). Layout consumers key off this; the style picker reads themeStyle.
+    // Derived: true whenever the style renders clean CSS chrome (the flat
+    // theme). Layout consumers key off this; the style picker reads themeStyle.
     minimalTheme: themeStyle !== "painted",
     // Raw-key check — the getters above normalize absent rows to defaults,
     // which would erase the "never chosen" signal. False only on a fresh
@@ -331,14 +337,10 @@ export async function update(request: Request): Promise<Response> {
     setSetting("accent_color", body.accentColor);
   }
   if (body.minimalTheme !== undefined) {
-    // Legacy toggle: turning it off always means painted; turning it on keeps
-    // an existing clean-chrome style (noir) instead of clobbering it.
+    // Legacy toggle: on means the flat theme, off means painted. (getThemeStyle
+    // -Setting already migrates any stored legacy style to "flat".)
     setBooleanSetting(MINIMAL_THEME_KEY, body.minimalTheme);
-    const current = getThemeStyleSetting();
-    setSetting(
-      THEME_STYLE_KEY,
-      body.minimalTheme ? (current === "painted" ? "minimal" : current) : "painted",
-    );
+    setSetting(THEME_STYLE_KEY, body.minimalTheme ? "flat" : "painted");
   }
   if (body.themeStyle !== undefined) {
     setSetting(THEME_STYLE_KEY, body.themeStyle);

--- a/src/shared/electron-contract.ts
+++ b/src/shared/electron-contract.ts
@@ -325,6 +325,9 @@ export type ElectronBridge = {
   getUserDataDir: () => Promise<string>;
   getUserName: () => Promise<{ source: "git" | "os"; fullName: string; firstName: string }>;
   reload: () => Promise<{ ok: true } | { ok: false; error: string }>;
+  /** Sync the native window background with the renderer theme (dark/light)
+   *  so resize gutters and the launch frame match the page ground. */
+  setWindowBackgroundColor: (color: string) => Promise<{ ok: true } | { ok: false; error: string }>;
   notifications: {
     getPermission: () => Promise<"granted" | "unsupported">;
     showSessionFinished: (payload: {

--- a/src/shared/surface-tint.ts
+++ b/src/shared/surface-tint.ts
@@ -3,13 +3,16 @@
 // controller (persistence + validation) and the renderer (DOM application),
 // so the enum lives here rather than in src/lib.
 //
-//  - "off":    surfaces render each style's exact base palette (the pre-tint
-//              look)
-//  - "subtle": a whisper of accent in the ground — the app leans toward the
-//              chosen color without losing the style's character
-//  - "vivid":  a clearly visible accent wash across backgrounds, headers,
-//              bars and session grounds
-export const SURFACE_TINTS = ["off", "subtle", "vivid"] as const;
+//  - "off":     surfaces render each style's exact base palette (the pre-tint
+//               look)
+//  - "subtle":  a whisper of accent in the ground — the app leans toward the
+//               chosen color without losing the style's character
+//  - "vivid":   a clearly visible accent wash across backgrounds, headers,
+//               bars and session grounds
+//  - "intense": a heavy accent wash — with a warm accent (terracotta, amber,
+//               deep-orange) this pulls the flat theme's near-black ground back
+//               into a warm-charcoal range, the way the old Ember palette read
+export const SURFACE_TINTS = ["off", "subtle", "vivid", "intense"] as const;
 
 export type SurfaceTint = (typeof SURFACE_TINTS)[number];
 

--- a/src/shared/surface-tint.ts
+++ b/src/shared/surface-tint.ts
@@ -1,0 +1,23 @@
+// Surface tint — how much of the accent color is mixed into the surface
+// tokens (--bg, --surface-0..3, --terminal-bg). Shared by the settings
+// controller (persistence + validation) and the renderer (DOM application),
+// so the enum lives here rather than in src/lib.
+//
+//  - "off":    surfaces render each style's exact base palette (the pre-tint
+//              look)
+//  - "subtle": a whisper of accent in the ground — the app leans toward the
+//              chosen color without losing the style's character
+//  - "vivid":  a clearly visible accent wash across backgrounds, headers,
+//              bars and session grounds
+export const SURFACE_TINTS = ["off", "subtle", "vivid"] as const;
+
+export type SurfaceTint = (typeof SURFACE_TINTS)[number];
+
+export const DEFAULT_SURFACE_TINT: SurfaceTint = "subtle";
+
+export function isSurfaceTint(value: unknown): value is SurfaceTint {
+  return (
+    typeof value === "string" &&
+    (SURFACE_TINTS as readonly string[]).includes(value)
+  );
+}

--- a/src/shared/theme-style.ts
+++ b/src/shared/theme-style.ts
@@ -2,14 +2,17 @@
 // controller (persistence + validation) and the renderer (DOM application),
 // so the enum lives here rather than in src/lib.
 //
-//  - "painted": pixel-art borders and shell imagery (the original look)
-//  - "minimal": clean CSS borders, textured cards, accent-tinted surfaces
-//  - "noir":    flat near-black surfaces with hairline dividers; borders only
-//               where they carry meaning (e.g. the focused pane)
-//  - "ember":   warm sepia near-black, edge-to-edge flush panes with square
-//               corners, a bundled JetBrains Mono face, and a solid accent
-//               border + soft drop shadow on the focused pane
-export const THEME_STYLES = ["painted", "minimal", "noir", "ember"] as const;
+//  - "painted": pixel-art borders and shell imagery (the original look);
+//               always dark.
+//  - "flat":    the one clean-chrome theme — warm sepia near-black, edge-to-
+//               edge flush panes with square corners, bundled JetBrains Mono +
+//               Plus Jakarta Sans faces, and a solid accent border + soft drop
+//               shadow on the focused pane. Supports dark and light.
+//
+// Legacy note: earlier builds split the flat look into "minimal" / "noir" /
+// "ember". Those values are migrated to "flat" on every READ path
+// (normalizeThemeStyle); the strict guard below rejects them on WRITE.
+export const THEME_STYLES = ["painted", "flat"] as const;
 
 export type ThemeStyle = (typeof THEME_STYLES)[number];
 
@@ -23,10 +26,30 @@ export function isThemeStyle(value: unknown): value is ThemeStyle {
 }
 
 /**
- * Styles that replace the painted borders/shell imagery with clean CSS chrome.
- * Noir and ember build on minimal's chrome (all three set `data-minimal` on
- * <html>), so layout decisions keyed on "minimal mode" apply to every non-
- * painted style.
+ * Coerce any stored/cached value — including the legacy "minimal" / "noir" /
+ * "ember" flat styles — into a current ThemeStyle. Anything flat-ish becomes
+ * "flat"; anything unrecognized falls back to the default (painted). Use this
+ * on every read path (server settings, client cache, pre-hydration script) so
+ * old preferences upgrade cleanly.
+ */
+export function normalizeThemeStyle(value: unknown): ThemeStyle {
+  if (value === "painted") return "painted";
+  if (
+    value === "flat" ||
+    value === "minimal" ||
+    value === "noir" ||
+    value === "ember"
+  ) {
+    return "flat";
+  }
+  return DEFAULT_THEME_STYLE;
+}
+
+/**
+ * Whether the style replaces the painted borders/shell imagery with clean CSS
+ * chrome. Only the flat theme does; kept as a helper because layout decisions
+ * key off "is this the flat theme?" (the DOM attribute is still `data-minimal`
+ * for cascade-churn reasons).
  */
 export function isCleanChromeStyle(style: ThemeStyle): boolean {
   return style !== "painted";

--- a/src/styles.css
+++ b/src/styles.css
@@ -1939,13 +1939,21 @@ body[data-card-glow] .cursor-glow {
   border-radius: 0 !important;
 }
 /* The flush cell seams need to read stronger than the base hairline, so grid
-   pane dividers run 15% darker than each theme's own primary border color.
-   Deriving from var(--border) keeps this correct across every flat palette
-   (and preserves the accent tint already baked into --border). Skip the
-   focused cell so it keeps its accent border (see the :focus-within rule
-   below). */
-[data-minimal="true"] [data-session-grid] .mc-card-frame:not(:focus-within) {
+   pane dividers push 15% off each theme's own primary border color. Both
+   derive from var(--border) (preserving its accent tint), but the direction
+   flips per mode: on the light paper ground "stronger" means darker, while on
+   the dark ground darkening would sink the faint light-on-dark hairline into
+   the surface — so dark brightens instead. Skip the focused cell so it keeps
+   its accent border (see the :focus-within rule below). */
+[data-minimal="true"][data-theme="light"]
+  [data-session-grid]
+  .mc-card-frame:not(:focus-within) {
   border-color: color-mix(in srgb, var(--border), black 15%) !important;
+}
+[data-minimal="true"][data-theme="dark"]
+  [data-session-grid]
+  .mc-card-frame:not(:focus-within) {
+  border-color: color-mix(in srgb, var(--border), white 15%) !important;
 }
 [data-minimal="true"] .mc-card-frame[data-solid="true"] {
   background: var(--surface-1) !important;

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,12 +7,12 @@
 @import "@fontsource/geist-mono/400.css";
 @import "@fontsource/geist-mono/500.css";
 @import "@fontsource/geist-mono/600.css";
-/* Ember theme's bundled terminal + UI mono face — clearer, warmer mono. */
+/* Flat theme's bundled terminal + UI mono face — clearer, warmer mono. */
 @import "@fontsource/jetbrains-mono/400.css";
 @import "@fontsource/jetbrains-mono/500.css";
 @import "@fontsource/jetbrains-mono/600.css";
 @import "@fontsource/jetbrains-mono/700.css";
-/* Ember theme's UI sans face. */
+/* Flat theme's UI sans face. */
 @import "@fontsource/plus-jakarta-sans/400.css";
 @import "@fontsource/plus-jakarta-sans/500.css";
 @import "@fontsource/plus-jakarta-sans/600.css";
@@ -80,21 +80,88 @@
   --radius-lg: 14px;
 }
 
-[data-theme="light"] {
-  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), #f7f6f2);
-  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), #ffffff);
-  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #fafaf7);
-  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #f1f0eb);
-  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #e7e6e0);
-  --border: rgba(0, 0, 0, 0.08);
-  --border-strong: rgba(0, 0, 0, 0.14);
-  --text: #1a1a1a;
-  --text-dim: rgba(26, 26, 26, 0.62);
-  --text-faint: rgba(26, 26, 26, 0.38);
-  --terminal-bg: color-mix(in srgb, var(--accent) var(--tint-lo), #ffffff);
+/* =====================================================================
+   SEMANTIC ROLE TOKENS — the vocabulary components should reference.
+   Every token answers "what is this for?" (surface / text tier / intent /
+   status / action) rather than naming a raw value. They ALIAS onto the
+   physical, tint-aware tokens above (--bg / --surface-* / --text* /
+   --accent* / --status-*), so each theme × dark-light re-binds the whole
+   app for free just by re-binding the physical layer, and the surface-tint
+   color-mix machinery flows through untouched. Prefer these names in
+   components over the physical bg / surface / text tokens.
+   ===================================================================== */
+:root {
+  /* Surfaces */
+  --background: var(--bg);
+  --card: var(--surface-0);
+  --card-raised: var(--surface-1);
+  --popover: var(--surface-2);
+  --elevated: var(--surface-3);
+  --terminal: var(--terminal-bg);
+  --overlay-scrim: color-mix(in srgb, var(--background) 68%, transparent);
+
+  /* Text hierarchy */
+  --foreground: var(--text);
+  --foreground-secondary: var(--text-dim);
+  --foreground-muted: var(--text-faint);
+
+  /* Intent */
+  --primary: var(--accent);
+  --primary-hover: var(--accent-hover);
+  /* Ink that sits ON a solid accent fill. Painted has no --mm-on-accent, so
+     it falls back to white; flat/flat-light re-bind --mm-on-accent. */
+  --primary-foreground: var(--mm-on-accent, #ffffff);
+  --destructive: var(--status-failed);
+  --destructive-foreground: var(--text);
+  --ring: color-mix(in srgb, var(--accent) 75%, transparent);
+  --input: var(--border-strong);
+  --input-bg: var(--surface-0);
+
+  /* Status roles — the canonical session-state vocabulary — each paired with
+     a low-alpha -bg tint for badges/pills. --status-* physical values live in
+     the palette blocks and re-bind per theme, so these derive for free. */
+  --status-info: oklch(0.78 0.1 220);
+  --status-ready-bg: color-mix(in srgb, var(--status-ready) 14%, transparent);
+  --status-running-bg: color-mix(in srgb, var(--status-running) 14%, transparent);
+  --status-needs-bg: color-mix(in srgb, var(--status-needs) 14%, transparent);
+  --status-interrupted-bg: color-mix(in srgb, var(--status-interrupted) 14%, transparent);
+  --status-done-bg: color-mix(in srgb, var(--status-done) 14%, transparent);
+  --status-warning-bg: color-mix(in srgb, var(--status-warning) 14%, transparent);
+  --status-failed-bg: color-mix(in srgb, var(--status-failed) 14%, transparent);
+  --status-info-bg: color-mix(in srgb, var(--status-info) 14%, transparent);
+
+  /* Domain-verb ACTION tokens — named by app behavior, mapped onto status
+     hues so a theme swap recolors them for free. */
+  --action-commit: var(--status-done);
+  --action-commit-text: var(--primary-foreground);
+  --action-verify: var(--status-ready);
+  --action-interrupt: var(--status-interrupted);
+  --running-indicator: var(--status-running);
+  --running-indicator-text: var(--text);
+}
+
+/* Flat theme, LIGHT mode — a warm-paper inversion of the Ember dark ground.
+   Scoped to the flat theme (data-minimal): Painted is always dark (its
+   data-theme is forced to "dark" at apply time), so light only ever means
+   flat-light. Warm off-white surfaces + warm-charcoal text keep the Ember
+   character in daylight. */
+[data-minimal="true"][data-theme="light"] {
+  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), #f5f2ea);
+  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), #fffdf8);
+  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #f7f4ec);
+  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #efe9dd);
+  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #e3dccc);
+  --border: rgba(60, 50, 30, 0.14);
+  --border-strong: rgba(60, 50, 30, 0.22);
+  --text: #2a241c;
+  --text-dim: rgba(42, 36, 28, 0.64);
+  --text-faint: rgba(42, 36, 28, 0.42);
+  --terminal-bg: color-mix(in srgb, var(--accent) var(--tint-lo), #fffdf8);
+  /* Light accent fills take white ink again. */
+  --mm-on-accent: #ffffff;
   --status-interrupted: oklch(0.58 0.17 35);
   --status-done: oklch(0.50 0.14 150);
-  --status-idle: rgba(26, 26, 26, 0.3);
+  --status-idle: rgba(42, 36, 28, 0.3);
   --status-warning: oklch(0.60 0.13 75);
   --banner-bg: linear-gradient(
     90deg,
@@ -102,7 +169,7 @@
     var(--surface-0) 34%,
     color-mix(in srgb, var(--accent) 14%, var(--surface-0))
   );
-  --banner-muted: rgba(26, 26, 26, 0.78);
+  --banner-muted: rgba(42, 36, 28, 0.78);
   --banner-link: color-mix(in srgb, var(--accent) 62%, black);
   --banner-icon-bg: color-mix(in srgb, var(--accent) 16%, var(--surface-0));
 }
@@ -723,11 +790,11 @@ select,
   outline-offset: 3px;
 }
 
-/* Minimal / noir / ember explicitly drop all painted chrome (their cards are
-   flat hairlines), so the painted pixel-frame toast is out of place there.
-   Flatten it to a tone-tinted hairline panel that matches those themes — the
-   icon badge, action, and close chip already track --mc-toast-tone, so they
-   carry over unchanged. Painted themes keep the border-image frame above. */
+/* The flat theme drops all painted chrome (its cards are flat hairlines), so
+   the painted pixel-frame toast is out of place. Flatten it to a tone-tinted
+   hairline panel — the icon badge, action, and close chip already track
+   --mc-toast-tone, so they carry over unchanged; --mm-radius (0) squares it.
+   Painted keeps the border-image frame above. */
 [data-minimal="true"] .mc-toast-panel {
   padding: 14px 48px 14px 16px;
   border: 1px solid color-mix(in srgb, var(--mc-toast-tone) 40%, var(--border-strong)) !important;
@@ -739,12 +806,6 @@ select,
     0 1px 0 rgb(255 255 255 / 4%) inset,
     0 10px 30px rgb(0 0 0 / 42%),
     0 0 0 1px color-mix(in srgb, var(--mc-toast-tone) 12%, transparent);
-}
-
-/* Ember squares every corner. Must stay after the minimal rule to win the
-   shared-specificity tie (ember sets both data-minimal and data-ember). */
-[data-ember="true"] .mc-toast-panel {
-  border-radius: 0 !important;
 }
 
 /* Custom toasts render their own CardFrame; strip the outer Sonner shell frame. */
@@ -1693,50 +1754,66 @@ body[data-card-glow] .cursor-glow {
 }
 
 /* =====================================================================
-   Minimal theme – considered, modern, restrained.
-   Warm brand-tinted neutrals, hairline elevation, halo focus rings,
-   squared chrome, and single-source motion tokens. No painted chrome.
-   Activated by `<html data-minimal="true">`.
+   FLAT theme – warm sepia near-black, flush + square, bundled mono.
+   The app's one clean-chrome theme (the former minimal / noir / ember styles
+   collapsed into this single look, which adopts Ember's character). Activated
+   by `<html data-minimal="true">` — the attribute name is retained so the ~360
+   lines of clean-chrome layout/button/input rules below (and the JS consumers
+   that key off it) don't churn; read "data-minimal" as "the flat theme".
+   Warm brown-black ground, cream text, square corners, edge-to-edge panes (the
+   grid gap/padding collapse to 0 in SessionGrid), a solid accent border + soft
+   drop shadow on the focused pane, and bundled JetBrains Mono + Plus Jakarta
+   Sans faces. Supports a light mode (see [data-minimal][data-theme="light"]).
    ===================================================================== */
 
 [data-minimal="true"] {
-  /* Near-black neutral ground with a barely-perceptible cool undertone (245°).
-     Cards (which sit on /card.png) need to read clearly as objects against
-     the page, so the page itself sits well below them. */
-  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), oklch(0.08 0.003 245));
-  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), oklch(0.115 0.004 245));
-  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), oklch(0.145 0.005 245));
-  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), oklch(0.185 0.006 245));
-  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), oklch(0.235 0.008 245));
-  --border: oklch(0.62 0.010 245 / 0.16);
-  --border-strong: oklch(0.72 0.016 245 / 0.26);
-  /* Terminal canvas: same near-black ground, lifted 5% toward the accent
-     so the running terminal carries a barely-there hint of the active theme
-     even with tint off; the surface tint adds on top of that baseline. */
-  --terminal-bg: color-mix(
-    in srgb,
-    var(--accent) calc(5% + var(--tint-lo)),
-    oklch(0.07 0.003 245)
-  );
+  /* Real dark near-black ladder — the depth the old Minimal theme had, with a
+     whisper of warmth (hue 65, near-zero chroma) so it still pairs with the
+     cream text + terracotta accent rather than reading cold. The page ground
+     sits well below the panes; hierarchy is by elevation, near-black up. */
+  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), oklch(0.09 0.004 65));
+  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), oklch(0.125 0.005 65));
+  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), oklch(0.155 0.006 65));
+  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), oklch(0.2 0.007 65));
+  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), oklch(0.25 0.009 65));
+  /* On a near-black ground a thin cream hairline reads cleanly, so it can be
+     dialled back from the mid-gray-tuned strength. */
+  --border: rgba(236, 224, 202, 0.12);
+  --border-strong: rgba(236, 224, 202, 0.24);
+  /* Warm cream text ladder — even higher contrast on the deep ground. Both dim
+     and faint stay clearly below --text to keep the tier hierarchy. */
+  --text: #e9e3d5;
+  --text-dim: #c6bca8;
+  --text-faint: #a89e8c;
+  /* Terminal canvas: the deepest step, just below the page ground. */
+  --terminal-bg: color-mix(in srgb, var(--accent) var(--tint-lo), oklch(0.075 0.004 65));
 
-  /* Minimal-only design tokens. Subtle rounded chrome matches the reference
-     aesthetic — small radii read as considered, not playful. */
-  --mm-radius-sm: 5px;
-  --mm-radius: 6px;
-  --mm-radius-lg: 8px;
+  /* Bundled faces: clearer, warmer mono for both xterm (via --mc-terminal-font,
+     read by createTerminalOptions) and every UI mono surface, plus Plus Jakarta
+     Sans for UI sans. */
+  --mc-terminal-font: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  --font-sans: "Plus Jakarta Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --sans: "Plus Jakarta Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+
+  /* Square everything — no rounded sessions or chrome. */
+  --mm-radius-sm: 0;
+  --mm-radius: 0;
+  --mm-radius-lg: 0;
   --mm-ease: cubic-bezier(0.22, 1, 0.36, 1);
   --mm-dur: 140ms;
+  /* Keyboard focus: crisp accent line plus a soft halo — a lone 1px ring gets
+     lost against the mid-gray ground. */
   --mm-ring:
-    0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent),
-    0 0 0 1px color-mix(in srgb, var(--accent) 75%, transparent);
-  --mm-elev-1:
-    0 1px 0 oklch(1 0 0 / 0.04) inset,
-    0 1px 2px oklch(0 0 0 / 0.30);
-  --mm-elev-2:
-    0 1px 0 oklch(1 0 0 / 0.05) inset,
-    0 1px 3px oklch(0 0 0 / 0.34),
-    0 6px 18px oklch(0 0 0 / 0.22);
-  --mm-on-accent: oklch(0.985 0.008 60);
+    0 0 0 1px color-mix(in srgb, var(--accent) 90%, transparent),
+    0 0 0 4px color-mix(in srgb, var(--accent) 24%, transparent);
+  --mm-elev-1: none;
+  --mm-elev-2: 0 12px 32px rgba(0, 0, 0, 0.45);
+  /* The default terracotta accent is a light mid-tone — near-white label reads
+     ~2.8:1 on it. Dark warm ink reads ~5.6:1 and wins on every accent but
+     indigo. Consumed by --primary-foreground. */
+  --mm-on-accent: #251e15;
 }
 
 /* Hide the painted shell frame around the app and reclaim the gutter
@@ -1748,52 +1825,31 @@ body[data-card-glow] .cursor-glow {
   display: none !important;
 }
 
-/* Cards: textured surface that picks up the active accent color.
-   Three-layer background composited with background-blend-mode:
-     1. Top: dark gradient overlay (normal) — keeps text legible across the card
-     2. Middle: /card.png texture (overlay) — its bright highlights/waves
-        blend with the accent below, so the texture is recolored by the theme
-     3. Bottom: solid var(--accent) — the canvas the texture is tinted against
-   With `overlay`, dark parts of card.png stay dark while light parts pick up
-   the accent — producing subtle theme-colored highlights along the card edge
-   without any extra layers or filter chains per-accent. */
-/* Cards: textured surface tinted ~12% by the active accent. The base layer
-   mixes only 12% accent into the dark ground, so the overlay-blended card.png
-   highlights pick up a hint of theme color — never a wash. Adjust the
-   `--mm-card-tint` value at the top of [data-minimal] to dial intensity. */
+/* Cards: flat, square panels — no card.png texture, no accent tint, no radius,
+   no elevation. A flat card is its warm surface color and a hairline. */
 [data-minimal="true"] .mc-card-frame {
-  border: 1px solid oklch(0.62 0.010 245 / 0.24) !important;
+  border: 1px solid var(--border) !important;
   border-image: none !important;
-  border-radius: var(--mm-radius) !important;
-  background:
-    url("/card.png") center / cover no-repeat,
-    color-mix(in srgb, var(--accent) 12%, oklch(0.14 0.005 245)) !important;
-  background-blend-mode: overlay, normal !important;
-  box-shadow:
-    0 1px 0 oklch(1 0 0 / 0.05) inset,
-    0 1px 2px oklch(0 0 0 / 0.40),
-    0 8px 22px oklch(0 0 0 / 0.30) !important;
+  border-radius: 0 !important;
+  background: var(--surface-0) !important;
+  background-blend-mode: normal !important;
+  box-shadow: none !important;
   transition:
     border-color var(--mm-dur) var(--mm-ease),
     box-shadow var(--mm-dur) var(--mm-ease) !important;
 }
 [data-minimal="true"] .mc-card-frame[data-solid="true"] {
-  background:
-    url("/card.png") center / cover no-repeat,
-    color-mix(in srgb, var(--accent) 12%, oklch(0.17 0.006 245)) !important;
-  background-blend-mode: overlay, normal !important;
+  background: var(--surface-1) !important;
+  background-blend-mode: normal !important;
 }
+/* Dashboard/project focused cards: solid accent border + soft drop shadow. */
 [data-minimal="true"] .mc-card-frame[data-focused="true"] {
-  border-color: color-mix(in srgb, var(--accent) 56%, transparent) !important;
-  background:
-    url("/card.png") center / cover no-repeat,
-    color-mix(in srgb, var(--accent) 18%, oklch(0.15 0.005 245)) !important;
-  background-blend-mode: overlay, normal !important;
+  border-color: color-mix(in srgb, var(--accent) 72%, transparent) !important;
+  background: var(--surface-0) !important;
+  background-blend-mode: normal !important;
   box-shadow:
-    0 1px 0 oklch(1 0 0 / 0.07) inset,
-    0 1px 2px oklch(0 0 0 / 0.40),
-    0 10px 26px oklch(0 0 0 / 0.30),
-    0 0 0 1px color-mix(in srgb, var(--accent) 32%, transparent) !important;
+    0 0 0 1px color-mix(in srgb, var(--accent) 42%, transparent),
+    0 6px 22px rgba(0, 0, 0, 0.45) !important;
 }
 
 :root:not([data-minimal="true"]) .mc-project-card[data-focused="true"] {
@@ -2068,236 +2124,29 @@ body[data-card-glow] .cursor-glow {
 }
 
 /* =====================================================================
-   Noir theme – flat, near-black, hairline.
-   Builds on minimal: noir sets BOTH `data-minimal` (which supplies the
-   clean-CSS chrome, edge-to-edge layout, and button/input grid) and
-   `data-noir` (this layer). Noir flattens what minimal elevates — no card
-   texture, no accent-tinted surfaces, shadows almost gone. Separation
-   comes from hairline dividers, not borders; borders appear only where
-   they carry meaning (the focused pane, the active control).
-   These selectors share specificity with the [data-minimal] rules above,
-   so this block must stay AFTER the minimal block to win the cascade.
-   Activated by `<html data-minimal="true" data-noir="true">`.
+   FLAT theme — chrome overrides (Ember character).
+   These sit AFTER the [data-minimal] button/input grid above so they win the
+   shared-specificity cascade. The palette + card rules already live in the
+   [data-minimal] block near the top of the flat section.
    ===================================================================== */
 
-[data-noir="true"] {
-  /* Neutral near-black ladder with a faint cool-violet cast so a pink or
-     purple accent sits naturally in it. Surfaces stay within a few percent
-     of each other — hierarchy comes from hairlines, not elevation. */
-  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), #0a0a0c);
-  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), #0f0f12);
-  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #131317);
-  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #19191e);
-  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #212127);
-  --border: rgba(255, 255, 255, 0.065);
-  --border-strong: rgba(255, 255, 255, 0.12);
-  --text: #e9e9ec;
-  --text-dim: rgba(233, 233, 236, 0.56);
-  --text-faint: rgba(233, 233, 236, 0.33);
-  /* Flat terminal canvas — unlike minimal, no baseline accent in the ground;
-     only the (noir-damped) surface tint can lean it toward the accent. */
-  --terminal-bg: color-mix(in srgb, var(--accent) var(--tint-lo), #0c0c0f);
-
-  /* Tighter chrome: squarer radii; the halo focus ring collapses to a
-     single hairline accent ring. */
-  --mm-radius-sm: 4px;
-  --mm-radius: 5px;
-  --mm-radius-lg: 7px;
-  --mm-ring: 0 0 0 1px color-mix(in srgb, var(--accent) 70%, transparent);
-  --mm-elev-1: none;
-  --mm-elev-2: 0 12px 32px oklch(0 0 0 / 0.4);
-}
-
-/* Cards: flat panels. Kill minimal's card.png texture and accent tint —
-   a noir card is its surface color, a hairline, and nothing else. */
-[data-noir="true"] .mc-card-frame {
-  border: 1px solid var(--border) !important;
-  background: var(--surface-0) !important;
-  background-blend-mode: normal !important;
-  box-shadow: none !important;
-}
-[data-noir="true"] .mc-card-frame[data-solid="true"] {
-  background: var(--surface-1) !important;
-  background-blend-mode: normal !important;
-}
-/* The focused pane is the one place noir spends a border: a 1px accent
-   line plus a whisper of glow, like a powered-on indicator. */
-[data-noir="true"] .mc-card-frame[data-focused="true"] {
-  border-color: color-mix(in srgb, var(--accent) 66%, transparent) !important;
-  background: var(--surface-0) !important;
-  background-blend-mode: normal !important;
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent),
-    0 0 24px color-mix(in srgb, var(--accent) 9%, transparent) !important;
-}
-
-/* Buttons: quieter than minimal. Ghost drops its border entirely; the
-   frame variant keeps a hairline of accent; primary stays a solid accent
-   fill but loses the inset gloss. */
-[data-noir="true"] .mc-btn-primary {
-  border-color: transparent;
+/* Buttons/inputs: quiet the base glosses; the square radius vars flatten the
+   corners. */
+[data-minimal="true"] .mc-btn-primary,
+[data-minimal="true"] .mc-btn-primary:hover {
   box-shadow: none;
 }
-[data-noir="true"] .mc-btn-primary:hover {
-  box-shadow: none;
-}
-[data-noir="true"] .mc-btn-frame {
-  background: transparent;
-  border-color: color-mix(in srgb, var(--accent) 32%, transparent);
-}
-[data-noir="true"] .mc-btn-ghost {
-  background: transparent;
-  border-color: transparent;
-}
-[data-noir="true"] .mc-btn-ghost:hover {
-  background: var(--surface-1);
-  border-color: transparent;
-}
-[data-noir="true"] .mc-btn-gray-frame {
-  background: var(--surface-1);
-  border-color: var(--border);
-}
-[data-noir="true"] .mc-btn-gray-frame:hover {
-  background: var(--surface-2);
-  border-color: var(--border-strong);
-}
-[data-noir="true"] .mc-btn-primary:focus-visible {
-  box-shadow: var(--mm-ring);
-}
-
-/* Inputs: flat field, hairline border; focus swaps the hairline for the
-   accent instead of stacking a halo. */
-[data-noir="true"] .mc-input-frame {
-  box-shadow: none !important;
-}
-[data-noir="true"] .mc-input-frame:focus-within {
-  border-color: color-mix(in srgb, var(--accent) 58%, transparent) !important;
-  background: var(--surface-0) !important;
-  box-shadow: none !important;
-}
-
-/* Settings toggle: no glow when on — flat accent fill reads clearly. */
-[data-noir="true"] .settings-toggle-switch[aria-checked="true"] {
-  box-shadow: none;
-}
-
-/* Session grid, focused cell: drop the grid's elevation shadows — in noir
-   the active session is a solid accent border and a whisper of bloom on an
-   otherwise flat card. */
-[data-noir="true"] [data-session-grid] .mc-card-frame:focus-within {
-  border-color: color-mix(in srgb, var(--accent) 78%, transparent) !important;
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--accent) 34%, transparent),
-    0 0 18px color-mix(in srgb, var(--accent) 10%, transparent) !important;
-}
-[data-noir="true"] [data-session-grid] .mc-card-frame:focus-within [data-session-header] {
-  background: color-mix(in srgb, var(--accent) 5%, transparent) !important;
-}
-
-/* =====================================================================
-   Ember theme – warm sepia near-black, flush + square, bundled mono.
-   Like noir it builds on minimal (sets BOTH `data-minimal` for the clean-
-   CSS chrome and `data-ember` for this layer), but the mood is warm rather
-   than cool: a brown-black ground, cream text, square corners, and edge-to-
-   edge panes (the grid's gap/padding collapse to 0 in JS — see SessionGrid).
-   The focused pane spends a solid accent border plus a soft drop shadow so
-   the active session lifts off the flush field. Ships JetBrains Mono as the
-   terminal + UI face for a clearer read.
-   Must stay AFTER the minimal and noir blocks to win the shared-specificity
-   cascade. Activated by `<html data-minimal="true" data-ember="true">`.
-   ===================================================================== */
-
-[data-ember="true"] {
-  /* Warm-charcoal ladder sampled from the reference: the pane/terminal ground
-     sits at a mid ~#2d2d2d (not near-black), faintly warm; headers and solid
-     cards lift one step to ~#34322d. Separation is by tone, not elevation. */
-  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), #242321);
-  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), #2c2b28);
-  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #34322d);
-  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #3e3b35);
-  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #4a463f);
-  /* Hairlines need more alpha here than on the near-black themes: the ground
-     is a mid-gray, so noir-strength borders melt into it (0.09 cream computes
-     to ~1.27:1 against surface-0 — invisible). */
-  --border: rgba(236, 224, 202, 0.15);
-  --border-strong: rgba(236, 224, 202, 0.3);
-  /* Cream text ladder, lifted a step for legibility on the mid-gray ground.
-     dim now holds ≥7:1 on surface-0 and ≥6:1 through surface-2; faint clears
-     AA (≥4.8:1 on surface-0/1) — the old #8c8274 faint fell to ~3.4:1 on the
-     card surfaces where timestamps, tab counts and section counts sit, so it
-     read muddy. Both stay clearly below --text to keep the tier hierarchy. */
-  --text: #e9e3d5;
-  --text-dim: #c6bca8;
-  --text-faint: #a89e8c;
-  /* Flat warm terminal canvas — matches the sampled ~#2d2d2d ground. */
-  --terminal-bg: color-mix(in srgb, var(--accent) var(--tint-lo), #2b2a27);
-
-  /* Bundled face: clearer, warmer mono for both xterm (via --mc-terminal-font,
-     read by createTerminalOptions) and every UI mono surface. */
-  --mc-terminal-font: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
-  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
-  --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
-  /* Bundled UI sans face — Plus Jakarta Sans. */
-  --font-sans: "Plus Jakarta Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
-  --sans: "Plus Jakarta Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
-
-  /* Square everything — no rounded sessions or chrome. */
-  --mm-radius-sm: 0;
-  --mm-radius: 0;
-  --mm-radius-lg: 0;
-  /* Keyboard focus: crisp accent line plus a soft halo — a lone 1px ring
-     gets lost against the mid-gray ground. */
-  --mm-ring:
-    0 0 0 1px color-mix(in srgb, var(--accent) 90%, transparent),
-    0 0 0 4px color-mix(in srgb, var(--accent) 24%, transparent);
-  --mm-elev-1: none;
-  --mm-elev-2: 0 12px 32px rgba(0, 0, 0, 0.45);
-  /* Ember's default terracotta accent is a light mid-tone — minimal's
-     near-white button label reads ~2.8:1 on it. Dark warm ink reads ~5.6:1
-     and beats near-white on every selectable accent except indigo. */
-  --mm-on-accent: #251e15;
-}
-
-/* Flat, square panels — kill minimal's card.png texture, accent tint, radius
-   and elevation. An ember card is its warm surface color and a hairline. */
-[data-ember="true"] .mc-card-frame {
-  border: 1px solid var(--border) !important;
-  border-radius: 0 !important;
-  background: var(--surface-0) !important;
-  background-blend-mode: normal !important;
-  box-shadow: none !important;
-}
-[data-ember="true"] .mc-card-frame[data-solid="true"] {
-  background: var(--surface-1) !important;
-  background-blend-mode: normal !important;
-}
-/* Dashboard/project focused cards: solid accent border + soft drop shadow. */
-[data-ember="true"] .mc-card-frame[data-focused="true"] {
-  border-color: color-mix(in srgb, var(--accent) 72%, transparent) !important;
-  background: var(--surface-0) !important;
-  background-blend-mode: normal !important;
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--accent) 42%, transparent),
-    0 6px 22px rgba(0, 0, 0, 0.45) !important;
-}
-
-/* Buttons/inputs: quiet the minimal glosses; the square radius vars above
-   already flatten their corners. */
-[data-ember="true"] .mc-btn-primary,
-[data-ember="true"] .mc-btn-primary:hover {
-  box-shadow: none;
-}
-/* Ghost buttons keep minimal's hairline border: on ember's mid-gray ground a
-   borderless ghost has no affordance at all. Hover lifts to surface-2 because
-   session headers already sit on surface-1, where minimal's surface-1 hover
-   would be invisible. */
-[data-ember="true"] .mc-btn-ghost:hover {
+/* Ghost buttons keep their hairline border: on the mid-gray ground a
+   borderless ghost has no affordance. Hover lifts to surface-2 because session
+   headers already sit on surface-1, where a surface-1 hover would be
+   invisible. */
+[data-minimal="true"] .mc-btn-ghost:hover {
   background: var(--surface-2);
 }
-[data-ember="true"] .mc-input-frame {
+[data-minimal="true"] .mc-input-frame {
   box-shadow: none !important;
 }
-[data-ember="true"] .mc-input-frame:focus-within {
+[data-minimal="true"] .mc-input-frame:focus-within {
   border-color: color-mix(in srgb, var(--accent) 58%, transparent) !important;
   box-shadow: none !important;
 }
@@ -2307,7 +2156,7 @@ body[data-card-glow] .cursor-glow {
    flush) so the buttons' hairlines and focus halo aren't clipped against the
    strip edges. Overrides the component's inline padding, so it needs
    !important. */
-[data-ember="true"] .mc-project-header {
+[data-minimal="true"] .mc-project-header {
   padding: 6px 20px !important;
 }
 
@@ -2316,17 +2165,17 @@ body[data-card-glow] .cursor-glow {
    digit, so the number reads muddy on the warm ground. Drop the chip to the
    near-black ground with a crisper hairline so the light digit sits in a
    defined dark notch and pops (~4:1). Inline styles, so !important. */
-[data-ember="true"] .mc-project-hotkey-badge {
+[data-minimal="true"] .mc-project-hotkey-badge {
   background: var(--bg) !important;
   border-color: var(--border-strong) !important;
   color: var(--text-dim) !important;
 }
 
-/* Session grid, focused cell: the active window in the reference — a solid
-   accent border with a little shadow lifting it off the flush field, plus a
-   whisper of accent bloom. (The cell is z-lifted in SessionGrid so the drop
-   shadow reads over its flush neighbours.) */
-[data-ember="true"] [data-session-grid] .mc-card-frame:focus-within {
+/* Session grid, focused cell: the active window — a solid accent border with a
+   little shadow lifting it off the flush field, plus a whisper of accent
+   bloom. (The cell is z-lifted in SessionGrid so the drop shadow reads over
+   its flush neighbours.) */
+[data-minimal="true"] [data-session-grid] .mc-card-frame:focus-within {
   border-color: color-mix(in srgb, var(--accent) 88%, transparent) !important;
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent),
@@ -2337,7 +2186,7 @@ body[data-card-glow] .cursor-glow {
      the inline drag/expand/nav z-indices still win when they're set. */
   z-index: 3;
 }
-[data-ember="true"] [data-session-grid] .mc-card-frame:focus-within [data-session-header] {
+[data-minimal="true"] [data-session-grid] .mc-card-frame:focus-within [data-session-header] {
   /* ~18% accent over the header surface reproduces the sampled warm active
      header (~#4d3e34) — the focused pane's title bar warms noticeably. */
   background: color-mix(in srgb, var(--accent) 18%, var(--surface-1)) !important;
@@ -2457,13 +2306,8 @@ body[data-card-glow] .cursor-glow {
    applySurfaceTint (src/lib/surface-tint.ts) and mirrored by the
    pre-hydration script in __root.tsx.
 
-   Recipes are tuned per style: painted/minimal take a clearly visible
-   wash; noir stays a whisper (its identity is the flat near-black
-   ground); ember leans its warm charcoal toward the accent hue without
-   losing the mid-gray lightness its text/hairline contrast ladder was
-   tuned against (keep vivid low enough that those ratios hold).
-   Cascade: these sit last in the file, and the per-style rows use two
-   attribute selectors so they beat the two generic rows. ============ */
+   Both themes (painted and the near-black flat theme) take the same wash —
+   the generic recipe below. ============ */
 
 [data-tint="subtle"] {
   --tint-lo: 2.5%;
@@ -2475,25 +2319,33 @@ body[data-card-glow] .cursor-glow {
   --tint-md: 9%;
   --tint-hi: 11%;
 }
-
-[data-noir="true"][data-tint="subtle"] {
-  --tint-lo: 1.5%;
-  --tint-md: 2%;
-  --tint-hi: 3%;
-}
-[data-noir="true"][data-tint="vivid"] {
-  --tint-lo: 4%;
-  --tint-md: 5.5%;
-  --tint-hi: 7%;
+/* Heavy accent wash (painted, and flat-light) — lifts the ground strongly
+   toward the accent. Flat-dark gets a dedicated recipe below instead. */
+[data-tint="intense"] {
+  --tint-lo: 13%;
+  --tint-md: 16%;
+  --tint-hi: 19%;
 }
 
-[data-ember="true"][data-tint="subtle"] {
-  --tint-lo: 3%;
-  --tint-md: 4%;
-  --tint-hi: 5%;
-}
-[data-ember="true"][data-tint="vivid"] {
-  --tint-lo: 7%;
-  --tint-md: 9%;
-  --tint-hi: 10%;
+/* Flat + Intense (DARK only) reproduces the old Ember theme's warm-charcoal
+   ground: the near-black base lifts to a neutral mid warm charcoal (#242321
+   ladder) with only a whisper of the accent, so the ground reads warm but
+   un-tinted while the accent still shows on buttons/dots/focus. This is the
+   "like Ember" look. Scoped to data-theme="dark" so flat-light keeps its paper
+   ground (it falls back to the generic intense wash above). Specificity (0,3,0)
+   beats both the [data-minimal] palette and the light block. */
+[data-minimal="true"][data-theme="dark"][data-tint="intense"] {
+  --bg: color-mix(in srgb, var(--accent) 4%, #242321);
+  --surface-0: color-mix(in srgb, var(--accent) 5%, #2c2b28);
+  --surface-1: color-mix(in srgb, var(--accent) 5%, #34322d);
+  --surface-2: color-mix(in srgb, var(--accent) 6%, #3e3b35);
+  --surface-3: color-mix(in srgb, var(--accent) 6%, #4a463f);
+  /* Terminal ground: a distinct neutral warm tone against the card/header
+     surface so the session content separates from the chrome. Set directly (no
+     accent mix) so a warm accent like terracotta doesn't cast it red. */
+  --terminal-bg: oklab(0.28 0 0.01);
+  /* The mid-gray ground melts thin hairlines — restore Ember's stronger cream
+     borders. */
+  --border: rgba(236, 224, 202, 0.15);
+  --border-strong: rgba(236, 224, 202, 0.3);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2564,12 +2564,12 @@ body[data-card-glow] .cursor-glow {
    Specificity (0,3,0) beats both the [data-minimal] palette and the light
    block. */
 [data-minimal="true"][data-theme="dark"][data-tint="intense"] {
-  --bg: color-mix(in srgb, var(--accent) 7%, #222222);
-  --surface-0: color-mix(in srgb, var(--accent) 8%, #2a2a2a);
-  --surface-1: color-mix(in srgb, var(--accent) 8%, #313131);
-  --surface-2: color-mix(in srgb, var(--accent) 9%, #3a3a3a);
-  --surface-3: color-mix(in srgb, var(--accent) 9%, #444444);
-  --terminal-bg: color-mix(in srgb, var(--accent) 6%, #2d2d2d);
+  --bg: color-mix(in srgb, var(--accent) 6%, #1b1b1b);
+  --surface-0: color-mix(in srgb, var(--accent) 8%, #2b2b2b);
+  --surface-1: color-mix(in srgb, var(--accent) 8%, #323232);
+  --surface-2: color-mix(in srgb, var(--accent) 9%, #3b3b3b);
+  --surface-3: color-mix(in srgb, var(--accent) 9%, #454545);
+  --terminal-bg: color-mix(in srgb, var(--accent) 6%, #2e2e2e);
   /* The mid-gray ground melts thin hairlines, so these run a touch stronger
      than the near-black base — neutral white so they pair with any accent
      (the old cream hairlines clashed with cool accents). */

--- a/src/styles.css
+++ b/src/styles.css
@@ -1750,6 +1750,89 @@ body[data-card-glow] .cursor-glow {
   background: transparent;
 }
 
+/* Pinned-project rail tiles (ProjectBar.tsx): a faint tonal wash on hover so
+   the tiles acknowledge the pointer before a click/drag. */
+.mc-pinned-tile {
+  background: transparent;
+  border: 1px solid transparent;
+  transition: background 120ms ease, border-color 150ms ease;
+}
+.mc-pinned-tile:hover {
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+}
+
+/* Status pills (StatusDot.tsx) and project activity badges
+   (ProjectStatusBadge.tsx). Painted keeps the hairlines; flat drops them —
+   the tonal fill + status dot carry the pill on their own. */
+.mc-status-pill {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+}
+.mc-project-status-badge {
+  background: var(--surface-0);
+  border: 1px solid var(--border);
+}
+.mc-project-status-badge[data-active] {
+  background: var(--accent-faint);
+  border-color: var(--accent-border);
+}
+[data-minimal="true"] .mc-status-pill,
+[data-minimal="true"] .mc-project-status-badge {
+  border-color: transparent;
+}
+[data-minimal="true"] .mc-project-status-badge:not([data-active]) {
+  background: var(--surface-2);
+}
+
+/* Terminal tabs (project/user terminal bar). Layout stays inline in
+   UserTerminalPanel; the visual state lives here so tabs get hover feedback. */
+.mc-terminal-tab {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+.mc-terminal-tab:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}
+.mc-terminal-tab[data-active] {
+  background: var(--surface-1);
+  border-color: var(--accent);
+}
+.mc-terminal-tab:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* Sessions view segmented control (Active / Pinned / Archived). Same split:
+   layout inline in SessionScopeToggle, visual state + hover here. */
+.mc-session-scope-toggle {
+  background: var(--surface-0);
+  border: 1px solid var(--border);
+}
+.mc-session-scope-tab {
+  background: transparent;
+  color: var(--text-dim);
+  transition: background 120ms ease, color 120ms ease;
+}
+.mc-session-scope-tab:hover {
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+  color: var(--text);
+}
+.mc-session-scope-tab[data-selected] {
+  background: var(--surface-2);
+  color: var(--text);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 1px 2px rgba(0, 0, 0, 0.3);
+}
+.mc-session-scope-tab:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 82%, white);
+  outline-offset: -2px;
+}
+
 /* xterm overrides to match the active app theme */
 .xterm-viewport {
   background-color: var(--terminal-bg) !important;
@@ -1781,10 +1864,11 @@ body[data-card-glow] .cursor-glow {
   --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), oklch(0.155 0.006 65));
   --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), oklch(0.2 0.007 65));
   --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), oklch(0.25 0.009 65));
-  /* On a near-black ground a thin cream hairline reads cleanly, so it can be
-     dialled back from the mid-gray-tuned strength. */
-  --border: rgba(236, 224, 202, 0.12);
-  --border-strong: rgba(236, 224, 202, 0.24);
+  /* On a near-black ground the surface ladder does most of the separating, so
+     the hairlines run very quiet — chrome buttons are borderless-tonal below,
+     and what keeps a border (cards, inputs) only needs a whisper of an edge. */
+  --border: rgba(236, 224, 202, 0.09);
+  --border-strong: rgba(236, 224, 202, 0.18);
   /* Warm cream text ladder — even higher contrast on the deep ground. Both dim
      and faint stay clearly below --text to keep the tier hierarchy. */
   --text: #e9e3d5;
@@ -1802,10 +1886,12 @@ body[data-card-glow] .cursor-glow {
   --font-sans: "Plus Jakarta Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
   --sans: "Plus Jakarta Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
 
-  /* Square everything — no rounded sessions or chrome. */
-  --mm-radius-sm: 0;
-  --mm-radius: 0;
-  --mm-radius-lg: 0;
+  /* Gently rounded chrome — enough to take the edge off the flat panels
+     without going pill-shaped. Session-grid panes stay square (flush layout,
+     see the [data-session-grid] override below). */
+  --mm-radius-sm: 4px;
+  --mm-radius: 6px;
+  --mm-radius-lg: 8px;
   --mm-ease: cubic-bezier(0.22, 1, 0.36, 1);
   --mm-dur: 140ms;
   /* Keyboard focus: crisp accent line plus a soft halo — a lone 1px ring gets
@@ -1830,18 +1916,24 @@ body[data-card-glow] .cursor-glow {
   display: none !important;
 }
 
-/* Cards: flat, square panels — no card.png texture, no accent tint, no radius,
+/* Cards: flat, gently rounded panels — no card.png texture, no accent tint,
    no elevation. A flat card is its warm surface color and a hairline. */
 [data-minimal="true"] .mc-card-frame {
   border: 1px solid var(--border) !important;
   border-image: none !important;
-  border-radius: 0 !important;
+  border-radius: var(--mm-radius-lg) !important;
   background: var(--surface-0) !important;
   background-blend-mode: normal !important;
   box-shadow: none !important;
   transition:
+    background-color var(--mm-dur) var(--mm-ease),
     border-color var(--mm-dur) var(--mm-ease),
     box-shadow var(--mm-dur) var(--mm-ease) !important;
+}
+/* Session-grid panes are laid out flush (gap 0), so their corners stay square —
+   rounding would notch the seams between touching cells. */
+[data-minimal="true"] [data-session-grid] .mc-card-frame {
+  border-radius: 0 !important;
 }
 [data-minimal="true"] .mc-card-frame[data-solid="true"] {
   background: var(--surface-1) !important;
@@ -1963,19 +2055,24 @@ body[data-card-glow] .cursor-glow {
   border-color: color-mix(in srgb, var(--accent) 38%, transparent);
   color: color-mix(in srgb, var(--accent) 72%, white);
 }
+/* Ghost / gray-frame / danger go borderless-tonal: on the flat ground a
+   hairline on every chrome button reads as wireframe noise. Affordance comes
+   from the icon/label + a tonal fill that appears on hover (gray-frame keeps
+   a resting fill so it still reads one step above ghost). The 1px border is
+   kept transparent so hover can light it without a layout shift. */
 [data-minimal="true"] .mc-btn-ghost {
   background: transparent;
-  border-color: var(--border-strong);
+  border-color: transparent;
   color: var(--text-dim);
 }
 [data-minimal="true"] .mc-btn-gray-frame {
   background: var(--surface-1);
-  border-color: var(--border-strong);
+  border-color: transparent;
   color: var(--text);
 }
 [data-minimal="true"] .mc-btn-danger {
   background: transparent;
-  border-color: color-mix(in srgb, var(--status-failed) 38%, transparent);
+  border-color: transparent;
   color: var(--status-failed);
 }
 
@@ -1996,11 +2093,9 @@ body[data-card-glow] .cursor-glow {
 }
 [data-minimal="true"] .mc-btn-gray-frame:hover {
   background: var(--surface-2);
-  border-color: color-mix(in srgb, var(--text-dim) 30%, var(--border-strong));
 }
 [data-minimal="true"] .mc-btn-danger:hover {
   background: color-mix(in srgb, var(--status-failed) 12%, transparent);
-  border-color: color-mix(in srgb, var(--status-failed) 58%, transparent);
 }
 
 /* Press: 0.5px micro-translate, faster ease-out to feel tactile */
@@ -2020,6 +2115,30 @@ body[data-card-glow] .cursor-glow {
 [data-minimal="true"] .mc-btn-danger::before,
 [data-minimal="true"] .mc-btn-gray-frame::before {
   display: none !important;
+}
+
+/* Review-changes + Ship segmented pair. The painted themes fuse these two into
+   one control via adjacent pixel frames (attached-left/right drop the touching
+   edge). The flat theme hides those ::before frames, so the borderless ghost
+   count and the Ship button read as two loose items. Restore the grouping with
+   a single hairline frame around the pair plus one divider between the cells. */
+[data-minimal="true"] .mc-ship-group {
+  border: 1px solid var(--border-strong);
+  border-radius: var(--mm-radius);
+  background: var(--surface-1);
+  overflow: hidden;
+}
+[data-minimal="true"] .mc-ship-group .mc-btn {
+  border-radius: 0;
+}
+/* Ship is the group's direct child (the count sits inside a display:contents
+   tooltip span). Give it the divider; drop the rest of its frame so the fill
+   tiles edge-to-edge within the shared border. */
+[data-minimal="true"] .mc-ship-group > .mc-btn {
+  border-top: 0;
+  border-right: 0;
+  border-bottom: 0;
+  border-left: 1px solid var(--border-strong);
 }
 
 /* Focus: soft brand-tinted halo, no hard outline */
@@ -2141,10 +2260,8 @@ body[data-card-glow] .cursor-glow {
 [data-minimal="true"] .mc-btn-primary:hover {
   box-shadow: none;
 }
-/* Ghost buttons keep their hairline border: on the mid-gray ground a
-   borderless ghost has no affordance. Hover lifts to surface-2 because session
-   headers already sit on surface-1, where a surface-1 hover would be
-   invisible. */
+/* Ghost hover lifts to surface-2 because session headers already sit on
+   surface-1, where a surface-1 hover would be invisible. */
 [data-minimal="true"] .mc-btn-ghost:hover {
   background: var(--surface-2);
 }
@@ -2154,6 +2271,67 @@ body[data-card-glow] .cursor-glow {
 [data-minimal="true"] .mc-input-frame:focus-within {
   border-color: color-mix(in srgb, var(--accent) 58%, transparent) !important;
   box-shadow: none !important;
+}
+
+/* Terminal tabs: borderless-tonal; the active tab reads by accent-tinted fill
+   instead of an accent outline. */
+[data-minimal="true"] .mc-terminal-tab {
+  border-color: transparent;
+  border-radius: var(--mm-radius-sm);
+}
+[data-minimal="true"] .mc-terminal-tab:hover {
+  border-color: transparent;
+  background: var(--surface-2);
+}
+[data-minimal="true"] .mc-terminal-tab[data-active] {
+  border-color: transparent;
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+/* Sessions segmented control: the surface-1 tray separates it from the band
+   without a hairline. */
+[data-minimal="true"] .mc-session-scope-toggle {
+  border-color: transparent;
+  background: var(--surface-1);
+}
+[data-minimal="true"] .mc-session-scope-tab[data-selected] {
+  background: var(--surface-3);
+}
+
+/* Chips join the borderless-tonal grammar: fill carries them, hover lifts. */
+[data-minimal="true"] .mc-hidden-chip {
+  border-color: transparent;
+  background: var(--surface-1);
+  border-radius: var(--mm-radius);
+}
+[data-minimal="true"] .mc-hidden-chip:hover {
+  border-color: transparent;
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+/* Every button acknowledges the press — the 0.5px dip the named variants
+   already have, extended to the base mc-btn variants (solid/accent/plain).
+   The base .mc-btn transition list doesn't include transform, so it's added
+   here or the dip would snap instead of easing back. */
+[data-minimal="true"] .mc-btn {
+  transition:
+    background-color var(--mm-dur) var(--mm-ease),
+    border-color var(--mm-dur) var(--mm-ease),
+    color var(--mm-dur) var(--mm-ease),
+    opacity var(--mm-dur) var(--mm-ease),
+    box-shadow var(--mm-dur) var(--mm-ease),
+    transform var(--mm-dur) var(--mm-ease);
+}
+[data-minimal="true"] .mc-btn:not(:disabled):not([aria-disabled="true"]):active {
+  transform: translateY(0.5px);
+  transition-duration: 60ms;
+}
+
+/* Toggle switches hint on hover before they're flipped. */
+[data-minimal="true"] .settings-toggle-switch:not(:disabled):not([aria-checked="true"]):hover {
+  border-color: var(--border-strong);
+  background: var(--surface-3);
 }
 
 /* Project header: collapse the tall default band (22px 24px 18px) to a tight
@@ -2355,25 +2533,26 @@ body[data-card-glow] .cursor-glow {
   --tint-hi: 19%;
 }
 
-/* Flat + Intense (DARK only) reproduces the old Ember theme's warm-charcoal
-   ground: the near-black base lifts to a neutral mid warm charcoal (#242321
-   ladder) with only a whisper of the accent, so the ground reads warm but
-   un-tinted while the accent still shows on buttons/dots/focus. This is the
-   "like Ember" look. Scoped to data-theme="dark" so flat-light keeps its paper
-   ground (it falls back to the generic intense wash above). Specificity (0,3,0)
-   beats both the [data-minimal] palette and the light block. */
+/* Flat + Intense (DARK only) lifts the near-black base to Ember's mid-charcoal
+   ladder — but the cast comes from the ACCENT mixed over a neutral charcoal,
+   not from a baked-in warm hex ladder. A terracotta accent reproduces the old
+   warm Ember ground; a blue accent gives a cool blue-charcoal; every accent
+   gets its own ground (this is the whole point of the Intense tint). The
+   terminal ground takes the same mix at a lower dose so session content still
+   separates from the chrome. Scoped to data-theme="dark" so flat-light keeps
+   its paper ground (it falls back to the generic intense wash above).
+   Specificity (0,3,0) beats both the [data-minimal] palette and the light
+   block. */
 [data-minimal="true"][data-theme="dark"][data-tint="intense"] {
-  --bg: color-mix(in srgb, var(--accent) 4%, #242321);
-  --surface-0: color-mix(in srgb, var(--accent) 5%, #2c2b28);
-  --surface-1: color-mix(in srgb, var(--accent) 5%, #34322d);
-  --surface-2: color-mix(in srgb, var(--accent) 6%, #3e3b35);
-  --surface-3: color-mix(in srgb, var(--accent) 6%, #4a463f);
-  /* Terminal ground: a distinct neutral warm tone against the card/header
-     surface so the session content separates from the chrome. Set directly (no
-     accent mix) so a warm accent like terracotta doesn't cast it red. */
-  --terminal-bg: oklab(0.28 0 0.01);
-  /* The mid-gray ground melts thin hairlines — restore Ember's stronger cream
-     borders. */
-  --border: rgba(236, 224, 202, 0.15);
-  --border-strong: rgba(236, 224, 202, 0.3);
+  --bg: color-mix(in srgb, var(--accent) 7%, #222222);
+  --surface-0: color-mix(in srgb, var(--accent) 8%, #2a2a2a);
+  --surface-1: color-mix(in srgb, var(--accent) 8%, #313131);
+  --surface-2: color-mix(in srgb, var(--accent) 9%, #3a3a3a);
+  --surface-3: color-mix(in srgb, var(--accent) 9%, #444444);
+  --terminal-bg: color-mix(in srgb, var(--accent) 6%, #2d2d2d);
+  /* The mid-gray ground melts thin hairlines, so these run a touch stronger
+     than the near-black base — neutral white so they pair with any accent
+     (the old cream hairlines clashed with cool accents). */
+  --border: rgba(255, 255, 255, 0.1);
+  --border-strong: rgba(255, 255, 255, 0.2);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -151,8 +151,10 @@
   --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #fafafb);
   --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #f2f2f4);
   --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #e9e9ee);
-  --border: rgba(18, 22, 33, 0.09);
-  --border-strong: rgba(18, 22, 33, 0.16);
+  /* Warm hairline gray (#cec5c0). Opaque rather than translucent, but still
+     accent-tinted via color-mix so it tracks the palette like the surfaces do. */
+  --border: color-mix(in srgb, var(--accent) var(--tint-md), #cec5c0);
+  --border-strong: color-mix(in srgb, var(--accent) var(--tint-hi), #b3a9a2);
   --text: #17181c;
   --text-dim: rgba(23, 24, 28, 0.6);
   --text-faint: rgba(23, 24, 28, 0.4);

--- a/src/styles.css
+++ b/src/styles.css
@@ -26,17 +26,26 @@
 }
 
 :root {
-  --bg: #000000;
-  --surface-0: #0e1013;
-  --surface-1: #14171b;
-  --surface-2: #1a1d22;
-  --surface-3: #22262c;
+  /* Surface tint: how much accent is mixed into the surface tokens below.
+     0% = each style's exact base palette. Raised by the `data-tint` blocks at
+     the bottom of this file (per-style recipes); applied via applySurfaceTint
+     (src/lib/surface-tint.ts). lo = page/terminal ground, md = surface-0/1,
+     hi = surface-2/3 (raised chrome reads slightly more tinted). */
+  --tint-lo: 0%;
+  --tint-md: 0%;
+  --tint-hi: 0%;
+
+  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), #000000);
+  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), #0e1013);
+  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #14171b);
+  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #1a1d22);
+  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #22262c);
   --border: rgba(255, 255, 255, 0.06);
   --border-strong: rgba(255, 255, 255, 0.12);
   --text: #e8e6df;
   --text-dim: rgba(232, 230, 223, 0.6);
   --text-faint: rgba(232, 230, 223, 0.38);
-  --terminal-bg: #050607;
+  --terminal-bg: color-mix(in srgb, var(--accent) var(--tint-lo), #050607);
 
   --accent: #ff5a1f;
   --accent-dim: rgba(255, 90, 31, 0.18);
@@ -72,17 +81,17 @@
 }
 
 [data-theme="light"] {
-  --bg: #f7f6f2;
-  --surface-0: #ffffff;
-  --surface-1: #fafaf7;
-  --surface-2: #f1f0eb;
-  --surface-3: #e7e6e0;
+  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), #f7f6f2);
+  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), #ffffff);
+  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #fafaf7);
+  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #f1f0eb);
+  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #e7e6e0);
   --border: rgba(0, 0, 0, 0.08);
   --border-strong: rgba(0, 0, 0, 0.14);
   --text: #1a1a1a;
   --text-dim: rgba(26, 26, 26, 0.62);
   --text-faint: rgba(26, 26, 26, 0.38);
-  --terminal-bg: #ffffff;
+  --terminal-bg: color-mix(in srgb, var(--accent) var(--tint-lo), #ffffff);
   --status-interrupted: oklch(0.58 0.17 35);
   --status-done: oklch(0.50 0.14 150);
   --status-idle: rgba(26, 26, 26, 0.3);
@@ -1694,16 +1703,21 @@ body[data-card-glow] .cursor-glow {
   /* Near-black neutral ground with a barely-perceptible cool undertone (245°).
      Cards (which sit on /card.png) need to read clearly as objects against
      the page, so the page itself sits well below them. */
-  --bg: oklch(0.08 0.003 245);
-  --surface-0: oklch(0.115 0.004 245);
-  --surface-1: oklch(0.145 0.005 245);
-  --surface-2: oklch(0.185 0.006 245);
-  --surface-3: oklch(0.235 0.008 245);
+  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), oklch(0.08 0.003 245));
+  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), oklch(0.115 0.004 245));
+  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), oklch(0.145 0.005 245));
+  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), oklch(0.185 0.006 245));
+  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), oklch(0.235 0.008 245));
   --border: oklch(0.62 0.010 245 / 0.16);
   --border-strong: oklch(0.72 0.016 245 / 0.26);
   /* Terminal canvas: same near-black ground, lifted 5% toward the accent
-     so the running terminal carries a barely-there hint of the active theme. */
-  --terminal-bg: color-mix(in srgb, var(--accent) 5%, oklch(0.07 0.003 245));
+     so the running terminal carries a barely-there hint of the active theme
+     even with tint off; the surface tint adds on top of that baseline. */
+  --terminal-bg: color-mix(
+    in srgb,
+    var(--accent) calc(5% + var(--tint-lo)),
+    oklch(0.07 0.003 245)
+  );
 
   /* Minimal-only design tokens. Subtle rounded chrome matches the reference
      aesthetic — small radii read as considered, not playful. */
@@ -2070,18 +2084,19 @@ body[data-card-glow] .cursor-glow {
   /* Neutral near-black ladder with a faint cool-violet cast so a pink or
      purple accent sits naturally in it. Surfaces stay within a few percent
      of each other — hierarchy comes from hairlines, not elevation. */
-  --bg: #0a0a0c;
-  --surface-0: #0f0f12;
-  --surface-1: #131317;
-  --surface-2: #19191e;
-  --surface-3: #212127;
+  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), #0a0a0c);
+  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), #0f0f12);
+  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #131317);
+  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #19191e);
+  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #212127);
   --border: rgba(255, 255, 255, 0.065);
   --border-strong: rgba(255, 255, 255, 0.12);
   --text: #e9e9ec;
   --text-dim: rgba(233, 233, 236, 0.56);
   --text-faint: rgba(233, 233, 236, 0.33);
-  /* Flat terminal canvas — unlike minimal, no accent mixed into the ground. */
-  --terminal-bg: #0c0c0f;
+  /* Flat terminal canvas — unlike minimal, no baseline accent in the ground;
+     only the (noir-damped) surface tint can lean it toward the accent. */
+  --terminal-bg: color-mix(in srgb, var(--accent) var(--tint-lo), #0c0c0f);
 
   /* Tighter chrome: squarer radii; the halo focus ring collapses to a
      single hairline accent ring. */
@@ -2196,11 +2211,11 @@ body[data-card-glow] .cursor-glow {
   /* Warm-charcoal ladder sampled from the reference: the pane/terminal ground
      sits at a mid ~#2d2d2d (not near-black), faintly warm; headers and solid
      cards lift one step to ~#34322d. Separation is by tone, not elevation. */
-  --bg: #242321;
-  --surface-0: #2c2b28;
-  --surface-1: #34322d;
-  --surface-2: #3e3b35;
-  --surface-3: #4a463f;
+  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), #242321);
+  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), #2c2b28);
+  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #34322d);
+  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #3e3b35);
+  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #4a463f);
   /* Hairlines need more alpha here than on the near-black themes: the ground
      is a mid-gray, so noir-strength borders melt into it (0.09 cream computes
      to ~1.27:1 against surface-0 — invisible). */
@@ -2215,7 +2230,7 @@ body[data-card-glow] .cursor-glow {
   --text-dim: #c6bca8;
   --text-faint: #a89e8c;
   /* Flat warm terminal canvas — matches the sampled ~#2d2d2d ground. */
-  --terminal-bg: #2b2a27;
+  --terminal-bg: color-mix(in srgb, var(--accent) var(--tint-lo), #2b2a27);
 
   /* Bundled face: clearer, warmer mono for both xterm (via --mc-terminal-font,
      read by createTerminalOptions) and every UI mono surface. */
@@ -2432,4 +2447,53 @@ body[data-card-glow] .cursor-glow {
 .mc-md-annot-add:hover {
   background: var(--surface-2);
   color: var(--text);
+}
+
+/* =====================================================================
+   SURFACE TINT — per-style accent-in-the-ground recipes.
+   `data-tint="subtle" | "vivid"` on <html> (absent = off) raises the
+   --tint-lo/md/hi percentages that every palette block above mixes into
+   --bg / --surface-0..3 / --terminal-bg via color-mix. Applied by
+   applySurfaceTint (src/lib/surface-tint.ts) and mirrored by the
+   pre-hydration script in __root.tsx.
+
+   Recipes are tuned per style: painted/minimal take a clearly visible
+   wash; noir stays a whisper (its identity is the flat near-black
+   ground); ember leans its warm charcoal toward the accent hue without
+   losing the mid-gray lightness its text/hairline contrast ladder was
+   tuned against (keep vivid low enough that those ratios hold).
+   Cascade: these sit last in the file, and the per-style rows use two
+   attribute selectors so they beat the two generic rows. ============ */
+
+[data-tint="subtle"] {
+  --tint-lo: 2.5%;
+  --tint-md: 3.5%;
+  --tint-hi: 4.5%;
+}
+[data-tint="vivid"] {
+  --tint-lo: 7%;
+  --tint-md: 9%;
+  --tint-hi: 11%;
+}
+
+[data-noir="true"][data-tint="subtle"] {
+  --tint-lo: 1.5%;
+  --tint-md: 2%;
+  --tint-hi: 3%;
+}
+[data-noir="true"][data-tint="vivid"] {
+  --tint-lo: 4%;
+  --tint-md: 5.5%;
+  --tint-hi: 7%;
+}
+
+[data-ember="true"][data-tint="subtle"] {
+  --tint-lo: 3%;
+  --tint-md: 4%;
+  --tint-hi: 5%;
+}
+[data-ember="true"][data-tint="vivid"] {
+  --tint-lo: 7%;
+  --tint-md: 9%;
+  --tint-hi: 10%;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -140,38 +140,43 @@
   --running-indicator-text: var(--text);
 }
 
-/* Flat theme, LIGHT mode — a warm-paper inversion of the Ember dark ground.
+/* Flat theme, LIGHT mode — a clean neutral SaaS light: pure white cards on a
+   cool near-white ground, near-black ink, hairline cool-gray borders.
    Scoped to the flat theme (data-minimal): Painted is always dark (its
    data-theme is forced to "dark" at apply time), so light only ever means
-   flat-light. Warm off-white surfaces + warm-charcoal text keep the Ember
-   character in daylight. */
+   flat-light. */
 [data-minimal="true"][data-theme="light"] {
-  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), #f5f2ea);
-  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), #fffdf8);
-  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #f7f4ec);
-  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #efe9dd);
-  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #e3dccc);
-  --border: rgba(60, 50, 30, 0.14);
-  --border-strong: rgba(60, 50, 30, 0.22);
-  --text: #2a241c;
-  --text-dim: rgba(42, 36, 28, 0.64);
-  --text-faint: rgba(42, 36, 28, 0.42);
-  --terminal-bg: color-mix(in srgb, var(--accent) var(--tint-lo), #fffdf8);
+  --bg: color-mix(in srgb, var(--accent) var(--tint-lo), #f4f4f6);
+  --surface-0: color-mix(in srgb, var(--accent) var(--tint-md), #ffffff);
+  --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #fafafb);
+  --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #f2f2f4);
+  --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #e9e9ee);
+  --border: rgba(18, 22, 33, 0.09);
+  --border-strong: rgba(18, 22, 33, 0.16);
+  --text: #17181c;
+  --text-dim: rgba(23, 24, 28, 0.6);
+  --text-faint: rgba(23, 24, 28, 0.4);
+  --terminal-bg: color-mix(in srgb, var(--accent) var(--tint-lo), #ffffff);
   /* Light accent fills take white ink again. */
   --mm-on-accent: #ffffff;
+  /* Status hues darken for contrast on white; the dark-theme pastels wash out. */
+  --status-ready: oklch(0.55 0.1 220);
+  --status-running: oklch(0.6 0.13 75);
+  --status-needs: oklch(0.55 0.19 25);
+  --status-failed: oklch(0.55 0.19 25);
   --status-interrupted: oklch(0.58 0.17 35);
-  --status-done: oklch(0.50 0.14 150);
-  --status-idle: rgba(42, 36, 28, 0.3);
-  --status-warning: oklch(0.60 0.13 75);
+  --status-done: oklch(0.5 0.14 150);
+  --status-idle: rgba(23, 24, 28, 0.3);
+  --status-warning: oklch(0.6 0.13 75);
   --banner-bg: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--accent) 14%, var(--surface-0)),
+    color-mix(in srgb, var(--accent) 12%, var(--surface-0)),
     var(--surface-0) 34%,
-    color-mix(in srgb, var(--accent) 14%, var(--surface-0))
+    color-mix(in srgb, var(--accent) 12%, var(--surface-0))
   );
-  --banner-muted: rgba(42, 36, 28, 0.78);
+  --banner-muted: rgba(23, 24, 28, 0.78);
   --banner-link: color-mix(in srgb, var(--accent) 62%, black);
-  --banner-icon-bg: color-mix(in srgb, var(--accent) 16%, var(--surface-0));
+  --banner-icon-bg: color-mix(in srgb, var(--accent) 14%, var(--surface-0));
 }
 
 * {
@@ -1810,10 +1815,10 @@ body[data-card-glow] .cursor-glow {
     0 0 0 4px color-mix(in srgb, var(--accent) 24%, transparent);
   --mm-elev-1: none;
   --mm-elev-2: 0 12px 32px rgba(0, 0, 0, 0.45);
-  /* The default terracotta accent is a light mid-tone — near-white label reads
-     ~2.8:1 on it. Dark warm ink reads ~5.6:1 and wins on every accent but
-     indigo. Consumed by --primary-foreground. */
-  --mm-on-accent: #251e15;
+  /* Ink that sits ON a solid accent fill (the primary/Ship button label + its
+     icon, which inherits this color). White for a clean, conventional filled-
+     button look on the accent. Consumed by --primary-foreground. */
+  --mm-on-accent: #ffffff;
 }
 
 /* Hide the painted shell frame around the app and reclaim the gutter
@@ -2190,6 +2195,29 @@ body[data-card-glow] .cursor-glow {
   /* ~18% accent over the header surface reproduces the sampled warm active
      header (~#4d3e34) — the focused pane's title bar warms noticeably. */
   background: color-mix(in srgb, var(--accent) 18%, var(--surface-1)) !important;
+}
+
+/* Light mode: soften the drop shadows — the near-opaque blacks tuned for the
+   dark ground read as heavy smudges on white. Same geometry, lower alpha. */
+[data-minimal="true"][data-theme="light"] .mc-card-frame[data-focused="true"] {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--accent) 42%, transparent),
+    0 4px 14px rgba(18, 22, 33, 0.1) !important;
+}
+[data-minimal="true"][data-theme="light"] [data-session-grid] .mc-card-frame:focus-within {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent),
+    0 4px 16px rgba(18, 22, 33, 0.12),
+    0 0 20px color-mix(in srgb, var(--accent) 8%, transparent) !important;
+}
+[data-minimal="true"][data-theme="light"] .mc-toast-panel {
+  box-shadow:
+    0 6px 20px rgba(18, 22, 33, 0.12),
+    0 0 0 1px color-mix(in srgb, var(--mc-toast-tone) 12%, transparent);
+}
+[data-theme="light"] .mc-tooltip,
+[data-theme="light"] [data-sonner-toast].mc-toast-custom-shell [data-content] {
+  box-shadow: 0 4px 14px rgba(18, 22, 33, 0.14);
 }
 
 .sr-only {

--- a/src/styles.css
+++ b/src/styles.css
@@ -151,10 +151,11 @@
   --surface-1: color-mix(in srgb, var(--accent) var(--tint-md), #fafafb);
   --surface-2: color-mix(in srgb, var(--accent) var(--tint-hi), #f2f2f4);
   --surface-3: color-mix(in srgb, var(--accent) var(--tint-hi), #e9e9ee);
-  /* Warm hairline gray (#cec5c0). Opaque rather than translucent, but still
-     accent-tinted via color-mix so it tracks the palette like the surfaces do. */
-  --border: color-mix(in srgb, var(--accent) var(--tint-md), #cec5c0);
-  --border-strong: color-mix(in srgb, var(--accent) var(--tint-hi), #b3a9a2);
+  /* The active accent color at low opacity, so the hairline tracks whatever
+     accent is selected — 15% for the base border, a touch stronger for
+     --border-strong. */
+  --border: color-mix(in srgb, var(--accent) 15%, transparent);
+  --border-strong: color-mix(in srgb, var(--accent) 30%, transparent);
   --text: #17181c;
   --text-dim: rgba(23, 24, 28, 0.6);
   --text-faint: rgba(23, 24, 28, 0.4);
@@ -1936,6 +1937,15 @@ body[data-card-glow] .cursor-glow {
    rounding would notch the seams between touching cells. */
 [data-minimal="true"] [data-session-grid] .mc-card-frame {
   border-radius: 0 !important;
+}
+/* The flush cell seams need to read stronger than the base hairline, so grid
+   pane dividers run 15% darker than each theme's own primary border color.
+   Deriving from var(--border) keeps this correct across every flat palette
+   (and preserves the accent tint already baked into --border). Skip the
+   focused cell so it keeps its accent border (see the :focus-within rule
+   below). */
+[data-minimal="true"] [data-session-grid] .mc-card-frame:not(:focus-within) {
+  border-color: color-mix(in srgb, var(--border), black 15%) !important;
 }
 [data-minimal="true"] .mc-card-frame[data-solid="true"] {
   background: var(--surface-1) !important;


### PR DESCRIPTION

<img width="1438" height="895" alt="image" src="https://github.com/user-attachments/assets/38e409b1-acbe-4773-85cc-c76206df8302" />

***

<img width="1433" height="1028" alt="image" src="https://github.com/user-attachments/assets/8068883b-26e7-4b36-b1b9-c618da87228a" />

***

<img width="1438" height="1031" alt="image" src="https://github.com/user-attachments/assets/38b00875-5c7e-40b1-ab1e-df043e2dac61" />

## Summary

Theme system follow-up on top of the painted+flat consolidation:

- **Live theme thumbnails** — the theme-style picker renders real 16:10 previews; each card now wears its own theme's chrome (painted card gets the pixel-art panel frame, flat card stays a hairline surface), with card width capped so previews stay thumbnail-sized on wide windows.
- **Accent surface tint** — the accent color is mixed into surface grounds (`--tint-lo/md/hi` ladder), including an Intense tier.
- **Clean neutral light mode** — flat-light reworked from warm paper to a conventional clean light: pure white cards on a cool near-white ground, near-black ink, hairline cool-gray borders; status hues darkened for contrast on white; dark-tuned drop shadows softened.
- **Native window background sync** — new `app:setBackgroundColor` IPC channel keeps the Electron window ground in sync with the renderer theme (launch flash, resize gutters, overscroll); the last color is persisted so the next launch paints correctly from frame one.
- Filled accent buttons take white ink (`--mm-on-accent`) for a conventional filled-button look.

## Testing

- `npx tsc --noEmit` + `npx tsc -p electron/tsconfig.json --noEmit` clean
- ESLint clean on touched files
- Vitest: theme-style, use-theme, theme-onboarding, ipc-safe-handle suites pass (28 tests)