### PR TITLE
fix(grid): quiet Archive-all button, correct confirm copy, reorder toolbar

### DIFF
--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -2898,6 +2898,31 @@ function ProjectPage() {
               onRun={runScript}
               disabled={!projectPathUsable}
             />
+            {showGrid && (
+              <Btn
+                variant="ghost"
+                icon="archive"
+                onClick={() => setConfirmArchiveAll(true)}
+                aria-label="Archive all sessions in this grid"
+                title="Archive all sessions in this grid"
+                style={{ width: 52, minWidth: 52, paddingInline: 0 }}
+              />
+            )}
+            <HotkeyTooltip action="file.finder" label="Find file">
+              <Btn
+                variant="ghost"
+                icon="search"
+                onClick={openFileFinderFresh}
+                disabled={!projectPathUsable}
+                aria-label="Find file in project"
+                title={
+                  projectPathBlocked
+                    ? "Project folder unavailable"
+                    : "Find file in project"
+                }
+                style={{ width: 52, minWidth: 52, paddingInline: 0 }}
+              />
+            </HotkeyTooltip>
             <div
               role="group"
               aria-label="Review changes and commit"
@@ -2924,21 +2949,17 @@ function ProjectPage() {
                 enabled={projectPathUsable}
               />
             </div>
-            <HotkeyTooltip action="file.finder" label="Find file">
-              <Btn
-                variant="ghost"
-                icon="search"
-                onClick={openFileFinderFresh}
-                disabled={!projectPathUsable}
-                aria-label="Find file in project"
-                title={
-                  projectPathBlocked
-                    ? "Project folder unavailable"
-                    : "Find file in project"
-                }
-                style={{ width: 52, minWidth: 52, paddingInline: 0 }}
+            {showGrid && (
+              <NewAgentButton
+                project={project}
+                onPrimary={onNewAgentPrimary}
+                onNewRow={onNewRowPrimary}
+                disabled={!projectPathReady}
+                onConfigure={() => {
+                  if (projectPathReady) setShowNewAgent(true);
+                }}
               />
-            </HotkeyTooltip>
+            )}
             <HotkeyTooltip
               action="session.gridView"
               label={terminals.gridView ? "Exit grid view" : "Grid view — show all sessions"}
@@ -2958,27 +2979,6 @@ function ProjectPage() {
                 }}
               />
             </HotkeyTooltip>
-            {showGrid && (
-              <>
-                <Btn
-                  variant="danger"
-                  icon="archive"
-                  onClick={() => setConfirmArchiveAll(true)}
-                  title="Archive all sessions in this grid"
-                >
-                  Archive all
-                </Btn>
-                <NewAgentButton
-                  project={project}
-                  onPrimary={onNewAgentPrimary}
-                  onNewRow={onNewRowPrimary}
-                  disabled={!projectPathReady}
-                  onConfigure={() => {
-                    if (projectPathReady) setShowNewAgent(true);
-                  }}
-                />
-              </>
-            )}
           </div>
         </div>
 
@@ -3689,8 +3689,8 @@ function ProjectPage() {
         width={460}
       >
         <div style={{ fontSize: 13, color: "var(--text)", marginBottom: 8 }}>
-          Archive all {terminals.sessions.length} open session
-          {terminals.sessions.length === 1 ? "" : "s"} across every project?
+          Archive all {gridScopeSessionCount} open session
+          {gridScopeSessionCount === 1 ? "" : "s"} in &ldquo;{project.name}&rdquo;?
         </div>
         <div style={{ fontSize: 12, color: "var(--text-dim)" }}>
           Any running sessions will be disconnected and their agents stopped. You


### PR DESCRIPTION

<img width="1349" height="838" alt="image" src="https://github.com/user-attachments/assets/dabefb82-4375-4f0f-b082-a2517f990273" />

## Summary
Grid-view toolbar cleanup, prompted by the "Archive all" button being too prominent and its confirm dialog implying it archived across every project.

- **Quieter Archive all** — the grid header's "Archive all" was a red `danger` button with a label, always visible. It's now a muted icon-only ghost button (archive icon, tooltip/`aria-label` retained), so it's discoverable but no longer shouts.
- **Correct confirm-dialog copy** — the archive action was already scoped to the current project/scope (commit `84d9b98`), but the confirm dialog still read *"Archive all N open sessions across every project?"* using the **global** session count. It now uses the scoped count (`gridScopeSessionCount`) and names the current project, matching the actual behavior.
- **Toolbar order** — reordered the grid action cluster to: Archive all → search → Changes/Ship group → New session → grid toggle (far right).

## Testing
- `npx tsc --noEmit` — clean
- `npx eslint src/routes/projects.$id.tsx` — clean

Behavioral note: no functional change to what gets archived (it was already current-project only); this corrects the misleading copy and de-emphasizes the control.