### PR TITLE
refactor: name fuzzy score tiers and export max score constant

### DIFF
--- a/src/lib/file-fuzzy.ts
+++ b/src/lib/file-fuzzy.ts
@@ -1,6 +1,15 @@
 // Lightweight fuzzy file-path scorer.
 // Higher scores rank earlier. 0 means "no match".
 
+/** Upper bound for basename-substring scores; used to normalize into 0–1 elsewhere. */
+export const FUZZY_SCORE_MAX = 1000;
+
+const BASENAME_PREFIX_BONUS = 50;
+const BASENAME_EXACT_MATCH_BONUS = 200;
+const PATH_SUBSTRING_SCORE_BASE = 500;
+const BASENAME_SUBSEQ_SCORE_BASE = 200;
+const PATH_SUBSEQ_SCORE_BASE = 50;
+
 export type Scored = { path: string; score: number };
 
 export function fuzzyScore(query: string, target: string): number {
@@ -15,24 +24,25 @@ export function fuzzyScore(query: string, target: string): number {
   if (baseIdx >= 0) {
     // Earlier match in basename = higher. Treat a leading dot (hidden file)
     // as if the basename started at the dot — `.env` should beat `environment.ts`.
-    const effectiveIdx = baseIdx === 1 && base.charCodeAt(0) === 46 ? 0 : baseIdx;
-    let score = 1000 - effectiveIdx + (effectiveIdx === 0 ? 50 : 0);
+    const effectiveIdx = baseIdx === 1 && base.startsWith(".") ? 0 : baseIdx;
+    let score =
+      FUZZY_SCORE_MAX - effectiveIdx + (effectiveIdx === 0 ? BASENAME_PREFIX_BONUS : 0);
     // Whole-basename match bumps the score above any longer file with an early match.
     if (q.length === base.length || (baseIdx === 1 && q.length + 1 === base.length)) {
-      score += 200;
+      score += BASENAME_EXACT_MATCH_BONUS;
     }
     return score;
   }
 
   // Substring anywhere in path.
   const pathIdx = t.indexOf(q);
-  if (pathIdx >= 0) return 500 - pathIdx;
+  if (pathIdx >= 0) return PATH_SUBSTRING_SCORE_BASE - pathIdx;
 
   // Subsequence match in basename, then in full path.
   const baseSub = subseq(q, base);
-  if (baseSub > 0) return 200 + baseSub;
+  if (baseSub > 0) return BASENAME_SUBSEQ_SCORE_BASE + baseSub;
   const pathSub = subseq(q, t);
-  if (pathSub > 0) return 50 + pathSub;
+  if (pathSub > 0) return PATH_SUBSEQ_SCORE_BASE + pathSub;
 
   return 0;
 }

--- a/src/lib/project-match.ts
+++ b/src/lib/project-match.ts
@@ -8,7 +8,7 @@
 // and expose a confidence flag so the caller can disambiguate instead of guessing.
 
 import { doubleMetaphone } from "double-metaphone";
-import { fuzzyScore } from "./file-fuzzy";
+import { FUZZY_SCORE_MAX, fuzzyScore } from "./file-fuzzy";
 
 export type ScoredMatch<T> = { item: T; score: number };
 export type MatchResult<T> = {
@@ -63,7 +63,7 @@ function phoneticEqual(a: string, b: string): boolean {
 }
 
 function scoreOne(query: string, name: string): number {
-  const fuzzy = Math.min(1, fuzzyScore(query, name) / 1000);
+  const fuzzy = Math.min(1, fuzzyScore(query, name) / FUZZY_SCORE_MAX);
   const lev = levSim(squash(query), squash(name));
   const phon = phoneticEqual(query, name) ? PHONETIC_SCORE : 0;
   return Math.max(fuzzy, lev, phon);


### PR DESCRIPTION
## Summary

- Replace unexplained numeric literals in `file-fuzzy.ts` scoring (1000, 500, 200, 50) with named tier constants so each match strategy’s relative weight is obvious at a glance.
- Export `FUZZY_SCORE_MAX` and use it in `project-match.ts` when normalizing fuzzy scores to 0–1, making the coupling between the two modules explicit instead of duplicating a magic divisor.
- Replace `charCodeAt(0) === 46` with `startsWith(".")` when treating hidden dotfiles as basename-prefix matches.

## Why

The fuzzy file scorer encodes a tiered ranking strategy via raw numbers scattered through the function. Without names, readers must reverse-engineer what each value means and how tiers relate. The `/ 1000` normalization in voice project matching duplicated the max score implicitly, so a future scoring tweak could silently desync the two modules.

## Test plan

- [x] `vitest run src/lib/__tests__/file-fuzzy.test.ts src/lib/__tests__/project-match.test.ts` (17 tests pass)
- [ ] Confirm file finder ranking behavior is unchanged in the UI (optional manual smoke test)


Made with [Cursor](https://cursor.com)