### PR TITLE
refactor(semver): extract shared version prefix helpers

### DIFF
--- a/electron/agent-cli-version.ts
+++ b/electron/agent-cli-version.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentCliVersionRequirement } from "./agent-cli-version-requirements";
 import { resolveAgentCliUpdateCommands } from "./agent-cli-version-requirements";
+import { versionCore } from "../src/shared/semver";
 import { buildCmdScriptCommand, isWindowsCommandScript } from "./windows-cmd";
 
 export type AgentVersionCheck =
@@ -55,8 +56,7 @@ export function extractCliVersion(text: string): string | null {
 }
 
 function comparableVersionParts(version: string): number[] {
-  const core = version.replace(/^v/i, "").split(/[-+]/)[0] ?? "";
-  return core.split(".").map((part) => Number(part));
+  return versionCore(version).split(".").map((part) => Number(part));
 }
 
 export function compareCliVersions(

--- a/src/queries/mission-control-version.ts
+++ b/src/queries/mission-control-version.ts
@@ -1,6 +1,6 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { academyUrl } from "~/shared/academy";
-import { isNewerSemver } from "~/shared/semver";
+import { isNewerSemver, stripVersionPrefix } from "~/shared/semver";
 
 declare const __MC_VERSION__: string;
 
@@ -23,7 +23,7 @@ async function fetchLatest(): Promise<LatestRelease> {
   if (!res.ok) throw new Error(`mc-releases ${res.status}`);
   const body = (await res.json()) as { releases?: Array<{ version?: string }> };
   const raw = body.releases?.[0]?.version ?? null;
-  const remote = raw ? raw.replace(/^v/i, "") : null;
+  const remote = raw ? stripVersionPrefix(raw) : null;
   return {
     latestVersion: remote,
     downloadUrl: DOWNLOADS_URL,

--- a/src/shared/__tests__/semver.test.ts
+++ b/src/shared/__tests__/semver.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { isNewerSemver, stripVersionPrefix, versionCore } from "../semver";
+
+describe("stripVersionPrefix", () => {
+  it("removes a leading v prefix", () => {
+    expect(stripVersionPrefix("v1.2.3")).toBe("1.2.3");
+    expect(stripVersionPrefix("V0.48.4")).toBe("0.48.4");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(stripVersionPrefix("  v1.0.0  ")).toBe("1.0.0");
+  });
+});
+
+describe("versionCore", () => {
+  it("drops prerelease and build suffixes", () => {
+    expect(versionCore("v1.2.3-beta.1")).toBe("1.2.3");
+    expect(versionCore("2026.05.20-2b5dd59")).toBe("2026.05.20");
+    expect(versionCore("1.0.0+build.42")).toBe("1.0.0");
+  });
+});
+
+describe("isNewerSemver", () => {
+  it("compares normalized semver triplets", () => {
+    expect(isNewerSemver("v0.49.0", "0.48.4")).toBe(true);
+    expect(isNewerSemver("0.48.4", "0.48.4")).toBe(false);
+    expect(isNewerSemver("0.48.3", "0.48.4")).toBe(false);
+  });
+});

--- a/src/shared/semver.ts
+++ b/src/shared/semver.ts
@@ -1,6 +1,15 @@
+/** Strip a leading `v`/`V` prefix from a version string (e.g. release tags). */
+export function stripVersionPrefix(version: string): string {
+  return version.trim().replace(/^v/i, "");
+}
+
+/** Core numeric segment before any `-` prerelease or `+` build suffix. */
+export function versionCore(version: string): string {
+  return stripVersionPrefix(version).split(/[-+]/)[0];
+}
+
 function parse(v: string): [number, number, number] | null {
-  const stripped = v.trim().replace(/^v/i, "").split(/[-+]/)[0];
-  const parts = stripped.split(".");
+  const parts = versionCore(v).split(".");
   if (parts.length !== 3) return null;
   const nums = parts.map((p) => Number(p));
   if (nums.some((n) => !Number.isFinite(n) || n < 0)) return null;


### PR DESCRIPTION
## Summary

- Extract `stripVersionPrefix` and `versionCore` helpers in `src/shared/semver.ts` for normalizing version strings (leading `v` prefix, prerelease/build suffixes).
- Reuse the helpers in the mission-control update check and agent CLI version comparison instead of duplicating inline `replace(/^v/i, "")` / `split(/[-+]/)` logic.
- Add unit tests covering the new helpers and existing `isNewerSemver` behavior.

## Why

Version normalization was copy-pasted in three places. Centralizing it makes the parsing rules easier to find and keeps release-tag handling consistent between the in-app update check and CLI version probes.

## Test plan

- [x] `vitest run src/shared/__tests__/semver.test.ts`
- [x] `vitest run electron/__tests__/agent-cli-version.test.ts`


Made with [Cursor](https://cursor.com)