### PR TITLE
Replace magic 204 with HTTP_NO_CONTENT in API client

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -55,6 +55,7 @@ import type {
 import type { VoiceCommandAliases } from "~/shared/voice-command-aliases";
 import type { SessionHeaderButtonVisibility } from "~/shared/session-header-buttons";
 import { pruneStoredSessionFinishNotifications } from "~/lib/session-notification-store";
+import { HTTP_NO_CONTENT } from "~/shared/http-status";
 
 // The api bearer token is intentionally NOT part of this HTTP-derived shape.
 // Renderer code obtains it through the Electron IPC channel `settings:getToken`
@@ -255,7 +256,7 @@ async function req<T>(url: string, init?: RequestInit): Promise<T> {
         : null) ?? `${res.status} ${res.statusText}: ${text}`;
     throw new ApiError(message, res.status, body);
   }
-  if (res.status === 204) return undefined as T;
+  if (res.status === HTTP_NO_CONTENT) return undefined as T;
   return (await res.json()) as T;
 }
 


### PR DESCRIPTION
## Summary

- Replace the bare `204` status check in `src/lib/api.ts` `req()` with the shared `HTTP_NO_CONTENT` constant from `~/shared/http-status`.
- The project already documents these constants so call sites read `HTTP_NOT_FOUND` instead of bare integers; server controllers already use `HTTP_NO_CONTENT`, but the client-side fetch helper was still using the magic number.

## Why

The magic number `204` in the API client is easy to misread or mistype, and it diverges from the named constants used elsewhere (e.g. `src/server/controllers/_helpers.ts`). Using `HTTP_NO_CONTENT` makes the no-body response path self-documenting without changing behavior.

## Test plan

- [x] `vitest run src/lib/__tests__/api.test.ts` (worktree deletion 204 response path)


Made with [Cursor](https://cursor.com)