### PR TITLE
Use shared errMsg helper in commit-cli detect endpoint

### DIFF
--- a/src/server/controllers/commit-cli.controller.ts
+++ b/src/server/controllers/commit-cli.controller.ts
@@ -1,4 +1,5 @@
 import { COMMIT_CLI_VALUES, type CommitCliDetection } from "~/shared/commit-cli";
+import { errMsg } from "~/shared/err-msg";
 import { detectInstalledCommitClis } from "../services/commit-cli";
 import { json } from "./_helpers";
 
@@ -19,12 +20,11 @@ export async function detect(): Promise<Response> {
     const detected = await detectInstalledCommitClis();
     return json({ detected });
   } catch (e) {
-    console.error(
-      `[commit-cli] detect endpoint fell back to empty shape: ${(e as Error)?.message ?? String(e)}`,
-    );
+    const error = errMsg(e);
+    console.error(`[commit-cli] detect endpoint fell back to empty shape: ${error}`);
     return json({
       detected: EMPTY_DETECTION,
-      error: e instanceof Error ? e.message : String(e),
+      error,
     });
   }
 }


### PR DESCRIPTION
## Summary

- The `detect` handler in `commit-cli.controller.ts` extracted error messages twice in the same `catch` block using two different ad-hoc patterns (`(e as Error)?.message ?? String(e)` and `e instanceof Error ? e.message : String(e)`).
- Replaced both with the existing `errMsg` utility from `~/shared/err-msg`, which is the project's canonical way to stringify unknown thrown values.

## Why

Duplicated, slightly inconsistent error-message extraction makes the catch block harder to scan and risks subtle divergence if one pattern is updated but not the other. Centralizing on `errMsg` improves readability with no behavior change.

## Test plan

- [x] Change is behavior-preserving (same `errMsg` logic as the prior `instanceof Error` checks)
- [ ] `pnpm test -- src/server/services/__tests__/commit-cli.test.ts` (could not run locally — native deps require Node 24 + build toolchain)

Made with [Cursor](https://cursor.com)