### PR TITLE
refactor: consolidate isValidTcpPort into shared tcp-port module

### DIFF
--- a/electron/runtime-port.ts
+++ b/electron/runtime-port.ts
@@ -1,12 +1,8 @@
-import { MAX_TCP_PORT } from "../src/shared/tcp-port";
+import { isValidTcpPort, MAX_TCP_PORT } from "../src/shared/tcp-port";
 
-export { MAX_TCP_PORT };
+export { isValidTcpPort, MAX_TCP_PORT };
 
 export const DEFAULT_DEV_SERVER_PORT = 5173;
-
-export function isValidTcpPort(port: number | null | undefined): port is number {
-  return typeof port === "number" && Number.isInteger(port) && port > 0 && port <= MAX_TCP_PORT;
-}
 
 export function nextTcpPort(port: number | null | undefined): number | null {
   if (!isValidTcpPort(port) || port >= MAX_TCP_PORT) return null;

--- a/electron/sandbox-settings.ts
+++ b/electron/sandbox-settings.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { getStringAppSetting, setAppSetting } from "./app-settings-store";
-import { MAX_TCP_PORT } from "../src/shared/tcp-port";
+import { isValidTcpPort } from "../src/shared/tcp-port";
 
 // Typed accessors for the legacy global sandbox settings (Electron-only). These
 // live in the main-process app_settings store (not the server /api/settings)
@@ -70,7 +70,7 @@ const BUILD_ARG_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const VOLUME_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
 
 export function isValidPort(n: number): boolean {
-  return Number.isInteger(n) && n >= 1 && n <= MAX_TCP_PORT;
+  return isValidTcpPort(n);
 }
 
 export function isValidVolumeName(name: string): boolean {

--- a/src/shared/mission-control-hook-env.ts
+++ b/src/shared/mission-control-hook-env.ts
@@ -1,4 +1,4 @@
-import { MAX_TCP_PORT } from "./tcp-port";
+import { isValidTcpPort } from "./tcp-port";
 
 export type PtyHookEnv = {
   apiUrl: string;
@@ -24,10 +24,6 @@ const ALLOWED_HOOK_HOSTS = new Set<string>([
   AGENT_LOCAL_HOOK_API_HOST,
 ]);
 
-function isValidPort(port: number | null | undefined): port is number {
-  return typeof port === "number" && Number.isInteger(port) && port > 0 && port <= MAX_TCP_PORT;
-}
-
 /**
  * Build the Mission Control API base URL an agent's hooks should POST to,
  * parameterized by host so the same construction serves both the Electron host
@@ -38,7 +34,7 @@ export function buildMissionControlApiUrl(
   port: number | null | undefined,
 ): string | null {
   if (!ALLOWED_HOOK_HOSTS.has(host)) return null;
-  if (!isValidPort(port)) return null;
+  if (!isValidTcpPort(port)) return null;
   return `http://${host}:${port}`;
 }
 

--- a/src/shared/tcp-port.ts
+++ b/src/shared/tcp-port.ts
@@ -1,2 +1,6 @@
 /** Highest valid TCP port number (2^16 − 1). */
 export const MAX_TCP_PORT = 65_535;
+
+export function isValidTcpPort(port: number | null | undefined): port is number {
+  return typeof port === "number" && Number.isInteger(port) && port > 0 && port <= MAX_TCP_PORT;
+}


### PR DESCRIPTION
## Summary
- Move `isValidTcpPort` into `src/shared/tcp-port.ts` alongside `MAX_TCP_PORT`, the single source of truth for TCP port bounds.
- Re-export from `electron/runtime-port.ts` to preserve the existing public API.
- Replace duplicated private `isValidPort` in `mission-control-hook-env.ts` and inline check in `sandbox-settings.ts` with the shared helper.

## Why
TCP port validation (`integer in 1..65535`) was copy-pasted in three places. Keeping it next to `MAX_TCP_PORT` makes the valid range obvious and prevents the checks from drifting apart over time.

## Test plan
- [x] `pnpm exec vitest run electron/__tests__/runtime-port.test.ts src/shared/__tests__/mission-control-hook-env.test.ts electron/__tests__/sandbox-settings.test.ts`


Made with [Cursor](https://cursor.com)