### PR TITLE
Derive terminal zoom min/max from TERMINAL_ZOOM_LEVELS

### DIFF
--- a/src/shared/terminal-zoom.ts
+++ b/src/shared/terminal-zoom.ts
@@ -4,8 +4,8 @@ export const TERMINAL_ZOOM_LEVELS = [-2, -1, 0, 1, 2] as const;
 export type TerminalZoomLevel = (typeof TERMINAL_ZOOM_LEVELS)[number];
 
 export const DEFAULT_TERMINAL_ZOOM_LEVEL: TerminalZoomLevel = 0;
-export const TERMINAL_ZOOM_MIN = -2;
-export const TERMINAL_ZOOM_MAX = 2;
+export const TERMINAL_ZOOM_MIN = TERMINAL_ZOOM_LEVELS[0];
+export const TERMINAL_ZOOM_MAX = TERMINAL_ZOOM_LEVELS[TERMINAL_ZOOM_LEVELS.length - 1];
 export const TERMINAL_ZOOM_STEP_PX = 2;
 
 export const TERMINAL_ZOOM_LABELS: Record<TerminalZoomLevel, string> = {


### PR DESCRIPTION
## Summary

- `TERMINAL_ZOOM_MIN` and `TERMINAL_ZOOM_MAX` were hard-coded as `-2` and `2`, duplicating the values already present in `TERMINAL_ZOOM_LEVELS`.
- Derive both bounds from the levels array so a future change to allowed zoom levels only needs to update one source of truth.

## Why

The duplicated literals are easy to drift out of sync if someone adds or removes a zoom level from the array but forgets to update the separate min/max constants. The helpers (`normalizeTerminalZoomLevel`, `clampTerminalZoomLevel`, `stepTerminalZoomLevel`) and the settings validation schema all depend on these exports, so keeping them derived reduces maintenance risk without changing runtime behavior.

## Test plan

- [x] `pnpm exec vitest run src/lib/__tests__/terminal-zoom.test.ts` — all 5 tests pass

Made with [Cursor](https://cursor.com)