### PR TITLE
Extract MS_PER_DAY for readable Recall time constants

### DIFF
--- a/src/server/services/__tests__/project-memory.test.ts
+++ b/src/server/services/__tests__/project-memory.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { MEMORY_STALE_AFTER_MS } from "~/shared/project-memory";
+import { MS_PER_DAY } from "~/shared/time-ms";
 
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mc-memory-test-"));
 process.env.MC_USER_DATA_DIR = tmpRoot;
@@ -28,7 +29,7 @@ const { buildFtsMatch, __setMemoryFtsAvailableForTest } = await import(
 
 /** Backdate a memory well past the staleness threshold (unverified/unused). */
 function makeStale(id: string) {
-  const old = Date.now() - (MEMORY_STALE_AFTER_MS + 1000 * 60 * 60 * 24);
+  const old = Date.now() - (MEMORY_STALE_AFTER_MS + MS_PER_DAY);
   getDb()
     .update(projectMemory)
     .set({ createdAt: old, updatedAt: old, lastUsedAt: null, lastVerifiedAt: null })

--- a/src/server/services/project-memory.ts
+++ b/src/server/services/project-memory.ts
@@ -1,4 +1,5 @@
 import { LOCAL_SCOPE_ID, normalizeScopeId } from "~/shared/sandbox";
+import { MS_PER_DAY } from "~/shared/time-ms";
 import {
   MEMORY_BODY_MAX,
   MEMORY_TITLE_MAX,
@@ -421,7 +422,7 @@ export function markMemoriesUsed(ids: readonly string[]): void {
 // --- Session Brief assembly (deterministic ranker + budget + markdown) ---------
 
 const BRIEF_CHAR_BUDGET = 2400;
-const RECENCY_HALF_LIFE_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
+const RECENCY_HALF_LIFE_MS = 30 * MS_PER_DAY;
 
 function tokenize(text: string): Set<string> {
   return new Set(

--- a/src/shared/project-memory.ts
+++ b/src/shared/project-memory.ts
@@ -1,3 +1,5 @@
+import { MS_PER_DAY } from "./time-ms";
+
 // Shared types + constants for Recall — Mission Control's project-level memory.
 // A "memory" is a small, curated, typed fact about a project that is fed to new
 // agent sessions as a Session Brief so the agent doesn't rediscover the project
@@ -58,7 +60,7 @@ export const MEMORY_AUTO_CAPTURE_PER_SESSION_MAX = 5;
  * sink in the brief ranking and are flagged for review in the panel. Pinned
  * memories are exempt from decay.
  */
-export const MEMORY_STALE_AFTER_MS = 1000 * 60 * 60 * 24 * 60; // 60 days
+export const MEMORY_STALE_AFTER_MS = 60 * MS_PER_DAY;
 
 /**
  * Relevance weight per type when assembling the Session Brief. Higher = more

--- a/src/shared/time-ms.ts
+++ b/src/shared/time-ms.ts
@@ -1,0 +1,5 @@
+/** Millisecond durations for readable time constants at call sites. */
+export const MS_PER_SECOND = 1_000;
+export const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+export const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+export const MS_PER_DAY = 24 * MS_PER_HOUR;


### PR DESCRIPTION
## Summary

Recall's staleness and recency thresholds were expressed as long chains of millisecond multiplications (`1000 * 60 * 60 * 24 * 60`), which makes the intended duration hard to read at a glance and easy to mis-count when editing.

This PR introduces a small shared `time-ms` module with `MS_PER_DAY` (and related units) and uses it at the two Recall call sites:

- `MEMORY_STALE_AFTER_MS` → `60 * MS_PER_DAY` (was an opaque 5-factor product)
- `RECENCY_HALF_LIFE_MS` → `30 * MS_PER_DAY`

Behavior is unchanged — the numeric values are identical.

## Test plan

- [x] Verified `60 * MS_PER_DAY` and `30 * MS_PER_DAY` equal the previous literals
- [ ] `pnpm test src/server/services/__tests__/project-memory.test.ts` (requires Node 24 + native sqlite build)


Made with [Cursor](https://cursor.com)