### PR TITLE
Remove redundant Authorization header case lookup

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -54,7 +54,8 @@ export function requireBearerTokenValueForSecret(
 }
 
 export function requireBearerToken(request: Request): { ok: true } | { ok: false; response: Response } {
-  const auth = request.headers.get("authorization") || request.headers.get("Authorization") || "";
+  // Headers.get() is case-insensitive per the Fetch spec — one lookup is enough.
+  const auth = request.headers.get("authorization") ?? "";
   const token = auth.replace(/^Bearer\s+/i, "").trim();
   return requireBearerTokenValue(token);
 }


### PR DESCRIPTION
## Summary

- `requireBearerToken` looked up the `Authorization` header twice — once as `"authorization"` and again as `"Authorization"`.
- The Fetch `Headers.get()` API is case-insensitive, so the second lookup could never return a value the first missed.
- The duplicate lookup suggested the server treated header names as case-sensitive, which made the auth path harder to read without adding any behavior.

## Changes

- Use a single `request.headers.get("authorization")` call with nullish coalescing.
- Add a brief comment documenting why one lookup is sufficient.

## Test plan

- [x] Verified behavior is unchanged: `Headers.get()` resolves any casing of `Authorization`.
- [ ] `pnpm test src/server/__tests__/api-auth.test.ts` (blocked locally by Node 24 / native binding requirements in this environment)


Made with [Cursor](https://cursor.com)