### PR TITLE
refactor: derive terminal zoom bounds from TERMINAL_ZOOM_LEVELS

### DIFF
--- a/src/shared/terminal-zoom.ts
+++ b/src/shared/terminal-zoom.ts
@@ -4,8 +4,8 @@ export const TERMINAL_ZOOM_LEVELS = [-2, -1, 0, 1, 2] as const;
 export type TerminalZoomLevel = (typeof TERMINAL_ZOOM_LEVELS)[number];
 
 export const DEFAULT_TERMINAL_ZOOM_LEVEL: TerminalZoomLevel = 0;
-export const TERMINAL_ZOOM_MIN = -2;
-export const TERMINAL_ZOOM_MAX = 2;
+export const TERMINAL_ZOOM_MIN = TERMINAL_ZOOM_LEVELS[0];
+export const TERMINAL_ZOOM_MAX = TERMINAL_ZOOM_LEVELS[TERMINAL_ZOOM_LEVELS.length - 1];
 export const TERMINAL_ZOOM_STEP_PX = 2;
 
 export const TERMINAL_ZOOM_LABELS: Record<TerminalZoomLevel, string> = {


### PR DESCRIPTION
## Summary
- `TERMINAL_ZOOM_MIN` and `TERMINAL_ZOOM_MAX` duplicated the endpoints of `TERMINAL_ZOOM_LEVELS` (`-2` and `2`), so changing the allowed zoom steps required updating three separate literals.
- Derive min/max from `TERMINAL_ZOOM_LEVELS` so the zoom range has a single source of truth.

## Why
The zoom helpers (`normalizeTerminalZoomLevel`, `clampTerminalZoomLevel`, `stepTerminalZoomLevel`) and settings validation all key off `TERMINAL_ZOOM_MIN`/`MAX`. Keeping those in sync with the level list by hand is easy to miss during future changes.

## Test plan
- [x] `pnpm exec vitest run src/lib/__tests__/terminal-zoom.test.ts`


Made with [Cursor](https://cursor.com)