### PR TITLE
Extract duplicated binary buffer sniff into shared helper

### DIFF
--- a/electron/file-handlers.ts
+++ b/electron/file-handlers.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import ignore from "ignore";
 import { FILE_READ_MAX_BYTES, FILE_READ_MAX_LINES } from "../src/shared/file-read-limits";
+import { bufferLooksBinary } from "../src/shared/git-status";
 import { IPC } from "./ipc-channels";
 import { safeHandle } from "./ipc-safe-handle";
 
@@ -236,14 +237,6 @@ function listFiles(projectRoot: string): string[] {
   return out;
 }
 
-function isProbablyBinary(buf: Buffer): boolean {
-  const len = Math.min(buf.length, 8192);
-  for (let i = 0; i < len; i++) {
-    if (buf[i] === 0) return true;
-  }
-  return false;
-}
-
 export function imageMimeForRelPath(relPath: string): (typeof IMAGE_MIME_BY_EXT)[keyof typeof IMAGE_MIME_BY_EXT] | null {
   const ext = path.extname(relPath).toLowerCase();
   return IMAGE_MIME_BY_EXT[ext as keyof typeof IMAGE_MIME_BY_EXT] ?? null;
@@ -285,7 +278,7 @@ export function registerFileHandlers(ipc: IpcMain, getWin: () => BrowserWindow |
             mtimeMs: stat.mtimeMs,
           };
         }
-        if (isProbablyBinary(buf)) {
+        if (bufferLooksBinary(buf)) {
           return { ok: false as const, error: "binary" as const };
         }
         const content = buf.toString("utf8");

--- a/src/server/services/git.ts
+++ b/src/server/services/git.ts
@@ -17,6 +17,7 @@ import {
   parsePorcelainZ,
   classifyDiffPatch,
   buildAdditionsDiff,
+  bufferLooksBinary,
   changedFileCount,
 } from "~/shared/git-status";
 
@@ -243,11 +244,7 @@ function readUntrackedAsDiff(cwd: string, file: string): GitDiff {
       return { kind: "too-large", lines: 0, bytes: stat.size };
     }
     const buf = fs.readFileSync(abs);
-    // Cheap binary sniff: any NUL in the first 8KB.
-    const sniff = buf.subarray(0, Math.min(buf.length, 8192));
-    for (let i = 0; i < sniff.length; i++) {
-      if (sniff[i] === 0) return { kind: "binary" };
-    }
+    if (bufferLooksBinary(buf)) return { kind: "binary" };
     const text = buf.toString("utf8");
     const lineCount = text.split("\n").length;
     if (lineCount > DIFF_MAX_LINES) {

--- a/src/shared/__tests__/git-status.test.ts
+++ b/src/shared/__tests__/git-status.test.ts
@@ -6,6 +6,7 @@ import {
   buildAdditionsDiff,
   isBinaryPatch,
   mapStatusCode,
+  bufferLooksBinary,
 } from "../git-status";
 
 describe("parsePorcelainZ", () => {
@@ -67,6 +68,20 @@ describe("classifyDiffPatch", () => {
     const big = "x".repeat(2 * 1024 * 1024 + 10);
     const result = classifyDiffPatch(big);
     expect(result.kind).toBe("too-large");
+  });
+});
+
+describe("bufferLooksBinary", () => {
+  it("detects NUL bytes in the sniff window", () => {
+    expect(bufferLooksBinary(new Uint8Array([0x41, 0x00, 0x42]))).toBe(true);
+    expect(bufferLooksBinary(new Uint8Array([0x41, 0x42, 0x43]))).toBe(false);
+  });
+
+  it("only scans the first BUFFER_BINARY_SNIFF_BYTES", () => {
+    const buf = new Uint8Array(8 * 1024 + 1);
+    buf.fill(0x41);
+    buf[8 * 1024] = 0;
+    expect(bufferLooksBinary(buf)).toBe(false);
   });
 });
 

--- a/src/shared/git-status.ts
+++ b/src/shared/git-status.ts
@@ -45,6 +45,18 @@ export type GitDiff =
 export const DIFF_MAX_BYTES = 2 * 1024 * 1024;
 export const DIFF_MAX_LINES = 50_000;
 
+/** Bytes to scan when sniffing raw file content for NUL (binary) markers. */
+export const BUFFER_BINARY_SNIFF_BYTES = 8 * 1024;
+
+/** Cheap binary sniff: any NUL in the first {@link BUFFER_BINARY_SNIFF_BYTES}. */
+export function bufferLooksBinary(buf: Uint8Array): boolean {
+  const len = Math.min(buf.length, BUFFER_BINARY_SNIFF_BYTES);
+  for (let i = 0; i < len; i++) {
+    if (buf[i] === 0) return true;
+  }
+  return false;
+}
+
 /** Map a porcelain v1 status code to one of our enum values. */
 export function mapStatusCode(code: string): GitFileStatus {
   if (code === "?") return "untracked";


### PR DESCRIPTION
## Summary
- Adds `bufferLooksBinary` and `BUFFER_BINARY_SNIFF_BYTES` to `src/shared/git-status.ts`, centralizing the NUL-byte sniff used to detect binary file content.
- Replaces identical inline logic in `src/server/services/git.ts` (untracked diff generation) and `electron/file-handlers.ts` (IPC file reads).
- Adds unit tests covering NUL detection and the 8KB scan window.

## Why
The same binary-detection loop (scan first 8KB for a NUL byte) was duplicated in two places with a magic number (`8192`). Extracting it makes the behavior easier to find, test, and keep consistent across server and Electron paths.

## Test plan
- [x] `pnpm exec vitest run src/shared/__tests__/git-status.test.ts`

Made with [Cursor](https://cursor.com)