### PR TITLE
Clarify MEMORY_STALE_AFTER_MS duration expression

### DIFF
--- a/src/shared/project-memory.ts
+++ b/src/shared/project-memory.ts
@@ -52,13 +52,15 @@ export const MEMORY_TAG_MAX = 40;
 /** Cap on how many memories a single auto-distill pass may add to one project. */
 export const MEMORY_AUTO_CAPTURE_PER_SESSION_MAX = 5;
 
+const MS_PER_DAY = 86_400_000;
+
 /**
  * A memory is considered "stale" once this long has passed since it was last
  * verified, used, or created (whichever is most recent). Stale unpinned memories
  * sink in the brief ranking and are flagged for review in the panel. Pinned
  * memories are exempt from decay.
  */
-export const MEMORY_STALE_AFTER_MS = 1000 * 60 * 60 * 24 * 60; // 60 days
+export const MEMORY_STALE_AFTER_MS = 60 * MS_PER_DAY;
 
 /**
  * Relevance weight per type when assembling the Session Brief. Higher = more


### PR DESCRIPTION
## Summary

- Replace the opaque `1000 * 60 * 60 * 24 * 60` millisecond chain in `MEMORY_STALE_AFTER_MS` with a named `MS_PER_DAY` constant and `60 * MS_PER_DAY`.
- The stale-memory threshold is still 60 days; the expression now reads as "60 days" without mental arithmetic.

## Why

The previous expression required counting four chained factors to confirm it matched the "60 days" comment. A typo in any factor would silently change recall staleness behavior. Using `60 * MS_PER_DAY` keeps the intent and the value aligned.

## Test plan

- [x] Verified the numeric value is unchanged (`86_400_000 * 60`).
- [ ] `pnpm test src/server/services/__tests__/project-memory.test.ts` (stale-memory brief ranking cases).


Made with [Cursor](https://cursor.com)