### PR TITLE
Consolidate duplicate UI view normalize helpers

### DIFF
--- a/src/shared/ui-preferences.ts
+++ b/src/shared/ui-preferences.ts
@@ -18,20 +18,29 @@ export const GIT_DIFF_CHANGED_FILES_WIDTH_MAX = 520;
 
 export type SelectedWorktreeByProject = Record<string, string>;
 
+function normalizeEnumValue<T extends string>(
+  value: unknown,
+  values: readonly T[],
+): T | null {
+  return typeof value === "string" && (values as readonly string[]).includes(value)
+    ? (value as T)
+    : null;
+}
+
 export function normalizeGitDiffChangedFilesView(
   value: unknown,
 ): GitDiffChangedFilesView | null {
-  return value === "list" || value === "tree" ? value : null;
+  return normalizeEnumValue(value, GIT_DIFF_CHANGED_FILES_VIEWS);
 }
 
 export function normalizeProjectsDashboardView(
   value: unknown,
 ): ProjectsDashboardView | null {
-  return value === "cards" || value === "table" ? value : null;
+  return normalizeEnumValue(value, PROJECTS_DASHBOARD_VIEWS);
 }
 
 export function normalizeFileFinderView(value: unknown): FileFinderView | null {
-  return value === "list" || value === "tree" ? value : null;
+  return normalizeEnumValue(value, FILE_FINDER_VIEWS);
 }
 
 export function normalizeGitDiffChangedFilesWidth(value: unknown): number | null {


### PR DESCRIPTION
## Summary

- Three `normalize*View` functions in `src/shared/ui-preferences.ts` each hard-coded their allowed string values (`"list" | "tree"`, `"cards" | "table"`, etc.) even though the canonical options already live in `GIT_DIFF_CHANGED_FILES_VIEWS`, `PROJECTS_DASHBOARD_VIEWS`, and `FILE_FINDER_VIEWS`.
- This duplication meant adding a new view option required updating two places and risked the validators drifting from the const arrays.
- Introduces a small `normalizeEnumValue` helper that validates against the const array, matching the `isThemeStyle` / `isSurfaceTint` pattern used elsewhere in shared code.

## Test plan

- [x] `pnpm exec vitest run src/lib/__tests__/ui-preference-cache.test.ts` passes
- [ ] Verify settings persistence still accepts valid view values and rejects unknown ones


Made with [Cursor](https://cursor.com)