### PR TITLE
Export graph-watcher timing constants to remove test duplication

### DIFF
--- a/src/server/services/__tests__/graph-watcher.test.ts
+++ b/src/server/services/__tests__/graph-watcher.test.ts
@@ -31,10 +31,13 @@ vi.mock("../recall-settings", () => ({
   readRecallSettings: (...a: unknown[]) => readRecallSettings(...a),
 }));
 
-const { ensureGraphWatch, stopGraphWatch, __isWatching } = await import("../graph-watcher");
-
-const DEBOUNCE_MS = 2500;
-const IDLE_TTL_MS = 15 * 60 * 1000;
+const {
+  ensureGraphWatch,
+  stopGraphWatch,
+  __isWatching,
+  GRAPH_WATCH_DEBOUNCE_MS,
+  GRAPH_WATCH_IDLE_TTL_MS,
+} = await import("../graph-watcher");
 
 describe("graph watcher", () => {
   beforeEach(() => {
@@ -69,7 +72,7 @@ describe("graph watcher", () => {
     expect(watch).toHaveBeenCalledTimes(1);
 
     capturedListener!("change", "src/foo.ts");
-    vi.advanceTimersByTime(DEBOUNCE_MS);
+    vi.advanceTimersByTime(GRAPH_WATCH_DEBOUNCE_MS);
     expect(startGraphIndex).toHaveBeenCalledWith("p1", "incremental");
   });
 
@@ -78,7 +81,7 @@ describe("graph watcher", () => {
     capturedListener!("change", "node_modules/pkg/index.js");
     capturedListener!("change", "src/readme.md");
     capturedListener!("change", "dist/bundle.js");
-    vi.advanceTimersByTime(DEBOUNCE_MS + 500);
+    vi.advanceTimersByTime(GRAPH_WATCH_DEBOUNCE_MS + 500);
     expect(startGraphIndex).not.toHaveBeenCalled();
   });
 
@@ -87,7 +90,7 @@ describe("graph watcher", () => {
     capturedListener!("change", "src/a.ts");
     vi.advanceTimersByTime(1000);
     capturedListener!("change", "src/b.ts");
-    vi.advanceTimersByTime(DEBOUNCE_MS);
+    vi.advanceTimersByTime(GRAPH_WATCH_DEBOUNCE_MS);
     expect(startGraphIndex).toHaveBeenCalledTimes(1);
   });
 
@@ -95,14 +98,14 @@ describe("graph watcher", () => {
     ensureGraphWatch("p1");
     isGraphIndexRunning.mockReturnValue(true);
     capturedListener!("change", "src/a.ts");
-    vi.advanceTimersByTime(DEBOUNCE_MS);
+    vi.advanceTimersByTime(GRAPH_WATCH_DEBOUNCE_MS);
     expect(startGraphIndex).not.toHaveBeenCalled(); // deferred until graph:indexed
   });
 
   it.skipIf(!RECURSIVE)("re-arms the idle timer and stops the watcher when quiet", () => {
     ensureGraphWatch("p1");
     expect(__isWatching("p1")).toBe(true);
-    vi.advanceTimersByTime(IDLE_TTL_MS);
+    vi.advanceTimersByTime(GRAPH_WATCH_IDLE_TTL_MS);
     expect(__isWatching("p1")).toBe(false);
     expect(fakeWatcher.close).toHaveBeenCalled();
   });

--- a/src/server/services/graph-watcher.ts
+++ b/src/server/services/graph-watcher.ts
@@ -20,9 +20,9 @@ import { readRecallSettings } from "./recall-settings";
 
 // Trailing debounce so a burst of saves (or an editor's atomic write) collapses
 // into one incremental build.
-const DEBOUNCE_MS = 2500;
+export const GRAPH_WATCH_DEBOUNCE_MS = 2500;
 // Stop watching a project this long after its last session activity.
-const IDLE_TTL_MS = 15 * 60 * 1000;
+export const GRAPH_WATCH_IDLE_TTL_MS = 15 * 60 * 1000;
 
 // Recursive fs.watch is supported on macOS + Windows only. On Linux we skip the
 // watcher entirely and rely on the session-start auto-index (graph-auto-index.ts).
@@ -82,7 +82,7 @@ function onFsEvent(projectId: string, filename: string): void {
   entry.debounce = setTimeout(() => {
     entry.debounce = null;
     fireIncremental(projectId);
-  }, DEBOUNCE_MS);
+  }, GRAPH_WATCH_DEBOUNCE_MS);
   entry.debounce.unref?.();
 }
 
@@ -114,7 +114,7 @@ function fireIncremental(projectId: string): void {
 
 function armIdle(projectId: string, entry: WatchEntry): void {
   if (entry.idle) clearTimeout(entry.idle);
-  entry.idle = setTimeout(() => stopGraphWatch(projectId), IDLE_TTL_MS);
+  entry.idle = setTimeout(() => stopGraphWatch(projectId), GRAPH_WATCH_IDLE_TTL_MS);
   entry.idle.unref?.();
 }
 


### PR DESCRIPTION
## Summary

- Export `GRAPH_WATCH_DEBOUNCE_MS` and `GRAPH_WATCH_IDLE_TTL_MS` from `graph-watcher.ts` instead of keeping them as file-private constants.
- Update `graph-watcher.test.ts` to import those values from the module under test, removing duplicated magic numbers (`2500` and `15 * 60 * 1000`).

## Why

The test file duplicated the debounce and idle TTL timings from production code. If someone changed one copy without the other, tests would still pass while asserting the wrong behavior. Sharing the exported constants keeps production and tests in sync.

## Test plan

- [x] `pnpm exec vitest run src/server/services/__tests__/graph-watcher.test.ts`


Made with [Cursor](https://cursor.com)