### PR TITLE
Derive terminal zoom bounds from TERMINAL_ZOOM_LEVELS

### DIFF
--- a/src/shared/terminal-zoom.ts
+++ b/src/shared/terminal-zoom.ts
@@ -4,8 +4,8 @@ export const TERMINAL_ZOOM_LEVELS = [-2, -1, 0, 1, 2] as const;
 export type TerminalZoomLevel = (typeof TERMINAL_ZOOM_LEVELS)[number];
 
 export const DEFAULT_TERMINAL_ZOOM_LEVEL: TerminalZoomLevel = 0;
-export const TERMINAL_ZOOM_MIN = -2;
-export const TERMINAL_ZOOM_MAX = 2;
+export const TERMINAL_ZOOM_MIN = TERMINAL_ZOOM_LEVELS[0];
+export const TERMINAL_ZOOM_MAX = TERMINAL_ZOOM_LEVELS[TERMINAL_ZOOM_LEVELS.length - 1];
 export const TERMINAL_ZOOM_STEP_PX = 2;
 
 export const TERMINAL_ZOOM_LABELS: Record<TerminalZoomLevel, string> = {


### PR DESCRIPTION
## Summary

`TERMINAL_ZOOM_MIN` and `TERMINAL_ZOOM_MAX` duplicated the first and last entries of `TERMINAL_ZOOM_LEVELS` as magic numbers (`-2` and `2`). If someone adds or removes a zoom step, they must remember to update three separate definitions — an easy source of drift.

This change derives the bounds directly from the levels array so min/max always stay in sync.

## Test plan

- [x] `vitest run src/lib/__tests__/terminal-zoom.test.ts` — all 5 tests pass


Made with [Cursor](https://cursor.com)