### PR TITLE
refactor: reuse shared shortId for dialog row ids

### DIFF
--- a/src/components/views/CustomScriptsDialog.tsx
+++ b/src/components/views/CustomScriptsDialog.tsx
@@ -11,11 +11,8 @@ import {
   type CustomScript,
   type ScriptArg,
 } from "~/shared/domain";
+import { shortId } from "~/shared/short-id";
 import type { Project } from "~/db/schema";
-
-function newRowId() {
-  return `cs-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-}
 
 export function CustomScriptsDialog({
   open,
@@ -53,7 +50,7 @@ export function CustomScriptsDialog({
 
   const add = () => {
     if (rows.length >= CUSTOM_SCRIPTS_MAX) return;
-    setRows((prev) => [...prev, { id: newRowId(), name: "", command: "" }]);
+    setRows((prev) => [...prev, { id: shortId("cs"), name: "", command: "" }]);
   };
 
   const addArg = (id: string) =>

--- a/src/components/views/LaunchCommandsDialog.tsx
+++ b/src/components/views/LaunchCommandsDialog.tsx
@@ -4,11 +4,8 @@ import { Btn } from "~/components/ui/Btn";
 import { EscTooltip } from "~/components/ui/Tooltip";
 import { Icon } from "~/components/ui/Icon";
 import { LAUNCH_COMMANDS_MAX, parseLaunchCommands, type LaunchCommand } from "~/shared/domain";
+import { shortId } from "~/shared/short-id";
 import type { Project } from "~/db/schema";
-
-function newRowId() {
-  return `lc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-}
 
 export function LaunchCommandsDialog({
   open,
@@ -39,7 +36,7 @@ export function LaunchCommandsDialog({
 
   const add = () => {
     if (rows.length >= LAUNCH_COMMANDS_MAX) return;
-    setRows((prev) => [...prev, { id: newRowId(), name: "", command: "" }]);
+    setRows((prev) => [...prev, { id: shortId("lc"), name: "", command: "" }]);
   };
 
   const save = async () => {


### PR DESCRIPTION
## Summary

- Remove duplicate `newRowId()` helpers from `LaunchCommandsDialog` and `CustomScriptsDialog`
- Both dialogs now call the existing `shortId(prefix)` utility from `~/shared/short-id`
- IDs remain opaque strings with the same `${prefix}-${base36 time}-${random}` shape; behavior is unchanged

## Why

`LaunchCommandsDialog` and `CustomScriptsDialog` each hand-rolled the same id-generation pattern that already lives in `shortId`. Keeping two local copies makes it harder to spot the canonical helper and risks the implementations drifting apart over time.

## Test plan

- [x] `pnpm generate:routes && pnpm exec tsc --noEmit` passes
- [ ] Open Launch Commands dialog → add a row → save (id is assigned)
- [ ] Open Custom Scripts dialog → add a row → save (id is assigned)


Made with [Cursor](https://cursor.com)