### PR TITLE
fix(screenshot): simplify screenshot tooltip labels

### DIFF
--- a/src/components/views/UserTerminalPanel.tsx
+++ b/src/components/views/UserTerminalPanel.tsx
@@ -379,7 +379,7 @@ export function UserTerminalPanel() {
         <div style={{ display: "flex", gap: 6, alignItems: "center", flex: "0 0 auto" }}>
           {screenshotCount > 0 && (
             <div style={{ position: "relative", display: "inline-flex", flex: "0 0 auto" }}>
-              <Tooltip content="Screenshots — captures you can reuse in this project">
+              <Tooltip content={screenshotsVisible ? "Hide screenshots" : "Show screenshots"}>
                 <Btn
                   variant="ghost"
                   size="sm"

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -2937,7 +2937,7 @@ function ProjectPage() {
             {screenshotSupported && (
               <HotkeyTooltip
                 action="screenshot.capture"
-                label="Screenshot — drag a region, then drop it on a session"
+                label="Screenshot"
               >
                 <Btn
                   variant="ghost"


### PR DESCRIPTION
Simplifies the screenshot tooltip copy in the grid toolbar and user terminal panel.

- Header capture button tooltip: "Screenshot — drag a region, then drop it on a session" → **"Screenshot"** (the keybinding badges still render separately)
- Screenshots panel toggle tooltip: "Screenshots — captures you can reuse in this project" → a stateful **"Show screenshots" / "Hide screenshots"** that reflects the toggle action