### PR TITLE
Screenshot editor: bounded editor panel + non-destructive crop

### DIFF
--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -57,6 +57,7 @@ export type IconName =
   | "circle"
   | "text"
   | "highlighter"
+  | "crop"
   | "undo"
   | "redo";
 
@@ -373,6 +374,13 @@ export function Icon({ name, size = 14, style }: { name: IconName; size?: number
           <path d="M3.5 4V3h9v1" />
           <path d="M8 3.5v9" />
           <path d="M6 12.5h4" />
+        </svg>
+      );
+    case "crop":
+      return (
+        <svg {...common}>
+          <path d="M4.5 1.5v9a1 1 0 001 1h9" />
+          <path d="M1.5 4.5h9a1 1 0 011 1v9" />
         </svg>
       );
     case "highlighter":

--- a/src/components/views/ScreenshotAnnotator.tsx
+++ b/src/components/views/ScreenshotAnnotator.tsx
@@ -293,6 +293,10 @@ function drawArrow(ctx: CanvasRenderingContext2D, x1: number, y1: number, x2: nu
 // annotation renders its thumbnail at the same size as a fresh capture.
 const PREVIEW_WIDTH_PX = 320;
 
+// Breathing room kept between the screenshot and the matte edges, so even a
+// full-width capture floats inside the workspace instead of bleeding to the rim.
+const MATTE_PAD_PX = 36;
+
 export function ScreenshotAnnotator({
   shot,
   onCancel,
@@ -375,7 +379,11 @@ export function ScreenshotAnnotator({
 
   const display = useMemo(() => {
     if (!dims.w || !dims.h || !stageBox.w || !stageBox.h) return { w: 0, h: 0 };
-    const scale = Math.min(stageBox.w / dims.w, stageBox.h / dims.h, 2.5);
+    // Fit inside the matte with guaranteed margins on all sides (stageBox is the
+    // matte's own box, already excluding the header and footer bars).
+    const availW = Math.max(1, stageBox.w - MATTE_PAD_PX * 2);
+    const availH = Math.max(1, stageBox.h - MATTE_PAD_PX * 2);
+    const scale = Math.min(availW / dims.w, availH / dims.h, 2.5);
     return { w: Math.round(dims.w * scale), h: Math.round(dims.h * scale) };
   }, [dims, stageBox]);
 
@@ -912,7 +920,9 @@ export function ScreenshotAnnotator({
         inset: 0,
         zIndex: 10050,
         display: "flex",
-        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 24,
         background: "rgba(4, 7, 10, 0.72)",
         backdropFilter: "blur(6px)",
         WebkitBackdropFilter: "blur(6px)",
@@ -920,164 +930,179 @@ export function ScreenshotAnnotator({
     >
       <style>{ANNOT_CSS}</style>
 
-      {/* Toolbar */}
-      <div className="mc-annot-bar-wrap">
-        <div className="mc-annot-bar">
-          <div className="mc-annot-group">
-            {TOOLS.map((t) => (
+      {/* A bounded editor window: header toolbar → canvas matte → footer, in
+          three tonal steps so it reads as a workspace rather than a floating
+          toolbar dropped over the app. */}
+      <div className="mc-annot-panel">
+        {/* Header: the working toolbar, attached as real app chrome. */}
+        <div className="mc-annot-header">
+          <div className="mc-annot-bar">
+            <div className="mc-annot-group">
+              {TOOLS.map((t) => (
+                <button
+                  key={t.tool}
+                  type="button"
+                  className={`mc-annot-tool${tool === t.tool ? " is-active" : ""}`}
+                  title={`${t.label} · ${t.key}`}
+                  aria-label={t.label}
+                  aria-pressed={tool === t.tool}
+                  onClick={() => setTool(t.tool)}
+                >
+                  <Icon name={t.icon} size={16} />
+                </button>
+              ))}
+            </div>
+
+            <span className="mc-annot-div" />
+
+            <div className="mc-annot-group">
+              {COLORS.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  className={`mc-annot-swatch${color === c ? " is-active" : ""}`}
+                  title={c}
+                  aria-label={`Color ${c}`}
+                  aria-pressed={color === c}
+                  onClick={() => {
+                    setColor(c);
+                    recolorSelected(c);
+                  }}
+                  style={{ background: c }}
+                />
+              ))}
+              <label className="mc-annot-swatch mc-annot-custom" title="Custom color">
+                <input
+                  type="color"
+                  value={color}
+                  onChange={(e) => {
+                    setColor(e.target.value);
+                    recolorSelected(e.target.value);
+                  }}
+                />
+              </label>
+            </div>
+
+            <span className="mc-annot-div" />
+
+            <div className="mc-annot-group">
+              {WIDTHS.map((w, i) => (
+                <button
+                  key={w.label}
+                  type="button"
+                  className={`mc-annot-width${widthIdx === i ? " is-active" : ""}`}
+                  title={w.label}
+                  aria-label={w.label}
+                  aria-pressed={widthIdx === i}
+                  onClick={() => setWidthIdx(i)}
+                >
+                  <span style={{ width: w.dot, height: w.dot, borderRadius: 999, background: "currentColor" }} />
+                </button>
+              ))}
+            </div>
+
+            <span className="mc-annot-div" />
+
+            <div className="mc-annot-group">
               <button
-                key={t.tool}
                 type="button"
-                className={`mc-annot-tool${tool === t.tool ? " is-active" : ""}`}
-                title={`${t.label} · ${t.key}`}
-                aria-label={t.label}
-                aria-pressed={tool === t.tool}
-                onClick={() => setTool(t.tool)}
+                className="mc-annot-tool"
+                title="Undo · ⌘Z"
+                aria-label="Undo"
+                disabled={!canUndo}
+                onClick={undo}
               >
-                <Icon name={t.icon} size={16} />
+                <Icon name="undo" size={16} />
               </button>
-            ))}
-          </div>
-
-          <span className="mc-annot-div" />
-
-          <div className="mc-annot-group">
-            {COLORS.map((c) => (
               <button
-                key={c}
                 type="button"
-                className={`mc-annot-swatch${color === c ? " is-active" : ""}`}
-                title={c}
-                aria-label={`Color ${c}`}
-                aria-pressed={color === c}
-                onClick={() => {
-                  setColor(c);
-                  recolorSelected(c);
-                }}
-                style={{ background: c }}
-              />
-            ))}
-            <label className="mc-annot-swatch mc-annot-custom" title="Custom color">
-              <input
-                type="color"
-                value={color}
-                onChange={(e) => {
-                  setColor(e.target.value);
-                  recolorSelected(e.target.value);
-                }}
-              />
-            </label>
-          </div>
-
-          <span className="mc-annot-div" />
-
-          <div className="mc-annot-group">
-            {WIDTHS.map((w, i) => (
-              <button
-                key={w.label}
-                type="button"
-                className={`mc-annot-width${widthIdx === i ? " is-active" : ""}`}
-                title={w.label}
-                aria-label={w.label}
-                aria-pressed={widthIdx === i}
-                onClick={() => setWidthIdx(i)}
+                className="mc-annot-tool"
+                title="Redo · ⇧⌘Z"
+                aria-label="Redo"
+                disabled={!canRedo}
+                onClick={redo}
               >
-                <span style={{ width: w.dot, height: w.dot, borderRadius: 999, background: "currentColor" }} />
+                <Icon name="redo" size={16} />
               </button>
-            ))}
+              <button
+                type="button"
+                className="mc-annot-tool"
+                title="Clear all"
+                aria-label="Clear all"
+                disabled={shapes.length === 0}
+                onClick={clearAll}
+              >
+                <Icon name="trash" size={16} />
+              </button>
+            </div>
           </div>
 
-          <span className="mc-annot-div" />
-
-          <div className="mc-annot-group">
-            <button
-              type="button"
-              className="mc-annot-tool"
-              title="Undo · ⌘Z"
-              aria-label="Undo"
-              disabled={!canUndo}
-              onClick={undo}
-            >
-              <Icon name="undo" size={16} />
-            </button>
-            <button
-              type="button"
-              className="mc-annot-tool"
-              title="Redo · ⇧⌘Z"
-              aria-label="Redo"
-              disabled={!canRedo}
-              onClick={redo}
-            >
-              <Icon name="redo" size={16} />
-            </button>
-            <button
-              type="button"
-              className="mc-annot-tool"
-              title="Clear all"
-              aria-label="Clear all"
-              disabled={shapes.length === 0}
-              onClick={clearAll}
-            >
-              <Icon name="trash" size={16} />
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* Stage */}
-      <div ref={stageRef} className="mc-annot-stage">
-        {status === "loading" && <div className="mc-annot-hint">Loading screenshot…</div>}
-        {status === "error" && <div className="mc-annot-hint">Couldn’t load the screenshot.</div>}
-        {status === "ready" && (
-          <div
-            className="mc-annot-canvas-frame"
-            style={{ width: display.w || undefined, height: display.h || undefined }}
-          >
-            <canvas
-              ref={canvasRef}
-              width={dims.w}
-              height={dims.h}
-              onPointerDown={onPointerDown}
-              onPointerMove={onPointerMove}
-              onPointerUp={onPointerUp}
-              onDoubleClick={onDoubleClick}
-              style={{
-                display: "block",
-                width: display.w || "100%",
-                height: display.h || "auto",
-                borderRadius: 10,
-                cursor,
-                touchAction: "none",
-              }}
-            />
-          </div>
-        )}
-      </div>
-
-      {/* Footer actions */}
-      <div className="mc-annot-footer">
-        <div className="mc-annot-footer-hint">
-          {tool === "text"
-            ? "Click to place text · double-click text to edit"
-            : tool === "select"
-              ? "Drag to move · handles to resize · ⌫ to delete"
-              : "Drag on the image to draw"}
-        </div>
-        <div style={{ display: "flex", gap: 8 }}>
-          <button type="button" className="mc-annot-btn" onClick={onCancel}>
-            Cancel
-          </button>
-          <button type="button" className="mc-annot-btn" onClick={save} disabled={busy !== null}>
-            {busy === "save" ? "Saving…" : "Save"}
-          </button>
           <button
             type="button"
-            className="mc-annot-btn is-primary"
-            onClick={attach}
-            disabled={busy !== null}
+            className="mc-annot-close"
+            title="Close · Esc"
+            aria-label="Close editor"
+            onClick={onCancel}
           >
-            {busy === "attach" ? "Attaching…" : "Attach to session"}
+            <Icon name="x" size={16} />
           </button>
+        </div>
+
+        {/* Canvas matte: the workspace the screenshot floats in. */}
+        <div ref={stageRef} className="mc-annot-stage">
+          {status === "loading" && <div className="mc-annot-hint">Loading screenshot…</div>}
+          {status === "error" && <div className="mc-annot-hint">Couldn’t load the screenshot.</div>}
+          {status === "ready" && (
+            <div
+              className="mc-annot-canvas-frame"
+              style={{ width: display.w || undefined, height: display.h || undefined }}
+            >
+              <canvas
+                ref={canvasRef}
+                width={dims.w}
+                height={dims.h}
+                onPointerDown={onPointerDown}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+                onDoubleClick={onDoubleClick}
+                style={{
+                  display: "block",
+                  width: display.w || "100%",
+                  height: display.h || "auto",
+                  borderRadius: 8,
+                  cursor,
+                  touchAction: "none",
+                }}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Footer: contextual hint + primary actions. */}
+        <div className="mc-annot-footer">
+          <div className="mc-annot-footer-hint">
+            {tool === "text"
+              ? "Click to place text · double-click text to edit"
+              : tool === "select"
+                ? "Drag to move · handles to resize · ⌫ to delete"
+                : "Drag on the image to draw"}
+          </div>
+          <div className="mc-annot-actions">
+            <button type="button" className="mc-annot-btn" onClick={onCancel}>
+              Cancel
+            </button>
+            <button type="button" className="mc-annot-btn" onClick={save} disabled={busy !== null}>
+              {busy === "save" ? "Saving…" : "Save"}
+            </button>
+            <button
+              type="button"
+              className="mc-annot-btn is-primary"
+              onClick={attach}
+              disabled={busy !== null}
+            >
+              {busy === "attach" ? "Attaching…" : "Attach to session"}
+            </button>
+          </div>
         </div>
       </div>
 
@@ -1122,15 +1147,29 @@ export function ScreenshotAnnotator({
 const ANNOT_CSS = `
 .mc-annot-root { animation: mc-annot-fade 140ms ease-out; }
 @keyframes mc-annot-fade { from { opacity: 0; } to { opacity: 1; } }
-.mc-annot-bar-wrap { display: flex; justify-content: center; padding: 16px 16px 0; }
-.mc-annot-bar {
-  display: flex; align-items: center; gap: 6px;
-  padding: 6px; border-radius: 14px;
-  background: var(--surface-2); border: 1px solid var(--border);
-  box-shadow: 0 10px 34px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.04);
-  animation: mc-annot-rise 200ms cubic-bezier(0.16,1,0.3,1);
+.mc-annot-panel {
+  display: flex; flex-direction: column;
+  width: min(1200px, 94vw); height: min(860px, 92vh);
+  background: var(--surface-1); border: 1px solid var(--border); border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 40px 120px rgba(0,0,0,0.6), 0 2px 8px rgba(0,0,0,0.4);
+  animation: mc-annot-pop 220ms cubic-bezier(0.16,1,0.3,1);
 }
-@keyframes mc-annot-rise { from { transform: translateY(-8px); opacity: 0; } to { transform: none; opacity: 1; } }
+.mc-annot-header {
+  display: flex; align-items: center; gap: 8px;
+  padding: 9px 10px; border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+}
+.mc-annot-bar {
+  display: flex; align-items: center; gap: 6px; flex: 1; min-width: 0; flex-wrap: wrap;
+}
+.mc-annot-close {
+  display: inline-flex; align-items: center; justify-content: center; flex: none;
+  width: 34px; height: 34px; padding: 0; border-radius: 9px;
+  border: 1px solid transparent; background: transparent; color: var(--text-dim);
+  cursor: pointer; transition: background 120ms, color 120ms;
+}
+.mc-annot-close:hover { background: var(--surface-3); color: var(--text); }
 .mc-annot-group { display: flex; align-items: center; gap: 3px; }
 .mc-annot-div { width: 1px; align-self: stretch; margin: 4px 4px; background: var(--border); }
 .mc-annot-tool {
@@ -1160,17 +1199,28 @@ const ANNOT_CSS = `
 .mc-annot-custom { display: inline-flex; align-items: center; justify-content: center; overflow: hidden;
   background: conic-gradient(from 0deg, #f5333f, #ffd23f, #39d353, #3b9dff, #a05bff, #f5333f); }
 .mc-annot-custom input { position: absolute; inset: -6px; opacity: 0; cursor: pointer; }
-.mc-annot-stage { flex: 1; min-height: 0; display: flex; align-items: center; justify-content: center; padding: 16px 24px; }
-.mc-annot-canvas-frame {
-  border-radius: 12px; overflow: hidden; box-shadow: 0 24px 70px rgba(0,0,0,0.55);
-  animation: mc-annot-pop 220ms cubic-bezier(0.16,1,0.3,1);
+.mc-annot-stage {
+  flex: 1; min-height: 0; position: relative;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--surface-0);
+  box-shadow: inset 0 1px 3px rgba(0,0,0,0.4);
+  background-image:
+    radial-gradient(circle at 1px 1px, color-mix(in srgb, var(--text) 6%, transparent) 1px, transparent 0);
+  background-size: 22px 22px;
 }
-@keyframes mc-annot-pop { from { transform: scale(0.98); opacity: 0; } to { transform: none; opacity: 1; } }
+.mc-annot-canvas-frame {
+  border-radius: 10px; overflow: hidden;
+  box-shadow: 0 16px 44px rgba(0,0,0,0.55), 0 0 0 1px color-mix(in srgb, var(--text) 8%, transparent);
+  animation: mc-annot-frame 220ms cubic-bezier(0.16,1,0.3,1);
+}
+@keyframes mc-annot-pop { from { transform: scale(0.985); opacity: 0; } to { transform: none; opacity: 1; } }
+@keyframes mc-annot-frame { from { transform: scale(0.99); opacity: 0; } to { transform: none; opacity: 1; } }
 .mc-annot-hint { color: var(--text-dim); font-family: var(--mono); font-size: 12px; }
 .mc-annot-footer {
   display: flex; align-items: center; justify-content: space-between; gap: 16px;
-  padding: 12px 20px 18px;
+  padding: 11px 16px; border-top: 1px solid var(--border); background: var(--surface-2);
 }
+.mc-annot-actions { display: flex; gap: 8px; }
 .mc-annot-footer-hint { color: var(--text-faint); font-family: var(--mono); font-size: 11px; letter-spacing: 0.02em; }
 .mc-annot-btn {
   height: 34px; padding: 0 16px; border-radius: 9px; font-size: 13px; font-weight: 600;
@@ -1194,6 +1244,6 @@ const ANNOT_CSS = `
 }
 .mc-annot-textarea::placeholder { color: rgba(200,215,240,0.45); font-weight: 500; }
 @media (prefers-reduced-motion: reduce) {
-  .mc-annot-root, .mc-annot-bar, .mc-annot-canvas-frame { animation: none; }
+  .mc-annot-root, .mc-annot-panel, .mc-annot-canvas-frame { animation: none; }
 }
 `;

--- a/src/components/views/ScreenshotAnnotator.tsx
+++ b/src/components/views/ScreenshotAnnotator.tsx
@@ -965,14 +965,22 @@ export function ScreenshotAnnotator({
   );
 
   /* ---- crop apply / reset ---- */
-  const applyCrop = useCallback(() => {
-    if (cropDraft) {
-      const b = clampCrop(cropDraft, dims.w, dims.h);
-      const full = b.x === 0 && b.y === 0 && b.w === dims.w && b.h === dims.h;
-      setCrop(full ? null : b);
-    }
-    setTool("select");
-  }, [cropDraft, dims.w, dims.h]);
+  // Commit the pending crop frame, then move to `next`. Leaving the crop tool by
+  // any route (Enter, Apply, or picking another tool) applies the frame — only
+  // Escape discards it — so a drawn selection is never silently thrown away.
+  const commitCropAndSwitch = useCallback(
+    (next: Tool) => {
+      if (tool === "crop" && next !== "crop" && cropDraft) {
+        const b = clampCrop(cropDraft, dims.w, dims.h);
+        const full = b.x === 0 && b.y === 0 && b.w === dims.w && b.h === dims.h;
+        setCrop(full ? null : b);
+      }
+      setTool(next);
+    },
+    [tool, cropDraft, dims.w, dims.h],
+  );
+
+  const applyCrop = useCallback(() => commitCropAndSwitch("select"), [commitCropAndSwitch]);
 
   const resetCrop = useCallback(() => {
     setCrop(null);
@@ -1059,13 +1067,13 @@ export function ScreenshotAnnotator({
       if (hit && !mod) {
         e.preventDefault();
         e.stopPropagation();
-        setTool(hit.tool);
+        commitCropAndSwitch(hit.tool); // switching tools applies a pending crop
       }
     };
     // Capture phase so app-global hotkeys don't also fire underneath.
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);
-  }, [applyCrop, deleteSelected, onCancel, redo, selectedId, textDraft, tool, undo]);
+  }, [applyCrop, commitCropAndSwitch, deleteSelected, onCancel, redo, selectedId, textDraft, tool, undo]);
 
   /* ---- export ---- */
   // Flattens the screenshot + annotations to a PNG on disk and returns its
@@ -1191,7 +1199,7 @@ export function ScreenshotAnnotator({
                   title={`${t.label} · ${t.key}`}
                   aria-label={t.label}
                   aria-pressed={tool === t.tool}
-                  onClick={() => setTool(t.tool)}
+                  onClick={() => commitCropAndSwitch(t.tool)}
                 >
                   <Icon name={t.icon} size={16} />
                 </button>
@@ -1328,7 +1336,7 @@ export function ScreenshotAnnotator({
           {tool === "crop" ? (
             <>
               <div className="mc-annot-footer-hint">
-                Drag to frame · handles to adjust · ⏎ apply
+                Drag to frame · ⏎ or pick a tool to apply · Esc to cancel
               </div>
               <div className="mc-annot-actions">
                 <button

--- a/src/components/views/ScreenshotAnnotator.tsx
+++ b/src/components/views/ScreenshotAnnotator.tsx
@@ -1458,9 +1458,14 @@ const ANNOT_CSS = `
 /* Far-right control: extend leftward so it stays inside the panel. */
 .mc-annot-close[data-tip]::after { left: auto; right: 0; }
 .mc-annot-bar {
-  display: flex; align-items: center; gap: 6px; flex: 1; min-width: 0; flex-wrap: wrap;
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+  flex: 1; min-width: 0; flex-wrap: wrap;
+  /* Leave room for the absolutely-positioned close button so the centered
+     toolbar stays optically centered in the header. */
+  padding-right: 40px;
 }
 .mc-annot-close {
+  position: absolute; top: 50%; right: 10px; transform: translateY(-50%);
   display: inline-flex; align-items: center; justify-content: center; flex: none;
   width: 34px; height: 34px; padding: 0; border-radius: 9px;
   border: 1px solid transparent; background: transparent; color: var(--text-dim);

--- a/src/components/views/ScreenshotAnnotator.tsx
+++ b/src/components/views/ScreenshotAnnotator.tsx
@@ -16,7 +16,7 @@ import type { PendingScreenshot } from "~/lib/terminal-store";
  * Model
  * ------------------------------------------------------------------ */
 
-type Tool = "select" | "pen" | "highlighter" | "arrow" | "rect" | "ellipse" | "text";
+type Tool = "select" | "crop" | "pen" | "highlighter" | "arrow" | "rect" | "ellipse" | "text";
 
 type Pt = { x: number; y: number };
 
@@ -37,6 +37,7 @@ type TextDraft = { x: number; y: number; fontSize: number; color: string; value:
 
 const TOOLS: Array<{ tool: Tool; icon: IconName; label: string; key: string }> = [
   { tool: "select", icon: "cursor", label: "Select / move", key: "V" },
+  { tool: "crop", icon: "crop", label: "Crop", key: "C" },
   { tool: "pen", icon: "pencil", label: "Pen", key: "P" },
   { tool: "highlighter", icon: "highlighter", label: "Highlighter", key: "H" },
   { tool: "arrow", icon: "arrow-up-right", label: "Arrow", key: "A" },
@@ -80,6 +81,10 @@ function nextId(): string {
 
 type Box = { x: number; y: number; w: number; h: number };
 
+// A crop window into the original image, in image px. Exported so the pending-
+// screenshot store and its callers can persist/restore it across a re-edit.
+export type CropBox = Box;
+
 function shapeBox(s: Shape, ctx: CanvasRenderingContext2D): Box {
   switch (s.type) {
     case "pen":
@@ -111,6 +116,41 @@ function shapeBox(s: Shape, ctx: CanvasRenderingContext2D): Box {
 
 function boxHit(b: Box, p: Pt): boolean {
   return p.x >= b.x && p.x <= b.x + b.w && p.y >= b.y && p.y <= b.y + b.h;
+}
+
+// Smallest crop the user can frame, in image px, so a stray click can't collapse
+// the selection to nothing.
+const CROP_MIN = 24;
+
+// Clamp a crop box inside the image and round to whole pixels (the exported
+// canvas is integer-sized).
+function clampCrop(b: Box, imgW: number, imgH: number): Box {
+  const w = Math.min(Math.max(CROP_MIN, Math.round(b.w)), imgW);
+  const h = Math.min(Math.max(CROP_MIN, Math.round(b.h)), imgH);
+  const x = Math.min(Math.max(0, Math.round(b.x)), imgW - w);
+  const y = Math.min(Math.max(0, Math.round(b.y)), imgH - h);
+  return { x, y, w, h };
+}
+
+// Resize a crop box by dragging one handle (nx,ny in {0,0.5,1}); the opposite
+// edge(s) stay put. Edges enforce CROP_MIN and never leave the image.
+function resizeCrop(b: Box, nx: number, ny: number, p: Pt, imgW: number, imgH: number): Box {
+  let { x, y, w, h } = b;
+  if (nx === 0) {
+    const right = x + w;
+    x = Math.min(Math.max(0, p.x), right - CROP_MIN);
+    w = right - x;
+  } else if (nx === 1) {
+    w = Math.min(Math.max(CROP_MIN, p.x - x), imgW - x);
+  }
+  if (ny === 0) {
+    const bottom = y + h;
+    y = Math.min(Math.max(0, p.y), bottom - CROP_MIN);
+    h = bottom - y;
+  } else if (ny === 1) {
+    h = Math.min(Math.max(CROP_MIN, p.y - y), imgH - y);
+  }
+  return { x, y, w, h };
 }
 
 function translate(s: Shape, dx: number, dy: number): Shape {
@@ -285,6 +325,53 @@ function drawArrow(ctx: CanvasRenderingContext2D, x1: number, y1: number, x2: nu
   ctx.fill();
 }
 
+// Crop selection: dim everything outside the frame, draw a bright border with
+// rule-of-thirds guides, and corner/edge grab handles. All in image px; `px` is
+// the image→screen scale so lines stay a crisp hairline at any zoom.
+function drawCropOverlay(ctx: CanvasRenderingContext2D, box: Box, imgW: number, imgH: number, px: number) {
+  ctx.save();
+  // Four rects masking the area outside the crop.
+  ctx.fillStyle = "rgba(4, 7, 10, 0.6)";
+  ctx.fillRect(0, 0, imgW, box.y);
+  ctx.fillRect(0, box.y + box.h, imgW, imgH - (box.y + box.h));
+  ctx.fillRect(0, box.y, box.x, box.h);
+  ctx.fillRect(box.x + box.w, box.y, imgW - (box.x + box.w), box.h);
+
+  // Rule-of-thirds guides.
+  ctx.strokeStyle = "rgba(255,255,255,0.28)";
+  ctx.lineWidth = 1 * px;
+  ctx.beginPath();
+  for (let i = 1; i < 3; i++) {
+    const gx = box.x + (box.w * i) / 3;
+    const gy = box.y + (box.h * i) / 3;
+    ctx.moveTo(gx, box.y);
+    ctx.lineTo(gx, box.y + box.h);
+    ctx.moveTo(box.x, gy);
+    ctx.lineTo(box.x + box.w, gy);
+  }
+  ctx.stroke();
+
+  // Frame border.
+  ctx.strokeStyle = "rgba(255,255,255,0.95)";
+  ctx.lineWidth = 1.5 * px;
+  ctx.strokeRect(box.x, box.y, box.w, box.h);
+
+  // Handles.
+  const hs = HANDLE_HALF * px;
+  ctx.fillStyle = "#ffffff";
+  ctx.strokeStyle = "rgba(70,120,220,0.95)";
+  ctx.lineWidth = 1.25 * px;
+  for (const h of HANDLE_POS) {
+    const hx = box.x + h.nx * box.w;
+    const hy = box.y + h.ny * box.h;
+    ctx.beginPath();
+    ctx.rect(hx - hs, hy - hs, hs * 2, hs * 2);
+    ctx.fill();
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
 /* ------------------------------------------------------------------ *
  * Component
  * ------------------------------------------------------------------ */
@@ -313,7 +400,7 @@ export function ScreenshotAnnotator({
   onSave: (
     path: string,
     previewDataUrl: string,
-    editable: { originalPath: string; shapes: Shape[] },
+    editable: { originalPath: string; shapes: Shape[]; crop: CropBox | null },
   ) => void;
 }) {
   const [status, setStatus] = useState<Status>("loading");
@@ -340,6 +427,15 @@ export function ScreenshotAnnotator({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [draft, setDraft] = useState<Shape | null>(null);
   const [textDraft, setTextDraft] = useState<TextDraft | null>(null);
+
+  // Committed crop window into the original image, in image px (null = full
+  // frame). Shapes stay in original-image coords, so the crop is a pure view —
+  // non-destructive, and independent of the shape undo history.
+  const [crop, setCrop] = useState<Box | null>(() => shot.crop ?? null);
+  // In-progress crop selection while the crop tool is active, before Apply.
+  const [cropDraft, setCropDraft] = useState<Box | null>(null);
+  const cropRef = useRef(crop);
+  cropRef.current = crop;
   // Which footer action is in flight ("save" | "attach"); both are disabled
   // while either runs so a double export can't race.
   const [busy, setBusy] = useState<"save" | "attach" | null>(null);
@@ -365,6 +461,15 @@ export function ScreenshotAnnotator({
     resize?: { shape: Shape; box: Box; nx: number; ny: number };
   } | null>(null);
 
+  // Crop-tool gesture scratch, separate from the shape gesture above.
+  const cropGesture = useRef<{
+    mode: "draw" | "move" | "resize";
+    start: Pt; // pointer origin (draw) or grab point (move)
+    box: Box; // crop box at gesture start
+    nx?: number;
+    ny?: number;
+  } | null>(null);
+
   /* ---- layout: fit the stage into the viewport ---- */
   const [stageBox, setStageBox] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
   useLayoutEffect(() => {
@@ -377,21 +482,42 @@ export function ScreenshotAnnotator({
     return () => ro.disconnect();
   }, [status]);
 
+  // The visible window into the image. While cropping we show the whole image so
+  // any region can be reframed; otherwise the committed crop (or the full image).
+  const view = useMemo<Box>(() => {
+    const full = { x: 0, y: 0, w: dims.w, h: dims.h };
+    if (tool === "crop") return full;
+    return crop ?? full;
+  }, [tool, crop, dims.w, dims.h]);
+
   const display = useMemo(() => {
-    if (!dims.w || !dims.h || !stageBox.w || !stageBox.h) return { w: 0, h: 0 };
+    if (!view.w || !view.h || !stageBox.w || !stageBox.h) return { w: 0, h: 0 };
     // Fit inside the matte with guaranteed margins on all sides (stageBox is the
     // matte's own box, already excluding the header and footer bars).
     const availW = Math.max(1, stageBox.w - MATTE_PAD_PX * 2);
     const availH = Math.max(1, stageBox.h - MATTE_PAD_PX * 2);
-    const scale = Math.min(availW / dims.w, availH / dims.h, 2.5);
-    return { w: Math.round(dims.w * scale), h: Math.round(dims.h * scale) };
-  }, [dims, stageBox]);
+    const scale = Math.min(availW / view.w, availH / view.h, 2.5);
+    return { w: Math.round(view.w * scale), h: Math.round(view.h * scale) };
+  }, [view, stageBox]);
+
+  // Entering/leaving the crop tool: seed the pending selection from the current
+  // crop (or the whole image), and drop any shape selection/draft in progress.
+  useEffect(() => {
+    if (tool !== "crop") {
+      setCropDraft(null);
+      return;
+    }
+    if (!dims.w || !dims.h) return;
+    setSelectedId(null);
+    setDraft(null);
+    setCropDraft(cropRef.current ?? { x: 0, y: 0, w: dims.w, h: dims.h });
+  }, [tool, dims.w, dims.h]);
 
   // WIDTHS/TEXT_SIZES are tuned as apparent sizes for a full-screen Retina
   // capture displayed at ~0.5x. Small region captures display zoomed (up to
   // 2.5x), which would blow marks up 5x on screen — so normalize by the actual
   // display scale to keep the apparent size constant.
-  const sizeScale = display.w > 0 && dims.w > 0 ? dims.w / display.w / 2 : 1;
+  const sizeScale = display.w > 0 && view.w > 0 ? view.w / display.w / 2 : 1;
   const strokeWidth = WIDTHS[widthIdx]!.w * sizeScale;
   const textSize = Math.round(TEXT_SIZES[widthIdx]! * sizeScale);
 
@@ -429,21 +555,27 @@ export function ScreenshotAnnotator({
     (ctx: CanvasRenderingContext2D, list: Shape[], withSelection: boolean) => {
       const img = imgRef.current;
       if (!img) return;
-      ctx.clearRect(0, 0, dims.w, dims.h);
+      // The canvas is sized to the current view window; translate so the image is
+      // drawn in original-image coordinates and only the window shows.
+      ctx.clearRect(0, 0, view.w, view.h);
+      ctx.save();
+      ctx.translate(-view.x, -view.y);
       ctx.drawImage(img, 0, 0, dims.w, dims.h);
       for (const s of list) {
         if (textDraft?.editingId === s.id) continue; // hidden while re-editing
         drawShape(ctx, s);
       }
       if (draft) drawShape(ctx, draft);
-      if (withSelection && selectedId) {
+
+      // Hairline weight: keep marquee/handle lines ~1.5px on screen at any zoom.
+      const px = view.w / Math.max(1, display.w);
+
+      if (tool === "crop" && cropDraft) {
+        drawCropOverlay(ctx, cropDraft, dims.w, dims.h, px);
+      } else if (withSelection && selectedId) {
         const sel = list.find((s) => s.id === selectedId);
         if (sel) {
           const b = shapeBox(sel, ctx);
-          // Draw the marquee + handles in image space but sized off the display
-          // scale, so the outline stays a crisp ~1.5px hairline on screen at any
-          // zoom instead of a chunky line blown up with the Retina bitmap.
-          const px = dims.w / Math.max(1, display.w);
           ctx.save();
           ctx.setLineDash([4 * px, 3 * px]);
           ctx.lineWidth = 1.5 * px;
@@ -463,8 +595,9 @@ export function ScreenshotAnnotator({
           ctx.restore();
         }
       }
+      ctx.restore();
     },
-    [dims.w, dims.h, display.w, draft, selectedId, textDraft],
+    [view, dims.w, dims.h, display.w, draft, selectedId, textDraft, tool, cropDraft],
   );
 
   useEffect(() => {
@@ -481,12 +614,13 @@ export function ScreenshotAnnotator({
       const canvas = canvasRef.current;
       if (!canvas) return { x: 0, y: 0 };
       const r = canvas.getBoundingClientRect();
+      // Map into the view window, then offset back into original-image coords.
       return {
-        x: ((clientX - r.left) / r.width) * dims.w,
-        y: ((clientY - r.top) / r.height) * dims.h,
+        x: view.x + ((clientX - r.left) / r.width) * view.w,
+        y: view.y + ((clientY - r.top) / r.height) * view.h,
       };
     },
-    [dims.w, dims.h],
+    [view],
   );
 
   /* ---- history ---- */
@@ -585,6 +719,27 @@ export function ScreenshotAnnotator({
 
       canvas.setPointerCapture(e.pointerId);
 
+      if (tool === "crop") {
+        const cur = cropDraft ?? { x: 0, y: 0, w: dims.w, h: dims.h };
+        const hr = HANDLE_HIT * (view.w / Math.max(1, display.w));
+        // Grab a handle to resize, the body to move, or empty space to reframe.
+        for (const h of HANDLE_POS) {
+          const hx = cur.x + h.nx * cur.w;
+          const hy = cur.y + h.ny * cur.h;
+          if (Math.abs(p.x - hx) <= hr && Math.abs(p.y - hy) <= hr) {
+            cropGesture.current = { mode: "resize", start: p, box: cur, nx: h.nx, ny: h.ny };
+            return;
+          }
+        }
+        if (boxHit(cur, p)) {
+          cropGesture.current = { mode: "move", start: p, box: cur };
+        } else {
+          cropGesture.current = { mode: "draw", start: p, box: cur };
+          setCropDraft({ x: p.x, y: p.y, w: 0, h: 0 });
+        }
+        return;
+      }
+
       if (tool === "select") {
         const ctx = canvas.getContext("2d")!;
         // Grabbing a resize handle of the already-selected shape takes priority
@@ -635,11 +790,56 @@ export function ScreenshotAnnotator({
       setDraft(newDraft);
       gesture.current = { startShapes: start, mode: "draw", moveId: null, last: p };
     },
-    [color, commitText, dims.w, display.w, selectedId, status, strokeWidth, textDraft, textSize, tool, toImage],
+    [color, commitText, cropDraft, dims.h, dims.w, display.w, selectedId, status, strokeWidth, textDraft, textSize, tool, toImage, view.w],
   );
 
   const onPointerMove = useCallback(
     (e: ReactPointerEvent<HTMLCanvasElement>) => {
+      // Active crop drag takes priority over everything else.
+      const cg = cropGesture.current;
+      if (cg) {
+        const p = toImage(e.clientX, e.clientY);
+        if (cg.mode === "draw") {
+          setCropDraft({
+            x: Math.min(cg.start.x, p.x),
+            y: Math.min(cg.start.y, p.y),
+            w: Math.abs(p.x - cg.start.x),
+            h: Math.abs(p.y - cg.start.y),
+          });
+        } else if (cg.mode === "move") {
+          const dx = p.x - cg.start.x;
+          const dy = p.y - cg.start.y;
+          setCropDraft({
+            x: Math.min(Math.max(0, cg.box.x + dx), dims.w - cg.box.w),
+            y: Math.min(Math.max(0, cg.box.y + dy), dims.h - cg.box.h),
+            w: cg.box.w,
+            h: cg.box.h,
+          });
+        } else if (cg.nx !== undefined && cg.ny !== undefined) {
+          setCropDraft(resizeCrop(cg.box, cg.nx, cg.ny, p, dims.w, dims.h));
+        }
+        return;
+      }
+
+      // Cursor affordance for the crop frame while hovering (no drag yet).
+      if (tool === "crop" && cropDraft && canvasRef.current) {
+        const cv = canvasRef.current;
+        const hp = toImage(e.clientX, e.clientY);
+        const hr = HANDLE_HIT * (view.w / Math.max(1, display.w));
+        let cur = "crosshair";
+        for (const h of HANDLE_POS) {
+          const hx = cropDraft.x + h.nx * cropDraft.w;
+          const hy = cropDraft.y + h.ny * cropDraft.h;
+          if (Math.abs(hp.x - hx) <= hr && Math.abs(hp.y - hy) <= hr) {
+            cur = resizeCursor(h.nx, h.ny);
+            break;
+          }
+        }
+        if (cur === "crosshair" && boxHit(cropDraft, hp)) cur = "move";
+        cv.style.cursor = cur;
+        return;
+      }
+
       // Cursor affordance for the resize handles while hovering (no drag yet).
       if (!gesture.current && tool === "select" && selectedId && canvasRef.current) {
         const cv = canvasRef.current;
@@ -711,11 +911,29 @@ export function ScreenshotAnnotator({
         return { ...d, x2, y2 };
       });
     },
-    [dims.w, display.w, selectedId, toImage, tool],
+    [cropDraft, dims.h, dims.w, display.w, selectedId, toImage, tool, view.w],
   );
 
   const onPointerUp = useCallback(
     (e: ReactPointerEvent<HTMLCanvasElement>) => {
+      const cg = cropGesture.current;
+      if (cg) {
+        cropGesture.current = null;
+        try {
+          canvasRef.current?.releasePointerCapture(e.pointerId);
+        } catch {
+          /* ignore */
+        }
+        // A too-small draw (usually just a click) reverts to the prior frame;
+        // otherwise snap to whole pixels within the image.
+        setCropDraft((d) => {
+          if (!d) return d;
+          if (cg.mode === "draw" && (d.w < CROP_MIN || d.h < CROP_MIN)) return cg.box;
+          return clampCrop(d, dims.w, dims.h);
+        });
+        return;
+      }
+
       const g = gesture.current;
       gesture.current = null;
       try {
@@ -743,8 +961,23 @@ export function ScreenshotAnnotator({
         });
       }
     },
-    [finalize, sizeScale],
+    [dims.h, dims.w, finalize, sizeScale],
   );
+
+  /* ---- crop apply / reset ---- */
+  const applyCrop = useCallback(() => {
+    if (cropDraft) {
+      const b = clampCrop(cropDraft, dims.w, dims.h);
+      const full = b.x === 0 && b.y === 0 && b.w === dims.w && b.h === dims.h;
+      setCrop(full ? null : b);
+    }
+    setTool("select");
+  }, [cropDraft, dims.w, dims.h]);
+
+  const resetCrop = useCallback(() => {
+    setCrop(null);
+    setCropDraft({ x: 0, y: 0, w: dims.w, h: dims.h });
+  }, [dims.w, dims.h]);
 
   const onDoubleClick = useCallback(
     (e: ReactPointerEvent<HTMLCanvasElement>) => {
@@ -792,14 +1025,22 @@ export function ScreenshotAnnotator({
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const typing = !!textDraft;
+      const cropping = tool === "crop";
       if (e.key === "Escape") {
         e.preventDefault();
         e.stopPropagation();
         if (typing) setTextDraft(null);
+        else if (cropping) setTool("select"); // leave crop, keep the applied frame
         else onCancel();
         return;
       }
       if (typing) return; // let the textarea handle everything else
+      if (cropping && e.key === "Enter") {
+        e.preventDefault();
+        e.stopPropagation();
+        applyCrop();
+        return;
+      }
       const mod = e.metaKey || e.ctrlKey;
       if (mod && e.key.toLowerCase() === "z") {
         e.preventDefault();
@@ -824,15 +1065,17 @@ export function ScreenshotAnnotator({
     // Capture phase so app-global hotkeys don't also fire underneath.
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);
-  }, [deleteSelected, onCancel, redo, selectedId, textDraft, undo]);
+  }, [applyCrop, deleteSelected, onCancel, redo, selectedId, textDraft, tool, undo]);
 
   /* ---- export ---- */
   // Flattens the screenshot + annotations to a PNG on disk and returns its
   // path plus a downscaled preview data URL for the floating thumbnail.
   const exportPng = useCallback(async (): Promise<{ path: string; previewDataUrl: string }> => {
+    // Export at the current view size — the committed crop (or the full image) —
+    // and let render() bake in the same window offset it draws on screen.
     const off = document.createElement("canvas");
-    off.width = dims.w;
-    off.height = dims.h;
+    off.width = view.w;
+    off.height = view.h;
     const ctx = off.getContext("2d");
     if (!ctx) throw new Error("no ctx");
     render(ctx, shapesRef.current, false);
@@ -848,15 +1091,15 @@ export function ScreenshotAnnotator({
     });
     if ("error" in saved) throw new Error(saved.error);
 
-    const scale = Math.min(1, PREVIEW_WIDTH_PX / dims.w);
+    const scale = Math.min(1, PREVIEW_WIDTH_PX / view.w);
     const thumb = document.createElement("canvas");
-    thumb.width = Math.max(1, Math.round(dims.w * scale));
-    thumb.height = Math.max(1, Math.round(dims.h * scale));
+    thumb.width = Math.max(1, Math.round(view.w * scale));
+    thumb.height = Math.max(1, Math.round(view.h * scale));
     const tctx = thumb.getContext("2d");
     if (!tctx) throw new Error("no ctx");
     tctx.drawImage(off, 0, 0, thumb.width, thumb.height);
     return { path: saved.path, previewDataUrl: thumb.toDataURL("image/png") };
-  }, [dims.w, dims.h, render]);
+  }, [view.w, view.h, render]);
 
   const attach = useCallback(async () => {
     if (status !== "ready" || busy) return;
@@ -874,11 +1117,11 @@ export function ScreenshotAnnotator({
     setBusy("save");
     try {
       const { path, previewDataUrl } = await exportPng();
-      onSave(path, previewDataUrl, { originalPath: basePath, shapes: shapesRef.current });
+      onSave(path, previewDataUrl, { originalPath: basePath, shapes: shapesRef.current, crop });
     } catch {
       setBusy(null);
     }
-  }, [basePath, busy, exportPng, onSave, status]);
+  }, [basePath, busy, crop, exportPng, onSave, status]);
 
   // Recolor the currently-selected shape when a color is picked in select mode.
   const recolorSelected = useCallback(
@@ -900,14 +1143,16 @@ export function ScreenshotAnnotator({
   const textOverlay = useMemo(() => {
     if (!textDraft || !canvasRef.current) return null;
     const r = canvasRef.current.getBoundingClientRect();
-    const sx = r.width / dims.w;
+    const sx = r.width / view.w;
+    // Text coords are in original-image space; subtract the view origin so the
+    // input lands over the glyphs even when a crop is active.
     return {
-      left: r.left + textDraft.x * sx,
-      top: r.top + textDraft.y * (r.height / dims.h),
+      left: r.left + (textDraft.x - view.x) * sx,
+      top: r.top + (textDraft.y - view.y) * (r.height / view.h),
       fontSize: textDraft.fontSize * sx,
       color: textDraft.color,
     };
-  }, [textDraft, dims.w, dims.h, display]);
+  }, [textDraft, view, display]);
 
   const overlay = (
     <div
@@ -1059,8 +1304,8 @@ export function ScreenshotAnnotator({
             >
               <canvas
                 ref={canvasRef}
-                width={dims.w}
-                height={dims.h}
+                width={view.w || dims.w}
+                height={view.h || dims.h}
                 onPointerDown={onPointerDown}
                 onPointerMove={onPointerMove}
                 onPointerUp={onPointerUp}
@@ -1078,31 +1323,54 @@ export function ScreenshotAnnotator({
           )}
         </div>
 
-        {/* Footer: contextual hint + primary actions. */}
+        {/* Footer: crop controls while framing, otherwise the primary actions. */}
         <div className="mc-annot-footer">
-          <div className="mc-annot-footer-hint">
-            {tool === "text"
-              ? "Click to place text · double-click text to edit"
-              : tool === "select"
-                ? "Drag to move · handles to resize · ⌫ to delete"
-                : "Drag on the image to draw"}
-          </div>
-          <div className="mc-annot-actions">
-            <button type="button" className="mc-annot-btn" onClick={onCancel}>
-              Cancel
-            </button>
-            <button type="button" className="mc-annot-btn" onClick={save} disabled={busy !== null}>
-              {busy === "save" ? "Saving…" : "Save"}
-            </button>
-            <button
-              type="button"
-              className="mc-annot-btn is-primary"
-              onClick={attach}
-              disabled={busy !== null}
-            >
-              {busy === "attach" ? "Attaching…" : "Attach to session"}
-            </button>
-          </div>
+          {tool === "crop" ? (
+            <>
+              <div className="mc-annot-footer-hint">
+                Drag to frame · handles to adjust · ⏎ apply
+              </div>
+              <div className="mc-annot-actions">
+                <button
+                  type="button"
+                  className="mc-annot-btn"
+                  onClick={resetCrop}
+                  disabled={!crop}
+                >
+                  Reset
+                </button>
+                <button type="button" className="mc-annot-btn is-primary" onClick={applyCrop}>
+                  Apply crop
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="mc-annot-footer-hint">
+                {tool === "text"
+                  ? "Click to place text · double-click text to edit"
+                  : tool === "select"
+                    ? "Drag to move · handles to resize · ⌫ to delete"
+                    : "Drag on the image to draw"}
+              </div>
+              <div className="mc-annot-actions">
+                <button type="button" className="mc-annot-btn" onClick={onCancel}>
+                  Cancel
+                </button>
+                <button type="button" className="mc-annot-btn" onClick={save} disabled={busy !== null}>
+                  {busy === "save" ? "Saving…" : "Save"}
+                </button>
+                <button
+                  type="button"
+                  className="mc-annot-btn is-primary"
+                  onClick={attach}
+                  disabled={busy !== null}
+                >
+                  {busy === "attach" ? "Attaching…" : "Attach to session"}
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
 

--- a/src/components/views/ScreenshotAnnotator.tsx
+++ b/src/components/views/ScreenshotAnnotator.tsx
@@ -58,6 +58,9 @@ const COLORS = [
   "#f5f7fa", // chalk
 ];
 
+// Human names for each swatch, shown in the hover tooltip.
+const COLOR_LABELS = ["Red", "Amber", "Yellow", "Green", "Blue", "Ink", "Chalk"];
+
 // Stroke widths in image (device) pixels. Screenshots are Retina, so these are
 // tuned to feel like ~thin/medium/thick marker tips on screen.
 const WIDTHS = [
@@ -1196,7 +1199,7 @@ export function ScreenshotAnnotator({
                   key={t.tool}
                   type="button"
                   className={`mc-annot-tool${tool === t.tool ? " is-active" : ""}`}
-                  title={`${t.label} · ${t.key}`}
+                  data-tip={`${t.label} · ${t.key}`}
                   aria-label={t.label}
                   aria-pressed={tool === t.tool}
                   onClick={() => commitCropAndSwitch(t.tool)}
@@ -1209,13 +1212,13 @@ export function ScreenshotAnnotator({
             <span className="mc-annot-div" />
 
             <div className="mc-annot-group">
-              {COLORS.map((c) => (
+              {COLORS.map((c, i) => (
                 <button
                   key={c}
                   type="button"
                   className={`mc-annot-swatch${color === c ? " is-active" : ""}`}
-                  title={c}
-                  aria-label={`Color ${c}`}
+                  data-tip={COLOR_LABELS[i] ?? c}
+                  aria-label={COLOR_LABELS[i] ?? `Color ${c}`}
                   aria-pressed={color === c}
                   onClick={() => {
                     setColor(c);
@@ -1224,7 +1227,7 @@ export function ScreenshotAnnotator({
                   style={{ background: c }}
                 />
               ))}
-              <label className="mc-annot-swatch mc-annot-custom" title="Custom color">
+              <label className="mc-annot-swatch mc-annot-custom" data-tip="Custom color">
                 <input
                   type="color"
                   value={color}
@@ -1244,7 +1247,7 @@ export function ScreenshotAnnotator({
                   key={w.label}
                   type="button"
                   className={`mc-annot-width${widthIdx === i ? " is-active" : ""}`}
-                  title={w.label}
+                  data-tip={w.label}
                   aria-label={w.label}
                   aria-pressed={widthIdx === i}
                   onClick={() => setWidthIdx(i)}
@@ -1260,7 +1263,7 @@ export function ScreenshotAnnotator({
               <button
                 type="button"
                 className="mc-annot-tool"
-                title="Undo · ⌘Z"
+                data-tip="Undo · ⌘Z"
                 aria-label="Undo"
                 disabled={!canUndo}
                 onClick={undo}
@@ -1270,7 +1273,7 @@ export function ScreenshotAnnotator({
               <button
                 type="button"
                 className="mc-annot-tool"
-                title="Redo · ⇧⌘Z"
+                data-tip="Redo · ⇧⌘Z"
                 aria-label="Redo"
                 disabled={!canRedo}
                 onClick={redo}
@@ -1280,7 +1283,7 @@ export function ScreenshotAnnotator({
               <button
                 type="button"
                 className="mc-annot-tool"
-                title="Clear all"
+                data-tip="Clear all"
                 aria-label="Clear all"
                 disabled={shapes.length === 0}
                 onClick={clearAll}
@@ -1293,7 +1296,7 @@ export function ScreenshotAnnotator({
           <button
             type="button"
             className="mc-annot-close"
-            title="Close · Esc"
+            data-tip="Close · Esc"
             aria-label="Close editor"
             onClick={onCancel}
           >
@@ -1435,7 +1438,25 @@ const ANNOT_CSS = `
   display: flex; align-items: center; gap: 8px;
   padding: 9px 10px; border-bottom: 1px solid var(--border);
   background: var(--surface-2);
+  position: relative; z-index: 2; /* lift tooltips above the canvas matte below */
 }
+/* Hover tooltips: instant, styled, and clipped inside the panel. Anchored to the
+   button's left edge so they extend into open space and never clip a corner. */
+.mc-annot-header [data-tip] { position: relative; }
+.mc-annot-header [data-tip]::after {
+  content: attr(data-tip);
+  position: absolute; top: calc(100% + 7px); left: 0;
+  padding: 4px 8px; border-radius: 7px; white-space: nowrap;
+  background: var(--surface-3); color: var(--text); border: 1px solid var(--border);
+  font-size: 11px; font-weight: 500; font-family: var(--mono); letter-spacing: 0.01em;
+  box-shadow: 0 8px 22px rgba(0,0,0,0.45);
+  opacity: 0; transform: translateY(-3px); pointer-events: none;
+  transition: opacity 110ms ease, transform 110ms ease;
+  z-index: 10;
+}
+.mc-annot-header [data-tip]:hover::after { opacity: 1; transform: translateY(0); transition-delay: 160ms; }
+/* Far-right control: extend leftward so it stays inside the panel. */
+.mc-annot-close[data-tip]::after { left: auto; right: 0; }
 .mc-annot-bar {
   display: flex; align-items: center; gap: 6px; flex: 1; min-width: 0; flex-wrap: wrap;
 }
@@ -1476,7 +1497,7 @@ const ANNOT_CSS = `
   background: conic-gradient(from 0deg, #f5333f, #ffd23f, #39d353, #3b9dff, #a05bff, #f5333f); }
 .mc-annot-custom input { position: absolute; inset: -6px; opacity: 0; cursor: pointer; }
 .mc-annot-stage {
-  flex: 1; min-height: 0; position: relative;
+  flex: 1; min-height: 0; position: relative; z-index: 1;
   display: flex; align-items: center; justify-content: center;
   background: var(--surface-0);
   box-shadow: inset 0 1px 3px rgba(0,0,0,0.4);
@@ -1521,5 +1542,7 @@ const ANNOT_CSS = `
 .mc-annot-textarea::placeholder { color: rgba(200,215,240,0.45); font-weight: 500; }
 @media (prefers-reduced-motion: reduce) {
   .mc-annot-root, .mc-annot-panel, .mc-annot-canvas-frame { animation: none; }
+  .mc-annot-header [data-tip]::after,
+  .mc-annot-header [data-tip]:hover::after { transform: none; transition: opacity 110ms ease; }
 }
 `;

--- a/src/components/views/ScreenshotHistory.tsx
+++ b/src/components/views/ScreenshotHistory.tsx
@@ -11,6 +11,7 @@ import { Icon } from "~/components/ui/Icon";
 import {
   ScreenshotAnnotator,
   type Shape as AnnotationShape,
+  type CropBox,
 } from "~/components/views/ScreenshotAnnotator";
 import { useTerminals, type ScreenshotEntry } from "~/lib/terminal-store";
 import { playScreenshotDrop } from "~/lib/screenshot-sound";
@@ -175,13 +176,14 @@ function ScreenshotHistoryCard({
     (
       imagePath: string,
       previewDataUrl: string,
-      editable: { originalPath: string; shapes: AnnotationShape[] },
+      editable: { originalPath: string; shapes: AnnotationShape[]; crop: CropBox | null },
     ) => {
       updateScreenshot(shot.id, {
         path: imagePath,
         previewDataUrl,
         originalPath: editable.originalPath,
         shapes: editable.shapes,
+        crop: editable.crop ?? undefined,
       });
       setEditing(false);
     },

--- a/src/components/views/ScreenshotThumbnail.tsx
+++ b/src/components/views/ScreenshotThumbnail.tsx
@@ -11,6 +11,7 @@ import { Icon } from "~/components/ui/Icon";
 import {
   ScreenshotAnnotator,
   type Shape as AnnotationShape,
+  type CropBox,
 } from "~/components/views/ScreenshotAnnotator";
 import { useTerminals, type PendingScreenshot } from "~/lib/terminal-store";
 import { playScreenshotDrop } from "~/lib/screenshot-sound";
@@ -182,13 +183,14 @@ function ScreenshotStackCard({ shot, projectId }: { shot: PendingScreenshot; pro
     (
       imagePath: string,
       previewDataUrl: string,
-      editable: { originalPath: string; shapes: AnnotationShape[] },
+      editable: { originalPath: string; shapes: AnnotationShape[]; crop: CropBox | null },
     ) => {
       updateScreenshot(shot.id, {
         path: imagePath,
         previewDataUrl,
         originalPath: editable.originalPath,
         shapes: editable.shapes,
+        crop: editable.crop ?? undefined,
       });
       setEditing(false);
     },

--- a/src/lib/terminal-store.tsx
+++ b/src/lib/terminal-store.tsx
@@ -64,6 +64,9 @@ export type ScreenshotEntry = {
   /** Editable annotation shapes from the last save, restored when re-editing so
    *  previously-added annotations stay selectable instead of baked-in pixels. */
   shapes?: AnnotationShape[];
+  /** Crop window into the original image (image px), restored when re-editing so
+   *  a cropped screenshot re-opens framed the same way. Undefined = full frame. */
+  crop?: { x: number; y: number; w: number; h: number };
 };
 
 /** @deprecated alias kept so the annotator's `shot: PendingScreenshot` prop


### PR DESCRIPTION

<img width="1428" height="887" alt="image" src="https://github.com/user-attachments/assets/7037de7a-249b-46ad-b270-e43e6f895ce9" />

Reworks the screenshot annotator into a proper editing surface and adds an image crop tool.

## Bounded editor panel
The old overlay was a full-screen dim with a floating toolbar pill and an edge-bleeding canvas — it read as a toolbar dropped over the app, not an editor. It's now a bounded editor window with three tonal layers:

- **Header** (`--surface-2`) — the toolbar attached as real app chrome, with a close ✕.
- **Canvas matte** (`--surface-0`, subtle dot grid) — the screenshot floats as a framed document with guaranteed margins, so it reads as a workspace at any image size.
- **Footer** (`--surface-2`) — contextual hint + primary actions.

The panel is centered and bounded to `min(1200px, 94vw) × min(860px, 92vh)`.

## Non-destructive crop tool
New **Crop** tool (icon, shortcut `C`):

- Crop is a **view window** in original-image coordinates — shapes stay in original coords, so it's non-destructive, independent of the shape undo history, and re-editable.
- Drag to frame with rule-of-thirds guides + 8 handles; move or resize the frame.
- **Leaving the crop tool by any route — Enter, Apply, or picking another tool — commits the frame; only Esc cancels.** (Fixes the initial version where switching tools silently discarded the frame.)
- The crop bakes into the exported PNG + preview, and persists on `ScreenshotEntry` so a re-edit re-opens framed the same way (threaded through both `ScreenshotHistory` and `ScreenshotThumbnail`).

## Verification
- `tsc --noEmit` + eslint clean across all touched files.
- `terminal-store` tests pass (20/20).
- Panel layout and crop overlay rendering battle-tested with real-token harness screenshots.

Follows the `/impeccable` product register (calm, operator-grade, restrained; chrome recedes via tonal steps).