### PR TITLE
feat(sessions): pinned-session filter in grid view

### DIFF
--- a/src/components/views/SessionGrid.tsx
+++ b/src/components/views/SessionGrid.tsx
@@ -369,6 +369,11 @@ type GridCellProps = {
   onRequestClose: (session: OpenTerminal) => void;
   onPtyReady: (taskId: string, ptyId: string | null, scopeKey: string) => void;
   onHeaderPointerDown: (taskId: string, event: ReactPointerEvent<HTMLDivElement>) => void;
+  /** Toggle this cell's pinned flag (stable across renders); omit to hide the
+   *  control. Pinned state itself is read live inside the pane. */
+  onTogglePin?: (taskId: string) => void;
+  /** True while this session's pin toggle is in flight (disables the control). */
+  pinBusy: boolean;
 };
 
 /** One grid cell (its terminal), memoized so a per-grid state change — moving
@@ -391,6 +396,8 @@ const GridCell = memo(function GridCell({
   onRequestClose,
   onPtyReady,
   onHeaderPointerDown,
+  onTogglePin,
+  pinBusy,
 }: GridCellProps) {
   return (
     <CardFrame
@@ -454,6 +461,8 @@ const GridCell = memo(function GridCell({
               reorderEnabled ? (e) => onHeaderPointerDown(session.taskId, e) : undefined
             }
             headerGrabbing={isDragging}
+            onTogglePin={onTogglePin ? () => onTogglePin(session.taskId) : undefined}
+            pinBusy={pinBusy}
           />
         )}
       </div>
@@ -613,10 +622,23 @@ function HiddenSessionsBar({
 export function SessionGrid({
   scopeKey,
   emptyHeader,
+  filter = "active",
+  pinnedTaskIds,
+  onTogglePinned,
+  pinningTaskIds,
 }: {
   scopeKey: string;
   /** "Sessions" title row rendered above the empty state (all sessions hidden). */
   emptyHeader?: ReactNode;
+  /** Which scope the grid renders. "pinned" packs the grid down to the pinned
+   *  sessions only (a view filter — the persisted layout is left untouched). */
+  filter?: "active" | "pinned";
+  /** Live set of pinned task ids, used by the "pinned" filter. */
+  pinnedTaskIds?: ReadonlySet<string>;
+  /** Toggle a session's pinned flag from its grid cell header. */
+  onTogglePinned?: (taskId: string) => void;
+  /** Task ids with an in-flight pin toggle (disables the cell's pin control). */
+  pinningTaskIds?: ReadonlySet<string>;
 }) {
   const {
     sessions,
@@ -678,18 +700,46 @@ export function SessionGrid({
     [allScopedSessions, hiddenTaskIds],
   );
 
+  // The scope toggle's "Pinned" tab narrows the grid to pinned sessions. This is
+  // purely a *view* filter: it drives what renders (packing the grid down to the
+  // pinned cells the same way hiding a session does), while the persisted layout
+  // and hidden-id bookkeeping keep working off the full scope above. In the
+  // "active" tab the predicate is a no-op so nothing about the grid changes.
+  const isFiltered = filter === "pinned";
+  const matchesFilter = useCallback(
+    (session: OpenTerminal) => !isFiltered || (pinnedTaskIds?.has(session.taskId) ?? false),
+    [isFiltered, pinnedTaskIds],
+  );
+  // The sessions the grid actually lays out and renders under the current tab.
+  const renderSessions = useMemo(
+    () => (isFiltered ? scopedSessions.filter(matchesFilter) : scopedSessions),
+    [isFiltered, scopedSessions, matchesFilter],
+  );
+
+  // The route hands us a fresh pin-toggle fn each render; wrap it behind a ref so
+  // each GridCell gets a stable callback and the per-cell memo still holds.
+  const togglePinnedRef = useRef(onTogglePinned);
+  useEffect(() => {
+    togglePinnedRef.current = onTogglePinned;
+  }, [onTogglePinned]);
+  const handleTogglePin = useCallback((taskId: string) => {
+    togglePinnedRef.current?.(taskId);
+  }, []);
+
   // The hidden sessions, most recently hidden first (Set preserves insertion
   // order; reversed so the newest hide lands leftmost in the restore bar).
+  // Under the "pinned" filter, only pinned hidden sessions belong to the view,
+  // so the restore bar stays consistent with the packed grid above it.
   const hiddenSessions = useMemo(() => {
     if (hiddenTaskIds.size === 0) return [];
     const byId = new Map(allScopedSessions.map((s) => [s.taskId, s]));
     const out: OpenTerminal[] = [];
     for (const id of hiddenTaskIds) {
       const session = byId.get(id);
-      if (session) out.unshift(session);
+      if (session && matchesFilter(session)) out.unshift(session);
     }
     return out;
-  }, [hiddenTaskIds, allScopedSessions]);
+  }, [hiddenTaskIds, allScopedSessions, matchesFilter]);
 
   // Drop hidden ids whose session is gone (archived/closed elsewhere) so a hide
   // never lingers and the empty-state math stays honest.
@@ -1152,9 +1202,13 @@ export function SessionGrid({
   // resolved to actual sessions. Any scoped session not yet placed (the frame
   // before reconcile runs) shows in a trailing row so it never flashes missing.
   const activeLayout = dragLayout ?? layout;
+  // Resolve layout cells against the *rendered* set so the "pinned" filter packs
+  // the grid to just its cells: a cell whose session isn't in the render set is
+  // dropped and any fully-emptied row collapses — the same packing hiding a
+  // session already relies on. The persisted layout above is unaffected.
   const sessionById = useMemo(
-    () => new Map(scopedSessions.map((s) => [s.taskId, s])),
-    [scopedSessions],
+    () => new Map(renderSessions.map((s) => [s.taskId, s])),
+    [renderSessions],
   );
   const { viewRows, hasUnplaced } = useMemo(() => {
     const seen = new Set<string>();
@@ -1170,12 +1224,12 @@ export function SessionGrid({
         return { cells, fr: activeLayout.rowSizes[ri] ?? 1 };
       })
       .filter((r) => r.cells.length > 0);
-    const extras = scopedSessions.filter((s) => !seen.has(s.taskId));
+    const extras = renderSessions.filter((s) => !seen.has(s.taskId));
     if (extras.length > 0) {
       rows.push({ cells: extras.map((s) => ({ session: s, fr: 1 })), fr: 1 });
     }
     return { viewRows: rows, hasUnplaced: extras.length > 0 };
-  }, [activeLayout, sessionById, scopedSessions]);
+  }, [activeLayout, sessionById, renderSessions]);
 
   const visibleSessions = useMemo(
     () => viewRows.flatMap((r) => r.cells.map((c) => c.session)),
@@ -1389,7 +1443,12 @@ export function SessionGrid({
     positionDraggedCell();
   });
 
-  const reorderEnabled = !expandedTaskId && visibleSessions.length > 1;
+  // Reordering/resizing edit the persisted per-scope layout, but the "pinned"
+  // filter only renders a subset of that layout's cells — dragging within the
+  // packed subset would write geometry back against cells that aren't on screen.
+  // So arranging happens in the Active tab (where the full layout lives); the
+  // Pinned tab is a read-through view.
+  const reorderEnabled = !expandedTaskId && visibleSessions.length > 1 && !isFiltered;
 
   // Pixel space the row-height tracks share, once outer padding + gaps are gone.
   const totalRowFr = layout.rowSizes.reduce((a, b) => a + b, 0) || 1;
@@ -1416,7 +1475,11 @@ export function SessionGrid({
     [gridSize.width, gridPad, gridGap],
   );
   const resizeEnabled =
-    !expandedTaskId && !dragLayout && visibleSessions.length > 1 && gridSize.width > 0;
+    !expandedTaskId &&
+    !dragLayout &&
+    visibleSessions.length > 1 &&
+    gridSize.width > 0 &&
+    !isFiltered;
 
   // Left/top pixel offset of the divider after track `index` (0-based).
   const dividerOffset = useCallback(
@@ -1949,8 +2012,23 @@ export function SessionGrid({
 
   // The project route only mounts the grid once the scope has a session, so an
   // empty grid usually means a transient frame — unless the user hid every
-  // session, in which case the restore bar must stay reachable.
-  if (scopedSessions.length === 0) {
+  // session, in which case the restore bar must stay reachable. The "pinned"
+  // tab can also empty the view while the scope still has (unpinned) sessions;
+  // there we stay in the grid and explain how to fill it rather than fall back.
+  if (renderSessions.length === 0) {
+    const someHidden = hiddenSessions.length > 0;
+    const emptyTitle = someHidden
+      ? isFiltered
+        ? "All pinned sessions hidden"
+        : "All sessions hidden"
+      : isFiltered
+        ? "No pinned sessions"
+        : "No active sessions";
+    const emptySubtitle = someHidden
+      ? "Click a session in the bar below to bring it back."
+      : isFiltered
+        ? "Pin a session from its header to keep it in this view."
+        : "Start a new session to begin working on this project.";
     return (
       <>
         {/* Grid mode leaves 12px under the project header where the list view
@@ -1966,12 +2044,9 @@ export function SessionGrid({
           }}
         >
           <EmptyState
-            title={hiddenSessions.length > 0 ? "All sessions hidden" : "No active sessions"}
-            subtitle={
-              hiddenSessions.length > 0
-                ? "Click a session in the bar below to bring it back."
-                : "Start a new session to begin working on this project."
-            }
+            title={emptyTitle}
+            subtitle={emptySubtitle}
+            icon={isFiltered && !someHidden ? "pin" : undefined}
             action={
               hiddenSessions.length > 0 ? (
                 // mc-btn-new-session gives the outlined accent look the list
@@ -2045,6 +2120,8 @@ export function SessionGrid({
                   onRequestClose={requestClose}
                   onPtyReady={setPtyId}
                   onHeaderPointerDown={startPointerReorder}
+                  onTogglePin={onTogglePinned ? handleTogglePin : undefined}
+                  pinBusy={pinningTaskIds?.has(session.taskId) ?? false}
                 />
               );
             })}

--- a/src/components/views/TerminalPane.tsx
+++ b/src/components/views/TerminalPane.tsx
@@ -194,6 +194,9 @@ function HeaderMoreMenu({
   expanded,
   onToggleExpanded,
   onHide,
+  onTogglePin,
+  pinned,
+  pinBusy,
   buttons,
   onRename,
   onClone,
@@ -214,6 +217,10 @@ function HeaderMoreMenu({
   onToggleExpanded?: () => void;
   /** Present only when the close control was also collapsed into the menu. */
   onHide?: () => void;
+  /** Present only when the pin control was collapsed into the menu (micro). */
+  onTogglePin?: () => void;
+  pinned: boolean;
+  pinBusy: boolean;
   /** Which discretionary actions the user has chosen to show (mirrors the header). */
   buttons: SessionHeaderButtonVisibility;
   onRename: () => void;
@@ -362,8 +369,17 @@ function HeaderMoreMenu({
               </DropdownMenuItem>
             )}
             {buttons.focus && (
-              <DropdownMenuItem icon="pin" onClick={() => pick(onFocusMode)}>
+              <DropdownMenuItem icon="external-link" onClick={() => pick(onFocusMode)}>
                 Focus session
+              </DropdownMenuItem>
+            )}
+            {onTogglePin && (
+              <DropdownMenuItem
+                icon={pinned ? "pin-fill" : "pin"}
+                disabled={pinBusy}
+                onClick={() => pick(onTogglePin)}
+              >
+                {pinned ? "Unpin session" : "Pin session"}
               </DropdownMenuItem>
             )}
             {onToggleExpanded && (
@@ -401,6 +417,8 @@ export function TerminalPane({
   onHeaderPointerDown,
   headerGrabbing = false,
   hideHeader = false,
+  onTogglePin,
+  pinBusy = false,
 }: {
   project: Project & { activeWorktreeId?: string | null; activeRuntimeScopeId?: string | null };
   task: Task;
@@ -415,6 +433,11 @@ export function TerminalPane({
   headerGrabbing?: boolean;
   /** Focused Session Mode renders its own window chrome instead. */
   hideHeader?: boolean;
+  /** Pin/unpin this session (session grid only). Pinned state is read live from
+   *  the task, so no separate flag is needed. Omit to hide the control. */
+  onTogglePin?: () => void;
+  /** True while a pin toggle is in flight — disables the control. */
+  pinBusy?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const paneRef = useRef<HTMLDivElement>(null);
@@ -1519,7 +1542,10 @@ export function TerminalPane({
             </>
           )}
         </div>
-        <div style={{ display: "flex", alignItems: "center", gap: 4, flexShrink: 0 }}>
+        <div
+          className="mc-pane-header-actions"
+          style={{ display: "flex", alignItems: "center", gap: 4, flexShrink: 0 }}
+        >
           {isSandboxTerminal && !tinyHeader && (
             <span
               title="This terminal runs inside the selected sandbox"
@@ -1550,6 +1576,9 @@ export function TerminalPane({
               expanded={expanded}
               onToggleExpanded={tinyHeader ? onToggleExpanded : undefined}
               onHide={microHeader ? onHide : undefined}
+              onTogglePin={microHeader ? onTogglePin : undefined}
+              pinned={liveTask.pinned}
+              pinBusy={pinBusy}
               buttons={sessionButtons}
               onRename={openRenameDialog}
               onClone={requestSessionClone}
@@ -1600,7 +1629,7 @@ export function TerminalPane({
                   <Btn
                     variant="ghost"
                     size="sm"
-                    icon="pin"
+                    icon="external-link"
                     onClick={requestFocusMode}
                     aria-label="Focus session in a floating window"
                     style={{ width: 34, padding: 0 }}
@@ -1608,6 +1637,25 @@ export function TerminalPane({
                 </HotkeyTooltip>
               )}
             </>
+          )}
+          {onTogglePin && !microHeader && (
+            <Tooltip content={liveTask.pinned ? "Unpin session" : "Pin session"}>
+              <Btn
+                variant="ghost"
+                size="sm"
+                icon={liveTask.pinned ? "pin-fill" : "pin"}
+                onClick={onTogglePin}
+                disabled={pinBusy}
+                aria-busy={pinBusy}
+                aria-pressed={liveTask.pinned}
+                aria-label={liveTask.pinned ? "Unpin session" : "Pin session"}
+                style={{
+                  width: 34,
+                  padding: 0,
+                  color: liveTask.pinned ? "var(--accent)" : undefined,
+                }}
+              />
+            </Tooltip>
           )}
           {onToggleExpanded && !tinyHeader && (
             <HotkeyTooltip

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -33,7 +33,7 @@ import { ScriptArgsModal } from "~/components/views/ScriptArgsModal";
 import { WorktreeSetupCommandDialog } from "~/components/views/WorktreeSetupCommandDialog";
 import { NewAgentButton } from "~/components/views/NewAgentButton";
 import { CursorGlow } from "~/components/ui/CursorGlow";
-import { HotkeyTooltip, StaticHotkeyTooltip } from "~/components/ui/Tooltip";
+import { HotkeyTooltip, StaticHotkeyTooltip, Tooltip } from "~/components/ui/Tooltip";
 import { Modal } from "~/components/ui/Modal";
 import { ConfirmDialog } from "~/components/ui/ConfirmDialog";
 import { RemoveProjectConfirmDialog } from "~/components/views/RemoveProjectConfirmDialog";
@@ -523,6 +523,13 @@ function ProjectPage() {
     wasSandboxProvisioningRef.current = sandboxProvisioning;
   }, [sandboxProvisioning, tasksQuery]);
   const hasArchivedTasks = tasks.some((t) => t.archived);
+  // Live pinned-session ids for the grid's "Pinned" filter — derived from the
+  // task query (not the store's open-time snapshot) so a pin toggle reflects
+  // immediately. Memoized so SessionGrid's filter doesn't churn every render.
+  const pinnedTaskIds = useMemo(
+    () => new Set(tasks.filter((t) => !t.archived && t.pinned).map((t) => t.id)),
+    [tasks],
+  );
   const groups = groupsQuery.data ?? [];
   useApiToken();
   const {
@@ -720,8 +727,11 @@ function ProjectPage() {
   // The grid only takes over the workspace once the scope has a session to show.
   // With none, we fall back to the normal sessions view so an empty grid matches
   // the single-panel empty state exactly (header, scope toggle, and all) instead
-  // of a bare centered message.
-  const showGrid = gridViewActive && gridScopeSessionCount > 0;
+  // of a bare centered message. Archived is a list-only management view (no live
+  // terminals to grid), so selecting it drops back to the list; the grid filters
+  // only between Active and Pinned (SessionGrid handles the empty-Pinned state).
+  const showGrid =
+    gridViewActive && sessionView !== "archived" && gridScopeSessionCount > 0;
   const syncTask = terminals.syncTask;
   const rehydrateTerminal = terminals.rehydrate;
   const toggleTerminalSession = terminals.toggle;
@@ -2568,6 +2578,20 @@ function ProjectPage() {
     </HeaderActions>
   );
 
+  // The Active / Pinned / Archived scope tabs. Extracted so the grid can show
+  // the same control inline (the grid filters Active↔Pinned) without duplicating
+  // the whole "Sessions" title row and its New session button.
+  const scopeToggle = (
+    <SessionScopeToggle
+      view={sessionView}
+      activeCount={activeTasks.length}
+      pinnedCount={pinnedTasks.length}
+      archivedCount={archivedTasks.length}
+      showArchivedTab={hasArchivedTasks || showArchived}
+      onChange={setSessionView}
+    />
+  );
+
   // "Sessions" title row (scope tabs + New session). Shared between the list
   // view and the grid's all-hidden empty state so both read identically.
   const sessionsHeader = (
@@ -2593,14 +2617,7 @@ function ProjectPage() {
         >
           Sessions
         </div>
-        <SessionScopeToggle
-          view={sessionView}
-          activeCount={activeTasks.length}
-          pinnedCount={pinnedTasks.length}
-          archivedCount={archivedTasks.length}
-          showArchivedTab={hasArchivedTasks || showArchived}
-          onChange={setSessionView}
-        />
+        {scopeToggle}
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
         {showArchived ? (
@@ -2885,6 +2902,21 @@ function ProjectPage() {
                 >
                   Custom scripts
                 </DropdownMenuItem>
+                {showGrid && gridScopeSessionCount > 0 && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      icon="archive"
+                      onClick={() => {
+                        setOverflowOpen(false);
+                        setConfirmArchiveAll(true);
+                      }}
+                      title="Archive all open sessions in this grid"
+                    >
+                      Archive all sessions
+                    </DropdownMenuItem>
+                  </>
+                )}
                 <DropdownMenuSeparator />
                 <HotkeyTooltip action="project.edit">
                   <DropdownMenuItem
@@ -2918,20 +2950,24 @@ function ProjectPage() {
               display: "inline-flex",
               alignItems: "center",
               justifyContent: "flex-end",
-              gap: 8,
+              gap: 6,
               flexWrap: "wrap",
               marginLeft: "auto",
               minWidth: 0,
             }}
           >
             {showGrid && (
-              <Btn
-                variant="ghost"
-                icon="archive"
-                onClick={() => setConfirmArchiveAll(true)}
-                aria-label="Archive all sessions in this grid"
-                title="Archive all sessions in this grid"
-                style={{ width: 52, minWidth: 52, paddingInline: 0 }}
+              // Compact scope switcher (Active / Pinned / Archived) — icon-only so
+              // it rides in the header beside the other controls instead of a
+              // full-width tab row. Archived drops back to the list view.
+              <SessionScopeToggle
+                view={sessionView}
+                activeCount={activeTasks.length}
+                pinnedCount={pinnedTasks.length}
+                archivedCount={archivedTasks.length}
+                showArchivedTab={hasArchivedTasks || showArchived}
+                onChange={setSessionView}
+                iconOnly
               />
             )}
             {screenshotSupported && (
@@ -2944,7 +2980,7 @@ function ProjectPage() {
                   icon="camera"
                   onClick={captureScreenshot}
                   aria-label="Capture a screenshot"
-                  style={{ width: 52, minWidth: 52, paddingInline: 0 }}
+                  style={{ width: 40, minWidth: 40, paddingInline: 0 }}
                 />
               </HotkeyTooltip>
             )}
@@ -2966,7 +3002,7 @@ function ProjectPage() {
                     ? "Project folder unavailable"
                     : "Find file in project"
                 }
-                style={{ width: 52, minWidth: 52, paddingInline: 0 }}
+                style={{ width: 40, minWidth: 40, paddingInline: 0 }}
               />
             </HotkeyTooltip>
             <div
@@ -3017,8 +3053,8 @@ function ProjectPage() {
                 aria-label={terminals.gridView ? "Exit grid view" : "Grid view — show all sessions"}
                 aria-pressed={terminals.gridView}
                 style={{
-                  width: 52,
-                  minWidth: 52,
+                  width: 40,
+                  minWidth: 40,
                   paddingInline: 0,
                   background: terminals.gridView ? "var(--surface-2)" : undefined,
                   color: terminals.gridView ? "var(--text)" : undefined,
@@ -3029,7 +3065,14 @@ function ProjectPage() {
         </div>
 
         {showGrid ? (
-          <SessionGrid scopeKey={selectedScopeKey} emptyHeader={sessionsHeader} />
+          <SessionGrid
+            scopeKey={selectedScopeKey}
+            emptyHeader={sessionsHeader}
+            filter={showPinned ? "pinned" : "active"}
+            pinnedTaskIds={pinnedTaskIds}
+            onTogglePinned={toggleSessionPinned}
+            pinningTaskIds={pinningTaskIds}
+          />
         ) : (
         <>
         {cleanupStatus && (
@@ -3757,6 +3800,7 @@ function SessionScopeToggle({
   archivedCount,
   showArchivedTab,
   onChange,
+  iconOnly = false,
 }: {
   view: SessionView;
   activeCount: number;
@@ -3764,24 +3808,41 @@ function SessionScopeToggle({
   archivedCount: number;
   showArchivedTab: boolean;
   onChange: (view: SessionView) => void;
+  /** Compact icon-only segments (tooltip carries the label + count) for the grid
+   *  header, so the switcher sits beside the other header controls instead of
+   *  taking a full row. */
+  iconOnly?: boolean;
 }) {
   // Visual state (background/color/box-shadow + hover) lives in styles.css
   // under .mc-session-scope-tab so unselected tabs get a hover treatment.
-  const segment: CSSProperties = {
-    appearance: "none",
-    border: 0,
-    fontFamily: "var(--mono)",
-    fontSize: 11,
-    fontWeight: 600,
-    letterSpacing: "0.04em",
-    textTransform: "uppercase",
-    padding: "5px 12px",
-    borderRadius: 7,
-    cursor: "pointer",
-    display: "inline-flex",
-    alignItems: "center",
-    gap: 6,
-  };
+  const segment: CSSProperties = iconOnly
+    ? {
+        appearance: "none",
+        border: 0,
+        borderRadius: 7,
+        cursor: "pointer",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 34,
+        height: 30,
+        padding: 0,
+      }
+    : {
+        appearance: "none",
+        border: 0,
+        fontFamily: "var(--mono)",
+        fontSize: 11,
+        fontWeight: 600,
+        letterSpacing: "0.04em",
+        textTransform: "uppercase",
+        padding: "5px 12px",
+        borderRadius: 7,
+        cursor: "pointer",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+      };
   const countStyle: CSSProperties = {
     color: "var(--text-faint)",
     fontVariantNumeric: "tabular-nums",
@@ -3816,7 +3877,7 @@ function SessionScopeToggle({
       {tabs.map((tab) => {
         const selected = view === tab.view;
         const tabIndex = tabs.findIndex((entry) => entry.view === tab.view);
-        return (
+        const button = (
           <button
             key={tab.view}
             ref={(node) => {
@@ -3825,6 +3886,7 @@ function SessionScopeToggle({
             type="button"
             role="radio"
             aria-checked={selected}
+            aria-label={iconOnly ? `${tab.label} sessions, ${tab.count}` : undefined}
             tabIndex={selected ? 0 : -1}
             className="mc-session-scope-tab"
             data-selected={selected || undefined}
@@ -3846,10 +3908,17 @@ function SessionScopeToggle({
               }
             }}
           >
-            <Icon name={tab.icon} size={13} />
-            {tab.label}
-            <span style={countStyle}>{tab.count}</span>
+            <Icon name={tab.icon} size={iconOnly ? 15 : 13} />
+            {!iconOnly && tab.label}
+            {!iconOnly && <span style={countStyle}>{tab.count}</span>}
           </button>
+        );
+        return iconOnly ? (
+          <Tooltip key={tab.view} content={`${tab.label} · ${tab.count}`}>
+            {button}
+          </Tooltip>
+        ) : (
+          button
         );
       })}
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2075,6 +2075,30 @@ body[data-card-glow] .cursor-glow {
   outline-offset: -2px;
 }
 
+/* Grid cell header controls rest at half strength so a wall of terminal panes
+   reads calm; the active session (the pane you're focused in) sits a little
+   brighter, and any control lights fully when you reach for it. Pressed-state
+   buttons (pin when pinned, expand when expanded) and keyboard focus stay full
+   so state and a11y aren't muted. Scoped to grid cells so the single-panel
+   view keeps its full-strength header. */
+[data-grid-cell] .mc-pane-header-actions button {
+  opacity: 0.5;
+  transition: opacity 120ms ease;
+}
+[data-grid-cell]:focus-within .mc-pane-header-actions button {
+  opacity: 0.9;
+}
+[data-grid-cell] .mc-pane-header-actions button:hover,
+[data-grid-cell] .mc-pane-header-actions button:focus-visible,
+[data-grid-cell] .mc-pane-header-actions button[aria-pressed="true"] {
+  opacity: 1;
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-grid-cell] .mc-pane-header-actions button {
+    transition: none;
+  }
+}
+
 /* xterm overrides to match the active app theme */
 .xterm-viewport {
   background-color: var(--terminal-bg) !important;


### PR DESCRIPTION

<img width="1751" height="895" alt="image" src="https://github.com/user-attachments/assets/06bca7f4-aa08-422d-b8dd-450d64de3319" />

## What

Brings the **Active / Pinned** scope filter to the session **grid view**, so pinned sessions are reachable there the same way they are in the list view.

## Changes

- **Filter the grid by the scope toggle.** The Pinned tab packs the grid down to just the pinned cells. This is a pure *view* filter — it reuses the same packing that hide/restore already relies on, and the persisted per-scope layout (`mc.gridLayout`) is left untouched. Reorder/resize are disabled on the Pinned tab (you arrange in Active, where the full layout lives).
- **Archived stays list-only.** Selecting Archived from grid view drops back to the normal list; the grid filters only Active ↔ Pinned.
- **Compact scope switcher in the header.** An icon-only segmented control (tooltip carries label + count) replaces the full-width tab row inside the grid.
- **Pin/unpin from a cell header.** Reads live pinned state and reuses the route's optimistic toggle (`toggleSessionPinned`, with the in-flight busy state and error rollback). Folds into the cell's overflow menu on narrow panes. Empty Pinned tab stays in the grid with a "No pinned sessions" state rather than bouncing to the list.
- **Focus mode gets its own pop-out icon** (`external-link`) so it no longer collides with the pin control.
- **Calmer grid headers.** Cell header controls rest at 0.5 opacity, 0.9 for the active (focused) pane, and full on hover / keyboard focus / pressed (pinned, expanded). Scoped to grid cells so the single-panel view keeps its full-strength header.
- **Header tidy-up.** Icon buttons tightened to 40px / 6px gap; Archive-all moved into the project overflow menu.

## Verification

- `tsc --noEmit` (app + `electron/tsconfig.json`) — clean
- `eslint` on all touched files — clean
- `vitest` store tests — pass
- Booted the real Vite dev server; changed modules transform cleanly and the running dev app HMRs the UI

Files: `src/routes/projects.$id.tsx`, `src/components/views/SessionGrid.tsx`, `src/components/views/TerminalPane.tsx`, `src/styles.css`.