### PR TITLE
feat(focus): screenshot capture in focus mode + responsive annotator toolbar

### DIFF
--- a/src/components/views/ScreenshotAnnotator.tsx
+++ b/src/components/views/ScreenshotAnnotator.tsx
@@ -1584,7 +1584,9 @@ const ANNOT_CSS = `
   .mc-annot-width { width: 24px; height: 28px; border-radius: 8px; }
   .mc-annot-swatch { width: 18px; height: 18px; }
   .mc-annot-close { width: 28px; height: 28px; }
-  .mc-annot-footer { padding: 9px 10px; gap: 10px; }
+  /* The hint is dropped below, leaving the actions as the footer's only child —
+     space-between would park them at the left, so pin them right instead. */
+  .mc-annot-footer { padding: 9px 10px; gap: 10px; justify-content: flex-end; }
   .mc-annot-footer-hint { display: none; }
 }
 /* Down to the minimum focus-window width (320px): one centered group per row.
@@ -1602,5 +1604,8 @@ const ANNOT_CSS = `
   .mc-annot-header .mc-annot-close {
     position: static; top: auto; transform: none; align-self: flex-start; flex: none;
   }
+  /* Keep all three footer actions on one line down to the 320px minimum. */
+  .mc-annot-btn { padding: 0 12px; white-space: nowrap; }
+  .mc-annot-actions { gap: 6px; }
 }
 `;

--- a/src/components/views/ScreenshotAnnotator.tsx
+++ b/src/components/views/ScreenshotAnnotator.tsx
@@ -1193,7 +1193,7 @@ export function ScreenshotAnnotator({
         {/* Header: the working toolbar, attached as real app chrome. */}
         <div className="mc-annot-header">
           <div className="mc-annot-bar">
-            <div className="mc-annot-group">
+            <div className="mc-annot-group mc-annot-group--tools">
               {TOOLS.map((t) => (
                 <button
                   key={t.tool}
@@ -1211,7 +1211,7 @@ export function ScreenshotAnnotator({
 
             <span className="mc-annot-div" />
 
-            <div className="mc-annot-group">
+            <div className="mc-annot-group mc-annot-group--colors">
               {COLORS.map((c, i) => (
                 <button
                   key={c}
@@ -1241,7 +1241,7 @@ export function ScreenshotAnnotator({
 
             <span className="mc-annot-div" />
 
-            <div className="mc-annot-group">
+            <div className="mc-annot-group mc-annot-group--widths">
               {WIDTHS.map((w, i) => (
                 <button
                   key={w.label}
@@ -1259,7 +1259,7 @@ export function ScreenshotAnnotator({
 
             <span className="mc-annot-div" />
 
-            <div className="mc-annot-group">
+            <div className="mc-annot-group mc-annot-group--history">
               <button
                 type="button"
                 className="mc-annot-tool"
@@ -1464,7 +1464,11 @@ const ANNOT_CSS = `
      toolbar stays optically centered in the header. */
   padding-right: 40px;
 }
-.mc-annot-close {
+/* Header-qualified so this outranks the [data-tip] hover-tooltip rule above —
+   a bare .mc-annot-close loses the specificity tie and its position: absolute
+   would be silently replaced by the tooltip anchor's position: relative,
+   dropping the button into the flex flow. */
+.mc-annot-header .mc-annot-close {
   position: absolute; top: 50%; right: 10px; transform: translateY(-50%);
   display: inline-flex; align-items: center; justify-content: center; flex: none;
   width: 34px; height: 34px; padding: 0; border-radius: 9px;
@@ -1549,5 +1553,54 @@ const ANNOT_CSS = `
   .mc-annot-root, .mc-annot-panel, .mc-annot-canvas-frame { animation: none; }
   .mc-annot-header [data-tip]::after,
   .mc-annot-header [data-tip]:hover::after { transform: none; transition: opacity 110ms ease; }
+}
+/* Narrow windows (the focus-mode floating card most of all): the single-row
+   toolbar needs ~835px, and free flex wrapping breaks it into ragged rows with
+   dividers stretched across them. Below that, lay the four groups out as a
+   deliberate 2×2 grid instead — tools + history on top, colors + widths
+   below — and pin the close button to the first row. */
+@media (max-width: 940px) {
+  .mc-annot-header { padding: 8px 10px; }
+  .mc-annot-bar {
+    display: grid;
+    grid-template-columns: auto auto;
+    justify-content: center;
+    align-items: center;
+    justify-items: start;
+    row-gap: 5px; column-gap: 14px;
+  }
+  .mc-annot-div { display: none; }
+  .mc-annot-group--tools { order: 1; }
+  .mc-annot-group--history { order: 2; }
+  .mc-annot-group--colors { order: 3; }
+  .mc-annot-group--widths { order: 4; }
+  /* Align with the first toolbar row instead of floating between rows. */
+  .mc-annot-header .mc-annot-close { top: 8px; transform: none; }
+}
+/* Tighter still: shrink the controls so both grid columns keep fitting. */
+@media (max-width: 520px) {
+  .mc-annot-bar { column-gap: 8px; }
+  .mc-annot-tool { width: 28px; height: 28px; border-radius: 8px; }
+  .mc-annot-width { width: 24px; height: 28px; border-radius: 8px; }
+  .mc-annot-swatch { width: 18px; height: 18px; }
+  .mc-annot-close { width: 28px; height: 28px; }
+  .mc-annot-footer { padding: 9px 10px; gap: 10px; }
+  .mc-annot-footer-hint { display: none; }
+}
+/* Down to the minimum focus-window width (320px): one centered group per row.
+   The close button joins the header flow (top-right, beside the first row) and
+   the bar reclaims its clearance, so the 8-tool row fits even at 320 with the
+   tool buttons slightly narrowed. */
+@media (max-width: 440px) {
+  .mc-annot-bar {
+    grid-template-columns: auto;
+    row-gap: 4px;
+    justify-items: center;
+    padding-right: 0;
+  }
+  .mc-annot-tool { width: 26px; }
+  .mc-annot-header .mc-annot-close {
+    position: static; top: auto; transform: none; align-self: flex-start; flex: none;
+  }
 }
 `;

--- a/src/components/views/ScreenshotThumbnail.tsx
+++ b/src/components/views/ScreenshotThumbnail.tsx
@@ -24,6 +24,10 @@ const THUMB_WIDTH_PX = 168;
 // pile regardless of each capture's aspect ratio. Images are cropped
 // (top-anchored, objectFit: cover) to fill the box.
 const THUMB_HEIGHT_PX = 120;
+// Compact cards for the focus-mode floating window, where the full-size stack
+// would cover most of the (small) terminal.
+const COMPACT_THUMB_WIDTH_PX = 116;
+const COMPACT_THUMB_HEIGHT_PX = 82;
 
 const cardBaseStyle: CSSProperties = {
   display: "flex",
@@ -31,7 +35,6 @@ const cardBaseStyle: CSSProperties = {
   alignItems: "stretch",
   gap: 6,
   padding: 8,
-  width: THUMB_WIDTH_PX + 16,
   borderRadius: 12,
   border: "1px solid var(--border)",
   background: "var(--surface-1)",
@@ -54,9 +57,21 @@ function sessionHostAtPoint(x: number, y: number): HTMLElement | null {
  * Dismiss with the ✕. Each card owns its own drag state so cards in the stack
  * move independently.
  */
-function ScreenshotStackCard({ shot, projectId }: { shot: PendingScreenshot; projectId: string }) {
+function ScreenshotStackCard({
+  shot,
+  projectId,
+  compact = false,
+}: {
+  shot: PendingScreenshot;
+  projectId: string;
+  compact?: boolean;
+}) {
   const { dismissPendingScreenshot, updateScreenshot, attachImageToSession, activeTaskIdFor } =
     useTerminals();
+
+  const thumbWidth = compact ? COMPACT_THUMB_WIDTH_PX : THUMB_WIDTH_PX;
+  const thumbHeight = compact ? COMPACT_THUMB_HEIGHT_PX : THUMB_HEIGHT_PX;
+  const cardStyle: CSSProperties = { ...cardBaseStyle, width: thumbWidth + 16 };
 
   const startRef = useRef<{ x: number; y: number } | null>(null);
   const draggingRef = useRef(false);
@@ -231,7 +246,7 @@ function ScreenshotStackCard({ shot, projectId }: { shot: PendingScreenshot; pro
             style={{
               display: "block",
               width: "100%",
-              height: THUMB_HEIGHT_PX,
+              height: thumbHeight,
               objectFit: "cover",
               objectPosition: "top",
             }}
@@ -252,8 +267,8 @@ function ScreenshotStackCard({ shot, projectId }: { shot: PendingScreenshot; pro
               display: "inline-flex",
               alignItems: "center",
               justifyContent: "center",
-              width: 28,
-              height: 28,
+              width: compact ? 22 : 28,
+              height: compact ? 22 : 28,
               padding: 0,
               borderRadius: 8,
               border: "none",
@@ -262,7 +277,7 @@ function ScreenshotStackCard({ shot, projectId }: { shot: PendingScreenshot; pro
               background: "rgba(0,0,0,0.6)",
             }}
           >
-            <Icon name="x" size={16} />
+            <Icon name="x" size={compact ? 13 : 16} />
           </button>
         )}
         {!ghost && (
@@ -280,8 +295,8 @@ function ScreenshotStackCard({ shot, projectId }: { shot: PendingScreenshot; pro
               display: "inline-flex",
               alignItems: "center",
               justifyContent: "center",
-              width: 26,
-              height: 26,
+              width: compact ? 22 : 26,
+              height: compact ? 22 : 26,
               padding: 0,
               borderRadius: 8,
               border: "none",
@@ -291,20 +306,24 @@ function ScreenshotStackCard({ shot, projectId }: { shot: PendingScreenshot; pro
               boxShadow: "0 2px 8px rgba(0,0,0,0.4)",
             }}
           >
-            <Icon name="plus" size={15} />
+            <Icon name="plus" size={compact ? 13 : 15} />
           </button>
         )}
       </div>
-      <div
-        style={{
-          fontSize: 11,
-          color: "var(--text-dim)",
-          textAlign: "center",
-          fontFamily: "var(--mono)",
-        }}
-      >
-        Click to edit · drag to attach
-      </div>
+      {/* The caption doesn't fit the compact card; its aria-label carries the
+          same instructions there. */}
+      {!compact && (
+        <div
+          style={{
+            fontSize: 11,
+            color: "var(--text-dim)",
+            textAlign: "center",
+            fontFamily: "var(--mono)",
+          }}
+        >
+          Click to edit · drag to attach
+        </div>
+      )}
     </>
   );
 
@@ -332,7 +351,7 @@ function ScreenshotStackCard({ shot, projectId }: { shot: PendingScreenshot; pro
         onLostPointerCapture={leaving ? undefined : abortDrag}
         onAnimationEnd={leaving ? dismiss : undefined}
         style={{
-          ...cardBaseStyle,
+          ...cardStyle,
           cursor: dragging ? "grabbing" : "grab",
           opacity: dragging ? 0 : 1,
           // Pointer capture still routes move/up here while dragging, so drop
@@ -387,7 +406,7 @@ function ScreenshotStackCard({ shot, projectId }: { shot: PendingScreenshot; pro
         <div
           aria-hidden
           style={{
-            ...cardBaseStyle,
+            ...cardStyle,
             position: "fixed",
             left: dragPoint.x,
             top: dragPoint.y,
@@ -405,17 +424,54 @@ function ScreenshotStackCard({ shot, projectId }: { shot: PendingScreenshot; pro
 }
 
 /**
- * Floating stack of freshly captured screenshots, pinned bottom-right. Each new
- * capture piles on top; the oldest sits at the bottom of the stack. Attaching or
- * dismissing a card only removes it from this stack — the screenshot lives on in
- * the on-demand history strip. Rendered globally via a portal so it floats above
- * the grid and drops can hit-test the whole document.
+ * Floating stack of freshly captured screenshots. Each new capture piles on
+ * top; attaching or dismissing a card only removes it from this stack — the
+ * screenshot lives on in the on-demand history strip.
+ *
+ * The default "floating" variant pins bottom-right, rendered globally via a
+ * portal so it floats above the grid and drops can hit-test the whole document.
+ * The "focus" variant is for the focus-mode floating window: compact cards
+ * anchored top-right *inside* the (relatively positioned) terminal wrapper, so
+ * they overlay old scrollback instead of the prompt and latest output at the
+ * bottom, and always sit below the header/session bar whatever their height.
  */
-export function ScreenshotThumbnail({ projectId }: { projectId: string }) {
+export function ScreenshotThumbnail({
+  projectId,
+  variant = "floating",
+}: {
+  projectId: string;
+  variant?: "floating" | "focus";
+}) {
   const { pendingScreenshots } = useTerminals();
   const shots = pendingScreenshots.filter((s) => s.projectId === projectId);
 
   if (shots.length === 0) return null;
+
+  if (variant === "focus") {
+    return (
+      <div
+        style={{
+          position: "absolute",
+          top: 8,
+          right: 8,
+          zIndex: 100,
+          display: "flex",
+          // Top-pinned: newest first, so the freshest capture hugs the corner
+          // and older ones trail downward.
+          flexDirection: "column",
+          alignItems: "flex-end",
+          gap: 6,
+          // Let clicks fall through the gaps between cards; each card
+          // re-enables pointer events for itself.
+          pointerEvents: "none",
+        }}
+      >
+        {[...shots].reverse().map((shot) => (
+          <ScreenshotStackCard key={shot.id} shot={shot} projectId={projectId} compact />
+        ))}
+      </div>
+    );
+  }
 
   return createPortal(
     <div

--- a/src/routes/focus.$taskId.tsx
+++ b/src/routes/focus.$taskId.tsx
@@ -8,15 +8,23 @@ import {
   type CSSProperties,
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { Btn } from "~/components/ui/Btn";
 import { StatusDot } from "~/components/ui/StatusDot";
 import { HotkeyTooltip, Tooltip } from "~/components/ui/Tooltip";
 import { TerminalPane } from "~/components/views/TerminalPane";
 import { FocusSessionBar } from "~/components/views/FocusSessionBar";
+import { ScreenshotThumbnail } from "~/components/views/ScreenshotThumbnail";
 import { applyQuestionServerEvent } from "~/lib/agent-question-store";
 import { STATUS_META } from "~/lib/design-meta";
 import { getElectron, isElectron } from "~/lib/electron";
 import { exitFocusSession, switchFocusSession } from "~/lib/focus-session";
+import {
+  screenshotCaptureErrorMessage,
+  screenshotFromResult,
+  screenshotSupported as isScreenshotSupported,
+} from "~/lib/screenshot";
+import { playScreenshotCapture } from "~/lib/screenshot-sound";
 import {
   orderSessions,
   reconcileFocusOrder,
@@ -217,6 +225,33 @@ function FocusSessionPage() {
       .catch(() => undefined);
   }, [alwaysOnTop]);
 
+  // Native screenshot capture, mirroring the project route (which is unmounted
+  // while floating, taking its hotkey handler and toolbar button with it): same
+  // macOS-only gate, same capture flow. Captures land in a compact thumbnail
+  // stack overlaid on the terminal (see the render below).
+  const screenshotSupported = useMemo(() => isScreenshotSupported(), []);
+  const addScreenshot = terminals.addScreenshot;
+  const captureScreenshot = useCallback(async () => {
+    const projectId = currentProjectId;
+    if (!projectId) return;
+    const electron = getElectron();
+    if (!electron) return;
+    const result = await electron.screenshot.captureRegion();
+    if ("error" in result) {
+      toast.error(screenshotCaptureErrorMessage(result.error));
+      return;
+    }
+    const shot = screenshotFromResult(result);
+    if (shot) {
+      playScreenshotCapture();
+      addScreenshot({ ...shot, projectId });
+    }
+  }, [addScreenshot, currentProjectId]);
+  useHotkey("screenshot.capture", () => void captureScreenshot(), {
+    capture: true,
+    enabled: screenshotSupported && hasSession,
+  });
+
   // Collapsible session bar. Preference persists across launches; hiding it
   // hands the extra vertical space to the terminal without touching the session.
   const [barOpen, setBarOpen] = useState(loadBarOpenPref);
@@ -316,6 +351,8 @@ function FocusSessionPage() {
         showBarToggle={showBar}
         barOpen={barOpen}
         onToggleBar={toggleBar}
+        showScreenshot={screenshotSupported}
+        onCaptureScreenshot={() => void captureScreenshot()}
       />
       {showBar && (
         <FocusSessionBar
@@ -326,7 +363,20 @@ function FocusSessionPage() {
           onSelect={selectSession}
         />
       )}
-      <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
+      {/* data-task-id makes the terminal a drop target for thumbnail drags
+          (sessionHostAtPoint), matching the grid cells / docked panel; the
+          relative position anchors the focus-variant stack to the terminal
+          area so it always clears the header and session bar. */}
+      <div
+        data-task-id={session.taskId}
+        style={{
+          flex: 1,
+          minHeight: 0,
+          display: "flex",
+          flexDirection: "column",
+          position: "relative",
+        }}
+      >
         <TerminalPane
           key={`${session.taskId}:${scopeKey}`}
           project={session.project}
@@ -336,6 +386,11 @@ function FocusSessionPage() {
           hideHeader
           onPtyReady={(ptyId) => terminals.setPtyId(session.taskId, ptyId, scopeKey)}
         />
+        {/* Compact capture stack pinned top-right, over old scrollback rather
+            than the prompt and freshest output at the bottom of the pane. */}
+        {screenshotSupported && (
+          <ScreenshotThumbnail projectId={session.project.id} variant="focus" />
+        )}
       </div>
     </div>
   );
@@ -416,6 +471,8 @@ function FocusSessionHeader({
   showBarToggle,
   barOpen,
   onToggleBar,
+  showScreenshot,
+  onCaptureScreenshot,
 }: {
   session: OpenTerminal;
   alwaysOnTop: boolean;
@@ -424,6 +481,8 @@ function FocusSessionHeader({
   showBarToggle: boolean;
   barOpen: boolean;
   onToggleBar: () => void;
+  showScreenshot: boolean;
+  onCaptureScreenshot: () => void;
 }) {
   // session.task is kept live by the ScopeTaskSync subscriptions above.
   const task = session.task;
@@ -489,6 +548,18 @@ function FocusSessionHeader({
       >
         {statusMeta.label}
       </span>
+      {showScreenshot && (
+        <HotkeyTooltip action="screenshot.capture" label="Screenshot">
+          <Btn
+            variant="ghost"
+            size="sm"
+            icon="camera"
+            onClick={onCaptureScreenshot}
+            aria-label="Capture a screenshot"
+            style={{ width: 30, padding: 0 }}
+          />
+        </HotkeyTooltip>
+      )}
       {isElectron() && (
         <Tooltip content={alwaysOnTop ? "Always on top: on" : "Always on top: off"}>
           <Btn


### PR DESCRIPTION

<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/18cc7a90-b6bf-4ed2-868c-f6e728c59da0" width="350">
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/0fd67a31-e1c6-4538-b8f0-adca333d410b" width="350">
    </td>
  </tr>
</table>

## Summary

Screenshots were dead in focused-session mode: the capture hotkey, camera button, and thumbnail stack all lived in the project route, which is unmounted while the focus window floats. This PR wires the full screenshot flow into focus mode and makes the annotation editor usable in narrow windows.

### Focus mode screenshot capture
- Same capture flow as the project route: the `screenshot.capture` hotkey plus a camera button in the focus header (macOS/Electron-gated, like everywhere else).
- New compact variant of `ScreenshotThumbnail` pinned top-right **inside** the terminal area — it overlays old scrollback instead of the prompt and latest output at the bottom, and always clears the header/session bar regardless of whether the bar is open.
- The terminal wrapper carries `data-task-id`, so drag-to-attach hit-tests the focused session exactly like grid cells and the docked panel. Click-to-edit, annotate, attach, dismiss-to-history all carry over.

### Responsive annotator toolbar
The editor's single-row toolbar needs ~835px; in the focus window (560px default, 320px min) it free-wrapped into ragged centered rows with dividers stretched across them. Replaced with explicit tiers:
- **≤940px** — the four control groups form a deliberate 2×2 grid (tools + history / colors + widths), dividers hidden, close button pinned level with the first row.
- **≤520px** — controls shrink; the footer hint drops and the actions pin right.
- **≤440px** — one centered group per row, close button joins the header flow; verified down to the 320px window minimum with Cancel / Save / Attach on one line.

Also fixes a latent specificity bug this surfaced: the header's `[data-tip]` tooltip rule (specificity 0-2-0) overrode `.mc-annot-close`'s `position: absolute` (0-1-0), so the close button was never actually pinned — it sat in the flex flow and `top: 50%` pushed it toward the bottom toolbar row at every width. Qualifying the selector restores the intended placement.

## Testing
- `pnpm test` — 1639 tests / 181 files pass; `tsc --noEmit` (both tsconfigs) and eslint clean.
- Toolbar tiers verified visually in-browser at 1100 / 560 / 460 / 445 / 320px using the component's actual CSS, with numeric overflow checks per group.