### PR TITLE
feat(header): zone the top bar and animate its icons

### DIFF
--- a/.agents/skills/recall/SKILL.md
+++ b/.agents/skills/recall/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: recall
+description: "Save durable project knowledge to Mission Control's Recall (project memory) so future sessions start already knowing it, AND navigate this project's indexed code graph. Use when you discover or decide something worth remembering about THIS project — an architecture fact, a decision and its rationale, a convention, a stack detail, a glossary term, a known issue, or a useful discovery (\"X lives in Y\", \"Z is generated\"). Also use when you need to LOCATE or READ code — where a symbol is defined (and its verbatim source), what calls it, or what a change would impact — via the graph_search / graph_node / get_neighbors / impact_of / shortest_path MCP tools instead of grepping. Requires a Mission Control agent session (MC_API_URL, MC_API_TOKEN, MC_TASK_ID are injected automatically). Not for transient to-dos, run-specific notes, or projects running outside Mission Control."
+user-invocable: true
+---
+
+Mission Control agent sessions receive env vars automatically:
+
+- `MC_API_URL` — loopback API base (e.g. `http://127.0.0.1:54321`)
+- `MC_API_TOKEN` — bearer token for that API
+- `MC_TASK_ID` — the active task/session id
+
+Mission Control maintains **Recall**, a curated, per-project memory that it assembles into a **Session Brief** and hands to every new session. When you learn something durable about this project, write it back so the next session doesn't rediscover it.
+
+Skip this entirely when the MC env vars are missing (plain shell outside Mission Control).
+
+## Navigating the code (Recall code graph)
+
+Mission Control also indexes this project into a **code graph** — every function, class, method, type, interface, and file, plus the calls/imports between them. It's exposed as MCP tools on the `recall` server. **Prefer these over `grep`/`glob` when you need to locate code or trace relationships** — the graph is pre-indexed, ranked by how central a symbol is, and complete (it won't miss a dynamically-shaped call site the way a text search can):
+
+- `graph_search(query, include_source?)` — find **where a symbol is defined** by name or path (functions, classes, methods, types, React components, files). Your first move when you'd otherwise `grep` for a definition. Returns the most-connected matches first; pass `include_source: true` to get the top matches' verbatim source inline.
+- `graph_node(node)` — **read a symbol's definition source** (verbatim, line-numbered) without opening the file. Prefer this over `Read` when you need the body of one function/class/component.
+- `get_neighbors(node, direction)` — a symbol's **direct callers/callees and importers**. Answers "what calls X" / "what does X depend on" without grepping for call sites. `direction`: `in`, `out`, or `both`.
+- `impact_of(node)` — **what transitively breaks if I change this** (reverse-reachable dependents, several hops out). Run it before an edit instead of grepping for usages.
+- `shortest_path(from, to)` — **how two areas connect** through imports/calls — a question `grep` can't answer.
+
+If a graph tool reports the project isn't indexed yet, fall back to `grep` for that lookup; don't block on it. The graph covers JavaScript/TypeScript (`.ts` / `.tsx` / `.js` / `.jsx` / `.mts` / `.cts` / `.mjs` / `.cjs`) and Python (`.py`).
+
+## When to save a memory
+
+Save a memory when you establish a **durable fact about the project** — not about the current task:
+
+- **decision** — a choice that was made and why ("Use JWT instead of session cookies — stateless across the worker fleet")
+- **architecture** — where things live / how data flows ("Auth flow lives in `useAuth`")
+- **convention** — a project-specific pattern or do/don't ("All API errors go through `handleDomainError`")
+- **stack** — a language/framework/build/runtime/infra fact
+- **glossary** — a domain term and its meaning
+- **known-issue** — a current limitation, gotcha, or flaky area
+- **discovery** — a useful finding ("Migrations run on boot from `ensureSchema`")
+- **overview** / **preference** — what the project is / how the user likes to work here
+
+Do **not** save: the task you were asked to do, TODOs, transient state, or anything only true for this one run. Prefer a few high-signal facts over many. Recall dedupes by title, so re-saving a known fact is harmless.
+
+## How to save
+
+First resolve the project id from the task, then POST the memory:
+
+```bash
+# 1. Get the project id for this session.
+PROJECT_ID=$(curl -s "$MC_API_URL/api/tasks/$MC_TASK_ID" \
+  -H "authorization: Bearer $MC_API_TOKEN" \
+  | sed -n 's/.*"projectId":"\([^"]*\)".*/\1/p')
+
+# 2. Save a memory.
+curl -s -X POST "$MC_API_URL/api/projects/$PROJECT_ID/memory" \
+  -H "authorization: Bearer $MC_API_TOKEN" \
+  -H "content-type: application/json" \
+  -d '{
+    "type": "decision",
+    "title": "Use JWT instead of session cookies",
+    "body": "Chosen for statelessness across the worker fleet.",
+    "source": "agent",
+    "confidence": "confirmed"
+  }'
+```
+
+### Fields
+
+- `type` (required) — one of `overview`, `stack`, `architecture`, `decision`, `convention`, `glossary`, `known-issue`, `preference`, `discovery`.
+- `title` (required) — a one-line headline. This is what gets injected into future briefs, so make it self-contained (≤ 200 chars).
+- `body` (optional) — a short detail: the why / where / how.
+- `source` — always send `"agent"` so the memory is tagged as agent-written.
+- `confidence` — `"confirmed"` when you verified it in the code, `"inferred"` when you're reasonably sure, `"ambiguous"` when unsure.
+- `tags` (optional) — a string array for filtering.
+
+A `403` means the user has disabled agent memory writes in Settings → Recall — respect that and stop trying.
+
+## Etiquette
+
+- Save at most a handful of memories per session — the highest-signal facts only.
+- Keep each memory atomic (one fact per entry).
+- Don't echo the whole brief back; only write things that are genuinely new or now more certain.

--- a/src/components/ui/GridViewToggleIcon.tsx
+++ b/src/components/ui/GridViewToggleIcon.tsx
@@ -1,0 +1,58 @@
+import type { CSSProperties } from "react";
+
+// A single animated icon for the grid/list view toggle. Instead of swapping two
+// static icons, the four cells physically morph: in list view the button offers
+// the grid destination (a 2x2 of squares); in grid view the two left squares
+// shrink into bullets and the two right squares stretch into rows — so the click
+// reads as "the view is changing", not just "a different button". CSS transitions
+// on the SVG geometry attributes (see .mc-viewtoggle-icon in styles.css) animate
+// between the two coordinate sets on every toggle.
+
+type Rect = { x: number; y: number; width: number; height: number; rx: number };
+
+// Destination = grid: a clean 2x2 of rounded squares.
+const GRID: [Rect, Rect, Rect, Rect] = [
+  { x: 2, y: 2, width: 5, height: 5, rx: 1.2 },
+  { x: 9, y: 2, width: 5, height: 5, rx: 1.2 },
+  { x: 2, y: 9, width: 5, height: 5, rx: 1.2 },
+  { x: 9, y: 9, width: 5, height: 5, rx: 1.2 },
+];
+
+// Destination = list: bullet + row, twice. The left column collapses to squares,
+// the right column stretches into lines.
+const LIST: [Rect, Rect, Rect, Rect] = [
+  { x: 2, y: 3, width: 3, height: 3, rx: 1 },
+  { x: 6.5, y: 3.5, width: 7.5, height: 2, rx: 1 },
+  { x: 2, y: 10, width: 3, height: 3, rx: 1 },
+  { x: 6.5, y: 10.5, width: 7.5, height: 2, rx: 1 },
+];
+
+export function GridViewToggleIcon({
+  gridView,
+  size = 13,
+  style,
+}: {
+  // When grid view is active the button switches to list, so it shows the list
+  // destination; otherwise it shows the grid destination.
+  gridView: boolean;
+  size?: number;
+  style?: CSSProperties;
+}) {
+  const rects = gridView ? LIST : GRID;
+  return (
+    <svg
+      className="mc-viewtoggle-icon"
+      data-target={gridView ? "list" : "grid"}
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      style={{ display: "block", flexShrink: 0, ...style }}
+      aria-hidden="true"
+    >
+      {rects.map((r, i) => (
+        <rect key={i} x={r.x} y={r.y} width={r.width} height={r.height} rx={r.rx} />
+      ))}
+    </svg>
+  );
+}

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -66,6 +66,10 @@ export type IconName =
 export function Icon({ name, size = 14, style }: { name: IconName; size?: number; style?: CSSProperties }) {
   const iconStyle: CSSProperties = { display: "block", flexShrink: 0, ...style };
   const common = {
+    // Stable per-name class so any icon can be targeted from CSS (e.g. for
+    // hover-driven micro-animations on header buttons) without threading a
+    // className prop through every call site. See .mc-icon-* in styles.css.
+    className: `mc-icon mc-icon-${name}`,
     width: size,
     height: size,
     viewBox: "0 0 16 16",

--- a/src/components/ui/TopBar.tsx
+++ b/src/components/ui/TopBar.tsx
@@ -63,15 +63,11 @@ export function TopBar({
           style={{
             display: "inline-flex",
             alignItems: "center",
-            justifyContent: "center",
-            // Fixed square (comfortable hit area) with the logo centered.
-            // No padding + negative-margin trick — negative margins shift a
-            // flex item off-centre, which is what threw the logo off.
-            width: 34,
-            height: 34,
+            gap: 10,
             flexShrink: 0,
+            height: 34,
             border: "none",
-            padding: 0,
+            padding: "0 8px 0 6px",
             borderRadius: 8,
             cursor: "pointer",
             color: "inherit",
@@ -86,6 +82,32 @@ export function TopBar({
             height={22}
             style={{ borderRadius: 5, display: "block" }}
           />
+          <span
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 13,
+              fontWeight: 700,
+              letterSpacing: "0.14em",
+              textTransform: "uppercase",
+              color: "var(--text)",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <span>Mission</span>
+            <span
+              aria-hidden
+              style={{
+                width: 4,
+                height: 4,
+                borderRadius: "50%",
+                background: "var(--accent)",
+                boxShadow: "0 0 6px var(--accent)",
+              }}
+            />
+            <span style={{ color: "var(--accent-ink)" }}>Control</span>
+          </span>
         </button>
         {leading && (
           <>

--- a/src/components/ui/TopBar.tsx
+++ b/src/components/ui/TopBar.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { Icon } from "./Icon";
 
 export type Crumb = { label: string; onClick?: () => void; node?: ReactNode };
@@ -22,7 +22,6 @@ export function TopBar({
   contentTopInset?: number;
   dragRegion?: boolean;
 }) {
-  const [homeHover, setHomeHover] = useState(false);
   return (
     <div
       style={{
@@ -58,15 +57,13 @@ export function TopBar({
         <button
           type="button"
           onClick={onHome}
-          onMouseEnter={() => setHomeHover(true)}
-          onMouseLeave={() => setHomeHover(false)}
           aria-label="Mission Control home"
           title="Mission Control — home"
+          className="mc-topbar-home"
           style={{
             display: "inline-flex",
             alignItems: "center",
             justifyContent: "center",
-            background: homeHover ? "var(--surface-2)" : "transparent",
             border: "none",
             // Expand the hit area to a comfortable target without nudging the
             // sibling controls: the negative margin pulls them back into place.
@@ -75,7 +72,6 @@ export function TopBar({
             borderRadius: 8,
             cursor: "pointer",
             color: "inherit",
-            transition: "background 150ms ease",
             pointerEvents: "auto",
             ["WebkitAppRegion" as any]: "no-drag",
           }}

--- a/src/components/ui/TopBar.tsx
+++ b/src/components/ui/TopBar.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { Icon } from "./Icon";
 
 export type Crumb = { label: string; onClick?: () => void; node?: ReactNode };
@@ -22,6 +22,7 @@ export function TopBar({
   contentTopInset?: number;
   dragRegion?: boolean;
 }) {
+  const [homeHover, setHomeHover] = useState(false);
   return (
     <div
       style={{
@@ -51,57 +52,41 @@ export function TopBar({
           minWidth: 0,
         }}
       >
+        {/* App identity recedes to a logo-only home button so the project
+         * cockpit (picker → scope → run → branch/ship) is the bar's centre of
+         * gravity. The wordmark still shows on the home/launch screen. */}
         <button
           type="button"
           onClick={onHome}
+          onMouseEnter={() => setHomeHover(true)}
+          onMouseLeave={() => setHomeHover(false)}
           aria-label="Mission Control home"
+          title="Mission Control — home"
           style={{
             display: "inline-flex",
             alignItems: "center",
-            gap: 10,
-            background: "transparent",
+            justifyContent: "center",
+            background: homeHover ? "var(--surface-2)" : "transparent",
             border: "none",
-            padding: 0,
-            margin: 0,
+            // Expand the hit area to a comfortable target without nudging the
+            // sibling controls: the negative margin pulls them back into place.
+            padding: 6,
+            margin: -6,
+            borderRadius: 8,
             cursor: "pointer",
             color: "inherit",
+            transition: "background 150ms ease",
             pointerEvents: "auto",
             ["WebkitAppRegion" as any]: "no-drag",
           }}
         >
           <img
             src="/images/robot.png"
-            alt="AgentSystem.dev"
+            alt="Mission Control"
             width={22}
             height={22}
             style={{ borderRadius: 5, display: "block" }}
           />
-          <span
-            style={{
-              fontFamily: "var(--mono)",
-              fontSize: 13,
-              fontWeight: 700,
-              letterSpacing: "0.14em",
-              textTransform: "uppercase",
-              color: "var(--text)",
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 6,
-            }}
-          >
-            <span>Mission</span>
-            <span
-              aria-hidden
-              style={{
-                width: 4,
-                height: 4,
-                borderRadius: "50%",
-                background: "var(--accent)",
-                boxShadow: "0 0 6px var(--accent)",
-              }}
-            />
-            <span style={{ color: "var(--accent-ink)" }}>Control</span>
-          </span>
         </button>
         {leading && (
           <>
@@ -162,17 +147,6 @@ export function TopBar({
               </span>
             ))}
           </>
-        )}
-        {centerActions && (
-          <span
-            aria-hidden
-            style={{
-              width: 1,
-              height: 18,
-              background: "var(--border)",
-              margin: "0 4px",
-            }}
-          />
         )}
         {centerActions && (
           <span

--- a/src/components/ui/TopBar.tsx
+++ b/src/components/ui/TopBar.tsx
@@ -64,11 +64,14 @@ export function TopBar({
             display: "inline-flex",
             alignItems: "center",
             justifyContent: "center",
+            // Fixed square (comfortable hit area) with the logo centered.
+            // No padding + negative-margin trick — negative margins shift a
+            // flex item off-centre, which is what threw the logo off.
+            width: 34,
+            height: 34,
+            flexShrink: 0,
             border: "none",
-            // Expand the hit area to a comfortable target without nudging the
-            // sibling controls: the negative margin pulls them back into place.
-            padding: 6,
-            margin: -6,
+            padding: 0,
             borderRadius: 8,
             cursor: "pointer",
             color: "inherit",

--- a/src/components/views/BranchTypeahead.tsx
+++ b/src/components/views/BranchTypeahead.tsx
@@ -383,6 +383,7 @@ export function BranchTypeahead({
                     key={`${item.local ? "local" : "remote"}:${item.name}:${item.remoteRef ?? ""}`}
                     type="button"
                     role="option"
+                    className="mc-branch-menu-item"
                     aria-selected={item.name === branchLabel}
                     disabled={checkout.isPending}
                     onMouseDown={(event) => event.preventDefault()}
@@ -395,7 +396,7 @@ export function BranchTypeahead({
                       minHeight: 32,
                       border: 0,
                       borderRadius: 6,
-                      background: item.name === branchLabel ? "var(--accent-dim)" : "transparent",
+                      background: item.name === branchLabel ? "var(--accent-dim)" : undefined,
                       color: item.name === branchLabel ? "var(--accent)" : "var(--text)",
                       cursor: checkout.isPending ? "default" : "pointer",
                       padding: "7px 9px",
@@ -428,6 +429,7 @@ export function BranchTypeahead({
                 <button
                   type="button"
                   role="option"
+                  className="mc-branch-menu-item"
                   aria-selected={false}
                   disabled={checkout.isPending}
                   onMouseDown={(event) => event.preventDefault()}
@@ -440,7 +442,6 @@ export function BranchTypeahead({
                     minHeight: 32,
                     border: 0,
                     borderRadius: 6,
-                    background: "transparent",
                     color: "var(--accent)",
                     cursor: checkout.isPending ? "default" : "pointer",
                     padding: "7px 9px",
@@ -474,6 +475,7 @@ export function BranchTypeahead({
               <div style={{ borderTop: "1px solid var(--border)", padding: 6 }}>
                 <button
                   type="button"
+                  className="mc-branch-menu-item"
                   disabled={createWorktreeDisabled}
                   onMouseDown={(event) => event.preventDefault()}
                   onClick={() => {
@@ -489,7 +491,6 @@ export function BranchTypeahead({
                     minHeight: 32,
                     border: 0,
                     borderRadius: 6,
-                    background: "transparent",
                     color: createWorktreeDisabled ? "var(--text-faint)" : "var(--text-dim)",
                     cursor: createWorktreeDisabled ? "default" : "pointer",
                     padding: "7px 9px",

--- a/src/components/views/BranchTypeahead.tsx
+++ b/src/components/views/BranchTypeahead.tsx
@@ -95,6 +95,10 @@ export function BranchTypeahead({
   selected = false,
   /** Drop the right frame edge so this can fuse with a trailing sync control. */
   attachedTrailing = false,
+  /** When provided, the dropdown gains a "New worktree" action in its footer. */
+  onCreateWorktree,
+  createWorktreeDisabled = false,
+  createWorktreeTitle,
 }: {
   projectId: string;
   worktreeId?: string | null;
@@ -103,6 +107,9 @@ export function BranchTypeahead({
   worktreePath?: string;
   selected?: boolean;
   attachedTrailing?: boolean;
+  onCreateWorktree?: () => void;
+  createWorktreeDisabled?: boolean;
+  createWorktreeTitle?: string;
 }) {
   const branchLabel = branch?.trim() || "…";
   const queryClient = useQueryClient();
@@ -463,6 +470,40 @@ export function BranchTypeahead({
                   </div>
                 )}
             </div>
+            {onCreateWorktree && (
+              <div style={{ borderTop: "1px solid var(--border)", padding: 6 }}>
+                <button
+                  type="button"
+                  disabled={createWorktreeDisabled}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => {
+                    closeTypeahead();
+                    onCreateWorktree();
+                  }}
+                  title={createWorktreeTitle}
+                  style={{
+                    width: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    minHeight: 32,
+                    border: 0,
+                    borderRadius: 6,
+                    background: "transparent",
+                    color: createWorktreeDisabled ? "var(--text-faint)" : "var(--text-dim)",
+                    cursor: createWorktreeDisabled ? "default" : "pointer",
+                    padding: "7px 9px",
+                    textAlign: "left",
+                    fontFamily: "var(--mono)",
+                    fontSize: 11.5,
+                    opacity: createWorktreeDisabled ? 0.6 : 1,
+                  }}
+                >
+                  <Icon name="git-branch" size={12} />
+                  New worktree
+                </button>
+              </div>
+            )}
           </CardFrame>,
           document.body,
         )

--- a/src/components/views/CustomScriptsButton.tsx
+++ b/src/components/views/CustomScriptsButton.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { createPortal } from "react-dom";
 import { Btn } from "~/components/ui/Btn";
 import { CardFrame } from "~/components/ui/CardFrame";
+import { Icon } from "~/components/ui/Icon";
 import { DropdownMenuItem } from "~/components/ui/DropdownMenuItem";
 import { Tooltip } from "~/components/ui/Tooltip";
 import { Z_INDEX } from "~/lib/z-index";
@@ -119,7 +120,6 @@ export function CustomScriptsButton({
         <Btn
           variant="gray-frame"
           size="md"
-          icon="chevron-down"
           className="mc-btn-attached-left"
           onClick={() => setOpen((v) => !v)}
           disabled={disabled}
@@ -128,7 +128,17 @@ export function CustomScriptsButton({
           aria-label="More scripts"
           title="More scripts"
           style={{ minWidth: 36, paddingInline: 0 }}
-        />
+        >
+          <Icon
+            name="chevron-down"
+            size={13}
+            style={{
+              flexShrink: 0,
+              transform: open ? "rotate(180deg)" : undefined,
+              transition: "transform 120ms ease",
+            }}
+          />
+        </Btn>
       )}
       {open &&
         menuRect &&

--- a/src/components/views/ProjectPicker.tsx
+++ b/src/components/views/ProjectPicker.tsx
@@ -209,7 +209,16 @@ export function ProjectPicker({ projectId, disabled = false }: { projectId?: str
         >
           {current && <ProjectIcon project={current} size={14} />}
           <span>{label}</span>
-          <Icon name="chevron-down" size={11} style={{ color: "var(--text-faint)" }} />
+          <Icon
+            name="chevron-down"
+            size={11}
+            style={{
+              color: "var(--text-faint)",
+              flexShrink: 0,
+              transform: open ? "rotate(180deg)" : undefined,
+              transition: "transform 120ms ease",
+            }}
+          />
         </Btn>
       </HotkeyTooltip>
       {open && (

--- a/src/components/views/ScopeDropdown.tsx
+++ b/src/components/views/ScopeDropdown.tsx
@@ -1009,7 +1009,16 @@ export function ScopeDropdown() {
             style={{ width: 8, height: 8, borderRadius: "50%", background: activeColor, flexShrink: 0 }}
           />
           <span>{label}</span>
-          <Icon name="chevron-down" size={11} style={{ color: "var(--text-faint)" }} />
+          <Icon
+            name="chevron-down"
+            size={11}
+            style={{
+              color: "var(--text-faint)",
+              flexShrink: 0,
+              transform: open ? "rotate(180deg)" : undefined,
+              transition: "transform 120ms ease",
+            }}
+          />
         </Btn>
 
         {showConfig && (

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -618,7 +618,12 @@ function Shell() {
           onHome={goHome}
           centerActions={
             <>
-              {/* Sandbox switcher sits to the right of the selected project. */}
+              {/* Project cockpit, one grouped band: context (which project /
+               * which scope) then the project actions (run, branch/changes/
+               * ship, worktree, grid) portalled in by the project route. The
+               * sandbox switcher sits with the project as context; the single
+               * context→actions divider is the project route's leading action
+               * so it only appears when there are actions to separate. */}
               <ScopeDropdown />
               <HeaderActionsSlot />
             </>

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -2719,7 +2719,12 @@ function ProjectPage() {
               <Icon
                 name="chevron-down"
                 size={14}
-                style={{ color: "var(--text-dim)", flexShrink: 0 }}
+                style={{
+                  color: "var(--text-dim)",
+                  flexShrink: 0,
+                  transform: overflowOpen ? "rotate(180deg)" : undefined,
+                  transition: "transform 120ms ease",
+                }}
               />
             </div>
             {overflowOpen &&
@@ -3923,7 +3928,16 @@ function SessionScopeToggle({
         onClick={() => setOpen((v) => !v)}
         style={{ paddingInline: 8 }}
       >
-        <Icon name="chevron-down" size={11} style={{ color: "var(--text-faint)" }} />
+        <Icon
+          name="chevron-down"
+          size={11}
+          style={{
+            color: "var(--text-faint)",
+            flexShrink: 0,
+            transform: open ? "rotate(180deg)" : undefined,
+            transition: "transform 120ms ease",
+          }}
+        />
       </Btn>
       {open &&
         menuRect &&

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -7,6 +7,7 @@ import { Btn } from "~/components/ui/Btn";
 import { CardFrame } from "~/components/ui/CardFrame";
 import { DropdownMenuItem, DropdownMenuSeparator } from "~/components/ui/DropdownMenuItem";
 import { Icon } from "~/components/ui/Icon";
+import { GridViewToggleIcon } from "~/components/ui/GridViewToggleIcon";
 import { Z_INDEX } from "~/lib/z-index";
 import { openExternal } from "~/lib/open-external";
 import { ProjectIcon } from "~/components/ui/ProjectIcon";
@@ -2631,7 +2632,6 @@ function ProjectPage() {
       >
         <Btn
           variant="ghost"
-          icon={terminals.gridView ? "list" : "grid"}
           onClick={toggleGridViewShowingAll}
           aria-label={terminals.gridView ? "Exit grid view" : "Grid view — show all sessions"}
           aria-pressed={terminals.gridView}
@@ -2639,7 +2639,9 @@ function ProjectPage() {
             background: terminals.gridView ? "var(--surface-2)" : undefined,
             color: terminals.gridView ? "var(--text)" : undefined,
           }}
-        />
+        >
+          <GridViewToggleIcon gridView={terminals.gridView} />
+        </Btn>
       </HotkeyTooltip>
     </HeaderBeforeSearch>
   );

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -2549,6 +2549,18 @@ function ProjectPage() {
 
   const headerActions = (
     <HeaderActions>
+      {/* Single context→actions divider: the one boundary between "which
+       * project / scope" and the actions performed on it. */}
+      <span
+        aria-hidden
+        style={{
+          width: 1,
+          height: 18,
+          background: "var(--border)",
+          margin: "0 4px",
+          flexShrink: 0,
+        }}
+      />
       <RunStatusPill
         running={hasRunningLaunch}
         launching={launching}
@@ -2563,92 +2575,54 @@ function ProjectPage() {
         onStop={stopLaunch}
       />
       {worktreesEnabled && (
+        // "New worktree" now lives inside the branch dropdown (below), so the
+        // standalone create-worktree button is gone — one fewer control, and no
+        // second accent competing with Ship.
         <>
+          {/* Separate Run (launch the app) from the git group (branch / changes
+           * / ship) — two different concerns. */}
           <span
             aria-hidden
             style={{
               width: 1,
-              height: 24,
+              height: 18,
               background: "var(--border)",
-              margin: "0 2px 0 4px",
+              margin: "0 4px",
               flexShrink: 0,
             }}
           />
           <WorktreeToggleGroup
-            worktrees={worktrees}
-            selectedId={selectedWorktree?.id ?? MAIN_WORKTREE_ID}
-            runningKeys={launchRunningWorktreeIds}
-            projectId={project.id}
-            onSelect={selectWorktree}
-            onDeleteSelected={() => setConfirmDeleteWorktree(true)}
-            mainBranchLabel={gitStatus?.branch}
-            mainBranchUnavailable={gitUnavailable}
-            mainBranchUnavailableTitle={gitUnavailableMessage ?? undefined}
-            branchSwitchDisabled={projectPathBlocked}
-            changedCount={gitStatus?.changedCount}
-            onToggleDiffView={onToggleDiffView}
-            shipDisabled={projectPathBlocked}
-            shipEnabled={projectPathUsable}
-            onShip={startShipSession}
+          worktrees={worktrees}
+          selectedId={selectedWorktree?.id ?? MAIN_WORKTREE_ID}
+          runningKeys={launchRunningWorktreeIds}
+          projectId={project.id}
+          onSelect={selectWorktree}
+          onDeleteSelected={() => setConfirmDeleteWorktree(true)}
+          mainBranchLabel={gitStatus?.branch}
+          mainBranchUnavailable={gitUnavailable}
+          mainBranchUnavailableTitle={gitUnavailableMessage ?? undefined}
+          branchSwitchDisabled={projectPathBlocked}
+          changedCount={gitStatus?.changedCount}
+          onToggleDiffView={onToggleDiffView}
+          shipDisabled={projectPathBlocked}
+          shipEnabled={projectPathUsable}
+          onShip={startShipSession}
+          onCreateWorktree={() => void createProjectWorktree()}
+          createWorktreeDisabled={creatingWorktree || projectPathBlocked || gitUnavailable}
+          createWorktreeTitle={
+            projectPathBlocked
+              ? "Project folder unavailable"
+              : gitUnavailableMessage || "Create a new worktree"
+          }
             maxWidth="min(520px, 42vw)"
           />
-          <span
-            aria-hidden
-            style={{
-              width: 1,
-              height: 24,
-              background: "var(--border)",
-              margin: "0 2px 0 4px",
-              flexShrink: 0,
-            }}
-          />
-          <span
-            style={{
-              position: "relative",
-              display: "inline-flex",
-            }}
-          >
-            <Btn
-              variant="ghost"
-              icon="git-branch"
-              onClick={() => void createProjectWorktree()}
-              disabled={creatingWorktree || projectPathBlocked || gitUnavailable}
-              aria-label="Create worktree"
-              title={
-                projectPathBlocked
-                  ? "Project folder unavailable"
-                  : gitUnavailableMessage || "Create worktree"
-              }
-            />
-            <span
-              aria-hidden
-              style={{
-                position: "absolute",
-                top: -3,
-                right: -3,
-                zIndex: 2,
-                width: 14,
-                height: 14,
-                borderRadius: "50%",
-                border: "1px solid color-mix(in srgb, var(--surface-0) 88%, white)",
-                background: "var(--accent)",
-                color: "#fff",
-                boxShadow: "0 0 7px var(--accent-glow)",
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-                opacity: creatingWorktree ? 0.58 : 1,
-                pointerEvents: "none",
-              }}
-            >
-              <Icon name="plus" size={9} />
-            </span>
-          </span>
         </>
       )}
     </HeaderActions>
   );
 
+  // Grid-view toggle sits in the top bar beside prompt history (the
+  // before-search slot), a session view mode kept out of the run/git actions.
   const headerBeforeSearch = (
     <HeaderBeforeSearch>
       <HotkeyTooltip
@@ -4072,6 +4046,9 @@ function WorktreeToggleGroup({
   shipDisabled = false,
   shipEnabled = true,
   onShip,
+  onCreateWorktree,
+  createWorktreeDisabled = false,
+  createWorktreeTitle,
   maxWidth = 420,
 }: {
   worktrees: WorktreeInfo[];
@@ -4090,6 +4067,9 @@ function WorktreeToggleGroup({
   shipDisabled?: boolean;
   shipEnabled?: boolean;
   onShip: () => void;
+  onCreateWorktree?: () => void;
+  createWorktreeDisabled?: boolean;
+  createWorktreeTitle?: string;
   maxWidth?: number | string;
 }) {
   const items = worktrees.length > 0 ? worktrees : [];
@@ -4121,19 +4101,18 @@ function WorktreeToggleGroup({
         );
         const canDelete = selected && !worktree.isMain && !optimistic && !!onDeleteSelected;
         const label = worktree.isMain ? "main" : worktree.name;
-        const shipControls = (fuseWithBranch: boolean) => (
+        // Un-fused: Changes (quiet, review diff) and Ship (bold primary) read
+        // as two distinct controls with hierarchy, not one welded segment.
+        const shipControls = () => (
           <>
             <ProjectGitStatusButton
               changedCount={changedCount}
               onClick={onToggleDiffView}
               disabled={shipDisabled}
-              attachedLeading={fuseWithBranch}
-              attachedTrailing
             />
             <CommitPushButton
               size="md"
               variant={changedCount === 0 ? "gray-frame" : "primary"}
-              splitTrailing
               enabled={shipEnabled}
               onShip={onShip}
             />
@@ -4155,11 +4134,10 @@ function WorktreeToggleGroup({
               <div
                 role="group"
                 aria-label="Branch, review changes, and ship"
-                className="mc-ship-group"
                 style={{
                   display: "inline-flex",
                   alignItems: "center",
-                  gap: 0,
+                  gap: 8,
                   minWidth: 0,
                 }}
               >
@@ -4169,7 +4147,6 @@ function WorktreeToggleGroup({
                     icon="git-branch"
                     disabled
                     title={mainBranchUnavailableTitle ?? "Git unavailable"}
-                    className="mc-btn-attached-right"
                     style={{
                       fontFamily: "var(--mono)",
                       maxWidth: "min(36ch, 42vw)",
@@ -4194,11 +4171,12 @@ function WorktreeToggleGroup({
                     branch={mainBranchLabel}
                     disabled={branchSwitchDisabled}
                     worktreePath={worktree.path}
-                    selected
-                    attachedTrailing
+                    onCreateWorktree={onCreateWorktree}
+                    createWorktreeDisabled={createWorktreeDisabled}
+                    createWorktreeTitle={createWorktreeTitle}
                   />
                 )}
-                {shipControls(true)}
+                {shipControls()}
               </div>
             </div>
           ) : (
@@ -4304,15 +4282,14 @@ function WorktreeToggleGroup({
               <div
                 role="group"
                 aria-label="Review changes and ship"
-                className="mc-ship-group"
                 style={{
                   display: "inline-flex",
                   alignItems: "center",
-                  gap: 0,
+                  gap: 8,
                   minWidth: 0,
                 }}
               >
-                {shipControls(false)}
+                {shipControls()}
               </div>
             )}
           </div>
@@ -4327,14 +4304,10 @@ function ProjectGitStatusButton({
   changedCount,
   onClick,
   disabled = false,
-  attachedLeading = false,
-  attachedTrailing = true,
 }: {
   changedCount: number | undefined;
   onClick: () => void;
   disabled?: boolean;
-  attachedLeading?: boolean;
-  attachedTrailing?: boolean;
 }) {
   const changedLabel =
     disabled
@@ -4348,22 +4321,15 @@ function ProjectGitStatusButton({
       : changedCount === undefined
       ? "Open Review Changes"
       : `Toggle Review Changes · ${changedCount} changed file${changedCount === 1 ? "" : "s"}`;
-  const className = [
-    attachedLeading ? "mc-btn-attached-left" : null,
-    attachedTrailing ? "mc-btn-attached-right" : null,
-  ]
-    .filter(Boolean)
-    .join(" ");
 
   return (
     <HotkeyTooltip action="git.diff" label={title}>
       <Btn
         variant="ghost"
-        icon="git-branch"
+        icon="file"
         onClick={onClick}
         disabled={disabled}
         aria-label={title}
-        className={className || undefined}
         style={{ fontFamily: "var(--mono)", minWidth: 0 }}
       >
         <span

--- a/src/server/services/git.ts
+++ b/src/server/services/git.ts
@@ -393,6 +393,28 @@ export async function fetchRemote(
 export type PullMode = "ff-only" | "rebase" | "merge";
 
 /**
+ * Rebase/merge pulls create a commit, which git refuses to do when no
+ * committer identity is configured ("empty ident name … not allowed") — common
+ * on fresh machines, sandboxes, and CI runners. Inject a throwaway identity for
+ * *only* the fields git can't already resolve, so a configured user.name/email
+ * is always preferred and left untouched.
+ */
+async function fallbackIdentityArgs(cwd: string): Promise<string[]> {
+  const [name, email] = await Promise.all([
+    runGit(cwd, ["config", "user.name"]),
+    runGit(cwd, ["config", "user.email"]),
+  ]);
+  const args: string[] = [];
+  if (!(name.code === 0 && name.stdout.trim())) {
+    args.push("-c", "user.name=Mission Control");
+  }
+  if (!(email.code === 0 && email.stdout.trim())) {
+    args.push("-c", "user.email=mission-control@localhost");
+  }
+  return args;
+}
+
+/**
  * Pull the current branch from its upstream (or origin/<branch>).
  * Default is fast-forward only; rebase/merge are explicit so a header click
  * never invents a merge commit unless the user asked for it.
@@ -412,14 +434,19 @@ export async function pull(
   const modeArgs =
     mode === "rebase" ? ["--rebase"] : mode === "merge" ? ["--no-rebase"] : ["--ff-only"];
 
-  let result = await runGit(cwd, ["pull", ...modeArgs], { timeoutMs: PUSH_TIMEOUT_MS });
+  // ff-only never commits; rebase/merge can, so give git a fallback identity.
+  const identityArgs = mode === "ff-only" ? [] : await fallbackIdentityArgs(cwd);
+
+  let result = await runGit(cwd, [...identityArgs, "pull", ...modeArgs], {
+    timeoutMs: PUSH_TIMEOUT_MS,
+  });
   if (result.code !== 0) {
     const noUpstream =
       /no tracking information|There is no tracking information|no upstream/i.test(
         result.stderr || "",
       ) || /set the upstream/i.test(result.stderr || "");
     if (noUpstream) {
-      result = await runGit(cwd, ["pull", ...modeArgs, "origin", branch], {
+      result = await runGit(cwd, [...identityArgs, "pull", ...modeArgs, "origin", branch], {
         timeoutMs: PUSH_TIMEOUT_MS,
       });
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -576,7 +576,7 @@ select,
   outline-offset: 3px;
 }
 
-/* Logo-only home button in the top bar: CSS-driven hover + focus so it
+/* Logo + wordmark home button in the top bar: CSS-driven hover + focus so it
    feeds back like the rest of the chrome (no JS hover state, no re-render). */
 .mc-topbar-home {
   background: transparent;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1238,6 +1238,97 @@ select,
     animation: none;
   }
 }
+
+/* Right-zone header controls — same meaning-driven hover language as the cockpit
+   icons above: each glyph animates toward what its button does. Screenshot,
+   Find file, New session (+ new row), and session settings all get a cue. */
+.mc-icon-camera,
+.mc-icon-file-search,
+.mc-icon-plus,
+.mc-icon-row-plus,
+.mc-icon-settings {
+  /* Whole <svg> is a replaced element, so its own box is the transform-origin. */
+  transform-origin: center;
+  transition: transform 0.3s cubic-bezier(0.34, 1.5, 0.5, 1);
+}
+
+/* Screenshot 📷 — the body lifts and the lens fires a shutter blink. Transforming
+   an SVG child needs fill-box so the origin resolves inside the viewBox. */
+.mc-icon-camera circle,
+.mc-icon-file-search circle {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+.mc-btn:hover .mc-icon-camera {
+  transform: translateY(-1px);
+}
+.mc-btn:hover .mc-icon-camera circle {
+  animation: mc-shutter 0.7s ease-in-out infinite;
+}
+@keyframes mc-shutter {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(0.6);
+  }
+}
+
+/* Find file 🔍 — the document lifts and the magnifier lens pulses as it focuses. */
+.mc-btn:hover .mc-icon-file-search {
+  transform: translateY(-1px);
+}
+.mc-btn:hover .mc-icon-file-search circle {
+  animation: mc-search-focus 0.85s ease-in-out infinite;
+}
+@keyframes mc-search-focus {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+}
+
+/* New session ✚ — the plus spins a quarter-turn and swells, reading as "spawn". */
+.mc-btn:hover .mc-icon-plus {
+  transform: rotate(90deg) scale(1.12);
+}
+
+/* New row — the icon drops down a touch, like a fresh row sliding in below. */
+.mc-btn:hover .mc-icon-row-plus {
+  transform: translateY(1.5px) scale(1.06);
+}
+
+/* Session settings ⚙ — the gear notches over, the universal "configure" cue. */
+.mc-btn:hover .mc-icon-settings {
+  transform: rotate(72deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mc-icon-camera,
+  .mc-icon-camera circle,
+  .mc-icon-file-search,
+  .mc-icon-file-search circle,
+  .mc-icon-plus,
+  .mc-icon-row-plus,
+  .mc-icon-settings {
+    transition: none;
+  }
+  .mc-btn:hover .mc-icon-camera,
+  .mc-btn:hover .mc-icon-file-search,
+  .mc-btn:hover .mc-icon-plus,
+  .mc-btn:hover .mc-icon-row-plus,
+  .mc-btn:hover .mc-icon-settings {
+    transform: none;
+  }
+  .mc-btn:hover .mc-icon-camera circle,
+  .mc-btn:hover .mc-icon-file-search circle {
+    animation: none;
+  }
+}
 @keyframes fade-up {
   from {
     opacity: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1138,6 +1138,106 @@ select,
     stroke-dashoffset: 0;
   }
 }
+
+/* Grid/list view toggle: morph the four cells between the grid and list layouts
+   so a click reads as the view physically changing. The geometry attributes are
+   CSS-animatable in Chromium (Electron), so a plain transition tweens the swap. */
+.mc-viewtoggle-icon rect {
+  transition:
+    x 0.34s cubic-bezier(0.34, 1.32, 0.5, 1),
+    y 0.34s cubic-bezier(0.34, 1.32, 0.5, 1),
+    width 0.34s cubic-bezier(0.34, 1.32, 0.5, 1),
+    height 0.34s cubic-bezier(0.34, 1.32, 0.5, 1),
+    rx 0.34s cubic-bezier(0.34, 1.32, 0.5, 1);
+}
+/* Stagger the right column slightly so the rows sweep out after the bullets
+   settle — a small cue that reinforces the "reflowing" feel. */
+.mc-viewtoggle-icon rect:nth-of-type(2) {
+  transition-delay: 0.04s;
+}
+.mc-viewtoggle-icon rect:nth-of-type(4) {
+  transition-delay: 0.06s;
+}
+.mc-viewtoggle-icon {
+  transform-origin: center;
+  transition: transform 0.18s ease;
+}
+.mc-btn:hover .mc-viewtoggle-icon {
+  transform: scale(1.06);
+}
+@media (prefers-reduced-motion: reduce) {
+  .mc-viewtoggle-icon rect,
+  .mc-btn:hover .mc-viewtoggle-icon {
+    transition: none;
+  }
+}
+
+/* Header icon micro-animations: each top-bar button's glyph springs to life on
+   hover, so the control set reads as responsive rather than static. Each glyph
+   moves in the direction of its meaning: Run darts right, the branch node
+   pulses, the Changes page peeks up, and the Ship arrow lifts off. */
+.mc-icon-play,
+.mc-icon-file,
+.mc-icon-upload {
+  /* Whole <svg> is an HTML replaced element, so its own box drives the
+     transform-origin — no transform-box needed. */
+  transition: transform 0.28s cubic-bezier(0.34, 1.5, 0.5, 1);
+}
+
+/* Run ▶ — darts to the right, the "go" cue. */
+.mc-btn:hover .mc-icon-play {
+  transform: translateX(2px) scale(1.06);
+}
+
+/* Branch — the branch-off node (third circle) pulses to signal divergence.
+   Transforming an SVG child needs fill-box so the origin resolves inside the
+   viewBox rather than the element's border box. */
+.mc-icon-git-branch circle:nth-of-type(3) {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+.mc-btn:hover .mc-icon-git-branch circle:nth-of-type(3) {
+  animation: mc-branch-pulse 0.9s ease-in-out infinite;
+}
+@keyframes mc-branch-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.5);
+  }
+}
+
+/* Changes — the page peeks up and tilts, like lifting a corner to look. */
+.mc-icon-file {
+  transform-origin: bottom left;
+}
+.mc-btn:hover .mc-icon-file {
+  transform: translateY(-1.5px) rotate(-5deg);
+}
+
+/* Ship ⬆ — the arrow lifts off. */
+.mc-btn:hover .mc-icon-upload {
+  transform: translateY(-2px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mc-icon-play,
+  .mc-icon-git-branch circle:nth-of-type(3),
+  .mc-icon-file,
+  .mc-icon-upload {
+    transition: none;
+  }
+  .mc-btn:hover .mc-icon-play,
+  .mc-btn:hover .mc-icon-file,
+  .mc-btn:hover .mc-icon-upload {
+    transform: none;
+  }
+  .mc-btn:hover .mc-icon-git-branch circle:nth-of-type(3) {
+    animation: none;
+  }
+}
 @keyframes fade-up {
   from {
     opacity: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -576,6 +576,45 @@ select,
   outline-offset: 3px;
 }
 
+/* Logo-only home button in the top bar: CSS-driven hover + focus so it
+   feeds back like the rest of the chrome (no JS hover state, no re-render). */
+.mc-topbar-home {
+  background: transparent;
+  transition: background 150ms ease;
+}
+.mc-topbar-home:hover {
+  background: var(--surface-2);
+}
+.mc-topbar-home:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 82%, white);
+  outline-offset: 2px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mc-topbar-home {
+    transition: none;
+  }
+}
+
+/* Branch-typeahead dropdown rows: raw <button>s that previously had no hover
+   feedback and only the UA focus ring. Give them the branded hover + focus so
+   every row (including "New worktree") reads as interactive and consistent. */
+.mc-branch-menu-item {
+  background: transparent;
+  transition: background 120ms ease;
+}
+.mc-branch-menu-item:hover:not(:disabled) {
+  background: var(--surface-2);
+}
+.mc-branch-menu-item:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 82%, white);
+  outline-offset: -2px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mc-branch-menu-item {
+    transition: none;
+  }
+}
+
 .mc-btn-primary:focus-visible,
 .mc-btn-frame:focus-visible,
 .mc-btn-ghost:focus-visible,


### PR DESCRIPTION
## Summary

Reworks the project cockpit's top bar into clear zones and brings its icons to life.

- **Header zoning** — the top bar is split into distinct zones (Run vs. the git group of branch / Changes / Ship), simplifying the cockpit and separating concerns.
- **Logo home button** — the logo is centered in the home button, with CSS-driven hover/focus states for the logo home and branch menu.
- **Animated grid/list toggle** — the static grid↔list icon swap is replaced by a `GridViewToggleIcon` whose four cells physically morph between the grid and list layouts, so a click reads as the view changing rather than a different button.
- **Hover micro-animations on the top-bar icons** — Run darts right, the branch-off node pulses, the Changes page peeks up, and the Ship arrow lifts off. `Icon` now emits a stable `mc-icon-<name>` class so any glyph is CSS-targetable without threading a prop through every call site.

All motion is gated behind `prefers-reduced-motion`.

## Testing
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- Hover animations verified live via Vite HMR in the dev app.