### PR TITLE
feat: multi-provider usage limits (CodexBar fork) — full catalog, fact-checked

### DIFF
--- a/docs/provider-usage.md
+++ b/docs/provider-usage.md
@@ -1,0 +1,90 @@
+# Provider usage (CodexBar fork)
+
+Mission Control hosts a **TypeScript/Electron port** of CodexBar's multi-provider
+usage-limits capability. The Swift app is the behavioral reference; the runtime
+is Windows + macOS inside this app — not `CodexBar.app`.
+
+## Surface
+
+| Piece | Location |
+| --- | --- |
+| Shared types + full provider catalog | `src/shared/provider-usage.ts` |
+| Pure normalize (Claude / Codex / Cursor + API-key providers) | `src/shared/provider-usage-normalize.ts` |
+| Aggregator + adapters | `src/server/services/provider-usage/` |
+| HTTP | `GET /api/provider-usage?providers=claude,codex,cursor` |
+| Legacy Claude-only | `GET /api/claude-usage-limits` (unchanged) |
+| Compact top-bar control | `ProviderUsageIndicator` (settings-gated) |
+| Settings | Settings → Usage |
+
+## Data model
+
+`ProviderUsageSnapshot` carries `status` (`ok | unauthenticated | rate_limited |
+error`) and `windows[]`. A window has either a real meter
+(`utilization: 0–100` + optional `resetsAt`) **or** is meterless
+(`utilization: null` + `detail: "$12.34"`) for prepaid balances and other
+value-not-percent providers. Adapters never fabricate a 0% bar for unknown
+usage and never report `unavailable` for a merely-unimplemented provider —
+missing credentials are `unauthenticated`, protocol gaps are `error` with an
+explanatory message.
+
+## Adapter tiers
+
+Every CodexBar `UsageProvider` id routes to a live adapter. After the
+fact-check against the CodexBar Swift sources they fall into three tiers:
+
+**Full (real usage windows, fact-checked against CodexBar)** —
+Claude (statusline-tap cache + Anthropic OAuth usage, sonnet/opus model-week
+slot, 401→unauthenticated / 403→error), Codex (`$CODEX_HOME/auth.json` →
+`chatgpt_base_url`-aware wham/usage, CodexRateWindowNormalizer window roles),
+Cursor (state.vscdb JWT with expiry check → usage-summary, full
+CursorStatusProbe plan-percent precedence chain incl. team/enterprise ratios),
+OpenCode Go (local `opencode.db` cost sums vs $12/$30/$60 plan windows),
+Windsurf (local `state.vscdb` `cachedPlanInfo`; daily/weekly are *remaining*
+percents → `100 − remaining`), Copilot (`copilot_internal/user` with Copilot
+editor headers; zero-entitlement snapshots dropped), Kilo (tRPC batch
+`user.getCreditBlocks`; `*_mUsd` micro-USD), Gemini (gemini-cli OAuth creds →
+`retrieveUserQuota`), plus the API-key providers (OpenRouter, DeepSeek,
+Moonshot, ElevenLabs, Poe, Crof, Venice, Kimi K2, Z.ai, Kimi, Synthetic,
+Chutes, Codebuff, CrossModel, LLM Proxy, LiteLLM, ClawRouter, MiniMax, Devin,
+Manus, Perplexity, T3 Chat, MiMo, Qoder, Abacus, Augment, CommandCode,
+Sakana, StepFun, Mistral, Doubao, Factory) with endpoints/fields corrected to
+the CodexBar Swift truth.
+
+**Meterless-but-honest** — providers whose API exposes a value, not a percent:
+balances/spend render as `detail` text (OpenAI org spend, Deepgram project
+balance, Amp displayText, Moonshot/Poe/DeepSeek balances, CrossModel
+micro-USD, Ollama local model count, Wayfinder gateway health, Azure OpenAI
+deployment probe, Groq key check).
+
+**Honest gaps** — CodexBar reaches these through protocols this port
+deliberately does not implement (gRPC-web/protobuf, SigV4 signing, scraped
+console `sec_token`s, private GraphQL schemas, CLI JSON-RPC). With credentials
+present they return `error` naming the gap; without credentials,
+`unauthenticated`: Warp, Grok, Bedrock (unless `CODEXBAR_BEDROCK_API_URL` is
+set), Vertex AI, Kiro, both Alibaba plans, OpenCode (web `/_server` protocol),
+Windsurf web fallback, MiniMax web-cookie path.
+
+## Credentials
+
+Resolution order everywhere: env vars → `~/.codexbar/config.json` (or
+`~/.config/codexbar/config.json`) provider entries → CLI auth files → cookies.
+Bare cookie-token env values are wrapped with the provider's real cookie name
+(e.g. Perplexity's `__Secure-next-auth.session-token`, Kimi's `kimi-auth`) —
+never a guessed `session=`. Windows and macOS file locations are both probed
+(e.g. Cursor/Windsurf `%APPDATA%\…\state.vscdb` vs
+`~/Library/Application Support/…`). No secrets are logged; tests inject fake
+readers/fixtures.
+
+## UI placement
+
+Opt-in master toggle (`providerUsageEnabled`, default off). When on, a single
+compact control appears in the top-bar right cluster: a small utilization ring
+plus the worst window across enabled providers (`codex 91%`). Clicking opens a
+CardFrame popover with per-provider windows (bar + % + reset, or detail text
+for meterless windows), auth help for unauthenticated providers, refresh, and
+a shortcut to Settings → Usage. Disabled ⇒ no chrome at all.
+
+Settings → Usage: searchable provider chip-grid over the full catalog with
+live status dots, a "Needs sign-in" list naming each adapter's expected env
+var / config entry / auth file, and Claude session/weekly window toggles when
+Claude is enabled.

--- a/src/components/views/GeneralSettingsPage.tsx
+++ b/src/components/views/GeneralSettingsPage.tsx
@@ -120,6 +120,8 @@ export function GeneralSettingsPage() {
     claudeUsageLimitsEnabled: settings?.claudeUsageLimitsEnabled ?? false,
     claudeUsageLimitsShowSession: settings?.claudeUsageLimitsShowSession ?? true,
     claudeUsageLimitsShowWeekly: settings?.claudeUsageLimitsShowWeekly ?? true,
+    providerUsageEnabled: settings?.providerUsageEnabled ?? false,
+    providerUsageIds: settings?.providerUsageIds ?? ["claude", "codex", "cursor"],
     recallEnabled: settings?.recallEnabled ?? false,
     recallAutoCaptureEnabled: settings?.recallAutoCaptureEnabled ?? true,
     recallEngineEnabled: settings?.recallEngineEnabled ?? true,

--- a/src/components/views/ProviderUsageIndicator.tsx
+++ b/src/components/views/ProviderUsageIndicator.tsx
@@ -1,0 +1,579 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type {
+  ProviderUsageSnapshot,
+  ProviderUsageWindow,
+} from "~/shared/provider-usage";
+import { DEFAULT_PROVIDER_USAGE_IDS } from "~/shared/provider-usage";
+import { Btn } from "~/components/ui/Btn";
+import { CardFrame } from "~/components/ui/CardFrame";
+import { OPEN_SETTINGS_EVENT } from "~/lib/design-meta";
+import { useProviderUsage, useSettings } from "~/queries";
+
+/**
+ * Compact multi-provider usage control (CodexBar fork).
+ *
+ * Collapsed: one quiet chip — a small utilization ring plus the single worst
+ * window across enabled providers (`codex 91%`). Expanded: a CardFrame popover
+ * with per-provider windows (bar + % + reset), auth help for unauthenticated
+ * providers, refresh, and a shortcut to Settings → Usage. Renders nothing when
+ * the feature is off so the chrome stays uncluttered.
+ */
+export function ProviderUsageIndicator() {
+  const { data: settings } = useSettings();
+  const enabled = settings?.providerUsageEnabled ?? false;
+  const providerIds = settings?.providerUsageIds ?? DEFAULT_PROVIDER_USAGE_IDS;
+  const showSession = settings?.claudeUsageLimitsShowSession ?? true;
+  const showWeekly = settings?.claudeUsageLimitsShowWeekly ?? true;
+  const { data, isLoading, isFetching, refetch } = useProviderUsage(enabled, providerIds);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  const providers = useMemo(() => {
+    if (!data?.providers) return [];
+    return data.providers.map((p) => filterProviderWindows(p, showSession, showWeekly));
+  }, [data, showSession, showWeekly]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+        requestAnimationFrame(() => triggerRef.current?.focus());
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  if (!enabled || providerIds.length === 0) return null;
+
+  const worst = pickWorstWindow(providers);
+  const collapsedLabel = worst
+    ? `${worst.providerName.toLowerCase()} ${worst.pct}%`
+    : collapsedFallbackLabel(providers, isLoading);
+
+  return (
+    <div
+      ref={rootRef}
+      style={{
+        position: "relative",
+        display: "inline-flex",
+        ["WebkitAppRegion" as unknown as string]: "no-drag",
+      }}
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        className="mc-btn mc-btn-ghost mc-btn-md"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label="Provider usage limits"
+        title={buildTooltip(providers)}
+        style={{ paddingInline: 8 }}
+      >
+        <span
+          className="mc-btn-content"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            fontFamily: "var(--mono)",
+            fontSize: 11,
+          }}
+        >
+          <UsageRing pct={worst?.pct ?? null} dim={!worst} />
+          <span
+            style={{
+              fontVariantNumeric: "tabular-nums",
+              whiteSpace: "nowrap",
+              color: worst ? "var(--text)" : "var(--text-dim)",
+            }}
+          >
+            {collapsedLabel}
+          </span>
+        </span>
+      </button>
+
+      {open && (
+        <CardFrame
+          role="dialog"
+          aria-label="Provider usage details"
+          solid
+          style={{
+            position: "absolute",
+            top: "calc(100% + 8px)",
+            right: 0,
+            width: 340,
+            maxWidth: "calc(100vw - 32px)",
+            padding: 10,
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+            boxShadow: "0 16px 36px rgba(0,0,0,0.46)",
+            zIndex: 200,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 8,
+              padding: "2px 2px 4px",
+            }}
+          >
+            <div
+              style={{
+                color: "var(--text)",
+                fontFamily: "var(--mono)",
+                fontSize: 11,
+                fontWeight: 800,
+                letterSpacing: "0.08em",
+                textTransform: "uppercase",
+              }}
+            >
+              Provider usage
+            </div>
+            <div style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+              <span
+                style={{
+                  color: "var(--text-faint)",
+                  fontFamily: "var(--mono)",
+                  fontSize: 10,
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                {providers.length}
+              </span>
+              <Btn
+                type="button"
+                variant="ghost"
+                size="sm"
+                icon="refresh"
+                disabled={isFetching}
+                onClick={() => void refetch()}
+                aria-label="Refresh provider usage"
+                title="Refresh"
+                style={{ width: 26, padding: 0, opacity: isFetching ? 0.5 : 1 }}
+              />
+              <Btn
+                type="button"
+                variant="ghost"
+                size="sm"
+                icon="settings"
+                onClick={() => {
+                  setOpen(false);
+                  window.dispatchEvent(
+                    new CustomEvent(OPEN_SETTINGS_EVENT, { detail: { panel: "usage" } }),
+                  );
+                }}
+                aria-label="Open usage settings"
+                title="Usage settings"
+                style={{ width: 26, padding: 0 }}
+              />
+            </div>
+          </div>
+
+          <div
+            style={{
+              maxHeight: 360,
+              overflowY: "auto",
+              display: "flex",
+              flexDirection: "column",
+              gap: 6,
+              paddingRight: 2,
+            }}
+          >
+            {providers.length === 0 && (
+              <div
+                style={{
+                  padding: "16px 8px",
+                  color: "var(--text-dim)",
+                  fontSize: 12,
+                  textAlign: "center",
+                }}
+              >
+                {isLoading ? "Checking provider limits…" : "No providers enabled."}
+              </div>
+            )}
+            {providers.map((p) => (
+              <ProviderRow key={p.id} snapshot={p} />
+            ))}
+          </div>
+
+          {data && (
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                color: "var(--text-faint)",
+                fontFamily: "var(--mono)",
+                fontSize: 10,
+                padding: "2px 2px 0",
+              }}
+            >
+              <span>{isFetching ? "refreshing…" : `updated ${timeFmt.format(new Date(data.fetchedAt))}`}</span>
+              <span>auto-refresh 45s</span>
+            </div>
+          )}
+        </CardFrame>
+      )}
+    </div>
+  );
+}
+
+/** Small donut showing the worst utilization; empty track when no data. */
+function UsageRing({ pct, dim }: { pct: number | null; dim: boolean }) {
+  const size = 14;
+  const stroke = 2.5;
+  const r = (size - stroke) / 2;
+  const c = 2 * Math.PI * r;
+  const clamped = pct === null ? 0 : Math.max(0, Math.min(100, pct));
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      aria-hidden
+      style={{ flexShrink: 0, transform: "rotate(-90deg)", opacity: dim ? 0.5 : 1 }}
+    >
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={r}
+        fill="none"
+        stroke="var(--border-strong)"
+        strokeWidth={stroke}
+      />
+      {pct !== null && (
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke={usageColor(clamped)}
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={`${(clamped / 100) * c} ${c}`}
+        />
+      )}
+    </svg>
+  );
+}
+
+function filterProviderWindows(
+  snapshot: ProviderUsageSnapshot,
+  showSession: boolean,
+  showWeekly: boolean,
+): ProviderUsageSnapshot {
+  if (snapshot.id !== "claude") return snapshot;
+  return {
+    ...snapshot,
+    windows: snapshot.windows.filter((w) => {
+      if (w.id === "session") return showSession;
+      if (w.id === "weekly" || w.id === "weeklyOpus") return showWeekly;
+      return true;
+    }),
+  };
+}
+
+/** Quiet one-word state when no provider has a renderable window yet. */
+function collapsedFallbackLabel(
+  providers: ProviderUsageSnapshot[],
+  isLoading: boolean,
+): string {
+  if (isLoading || providers.length === 0) return "usage";
+  if (providers.some((p) => p.status === "rate_limited")) return "rate-limited";
+  if (providers.every((p) => p.status === "unauthenticated")) return "sign in";
+  return "usage";
+}
+
+/** The most-consumed window across all providers with usable data. */
+function pickWorstWindow(
+  providers: ProviderUsageSnapshot[],
+): { providerName: string; pct: number } | null {
+  let best: { providerName: string; pct: number } | null = null;
+  for (const p of providers) {
+    if (p.status !== "ok") continue;
+    for (const w of p.windows) {
+      if (w.utilization === null) continue; // meterless (balance) windows
+      const pct = Math.max(0, Math.min(100, Math.round(w.utilization)));
+      if (!best || pct > best.pct) best = { providerName: p.displayName, pct };
+    }
+  }
+  return best;
+}
+
+function ProviderRow({ snapshot }: { snapshot: ProviderUsageSnapshot }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 5,
+        padding: "8px 8px",
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+        background: "rgba(255,255,255,0.03)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          gap: 8,
+        }}
+      >
+        <span style={{ color: "var(--text)", fontSize: 12, fontWeight: 600 }}>
+          {snapshot.displayName}
+        </span>
+        <StatusTag snapshot={snapshot} />
+      </div>
+      {snapshot.windows.map((w) => (
+        <WindowRow key={w.id} window={w} />
+      ))}
+      {snapshot.status === "unauthenticated" && (
+        <div
+          style={{
+            color: "var(--text-faint)",
+            fontSize: 11,
+            lineHeight: 1.4,
+          }}
+          title={snapshot.error}
+        >
+          {authHelp(snapshot)}
+        </div>
+      )}
+      {snapshot.status === "error" && snapshot.error && (
+        <div
+          style={{
+            color: "var(--text-faint)",
+            fontSize: 11,
+            lineHeight: 1.4,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+          title={snapshot.error}
+        >
+          {snapshot.error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusTag({ snapshot }: { snapshot: ProviderUsageSnapshot }) {
+  const { label, color } = statusPresentation(snapshot);
+  if (!label) return null;
+  return (
+    <span
+      style={{
+        color,
+        fontFamily: "var(--mono)",
+        fontSize: 10,
+        whiteSpace: "nowrap",
+        flexShrink: 0,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function statusPresentation(s: ProviderUsageSnapshot): { label: string | null; color: string } {
+  switch (s.status) {
+    case "ok":
+      return { label: null, color: "var(--text-faint)" };
+    case "unauthenticated":
+      return { label: "sign in", color: "var(--text-faint)" };
+    case "rate_limited":
+      return { label: "rate-limited", color: "var(--status-warning)" };
+    case "unavailable":
+      return { label: "unavailable", color: "var(--text-faint)" };
+    case "error":
+      return { label: "error", color: "var(--status-failed)" };
+    default:
+      return { label: s.status, color: "var(--text-faint)" };
+  }
+}
+
+/** Human hint for how to authenticate, derived from the adapter's reason string. */
+function authHelp(s: ProviderUsageSnapshot): string {
+  const reason = s.error?.trim();
+  if (reason) return `No credentials — ${reason}`;
+  return "No credentials found for this provider.";
+}
+
+function WindowRow({ window }: { window: ProviderUsageWindow }) {
+  const reset = formatReset(window.resetsAt);
+  if (window.utilization === null) {
+    // Meterless window (prepaid balance, spend total) — show the value, no bar.
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          fontFamily: "var(--mono)",
+          fontSize: 11,
+        }}
+      >
+        <span
+          style={{
+            color: "var(--text-dim)",
+            width: 52,
+            flexShrink: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+          title={window.label}
+        >
+          {window.label}
+        </span>
+        <span
+          style={{
+            flex: 1,
+            textAlign: "right",
+            color: "var(--text)",
+            fontVariantNumeric: "tabular-nums",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {window.detail ?? "—"}
+        </span>
+        <span
+          style={{
+            color: "var(--text-faint)",
+            width: 64,
+            flexShrink: 0,
+            textAlign: "right",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {reset ? `↻ ${reset}` : ""}
+        </span>
+      </div>
+    );
+  }
+  const pct = Math.max(0, Math.min(100, Math.round(window.utilization)));
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        fontFamily: "var(--mono)",
+        fontSize: 11,
+      }}
+    >
+      <span
+        style={{
+          color: "var(--text-dim)",
+          width: 52,
+          flexShrink: 0,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+        title={window.label}
+      >
+        {window.label}
+      </span>
+      <span
+        aria-hidden
+        style={{
+          position: "relative",
+          flex: 1,
+          height: 5,
+          borderRadius: 3,
+          background: "var(--surface-2)",
+          overflow: "hidden",
+        }}
+      >
+        <span
+          style={{
+            position: "absolute",
+            insetBlock: 0,
+            insetInlineStart: 0,
+            width: `${pct}%`,
+            background: usageColor(pct),
+            borderRadius: 3,
+          }}
+        />
+      </span>
+      <span
+        style={{
+          fontVariantNumeric: "tabular-nums",
+          color: "var(--text)",
+          width: 34,
+          textAlign: "right",
+          flexShrink: 0,
+        }}
+      >
+        {pct}%
+      </span>
+      <span
+        style={{
+          color: "var(--text-faint)",
+          width: 64,
+          flexShrink: 0,
+          textAlign: "right",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {reset ? `↻ ${reset}` : ""}
+      </span>
+    </div>
+  );
+}
+
+function usageColor(pct: number): string {
+  if (pct >= 90) return "var(--status-failed)";
+  if (pct >= 70) return "var(--status-warning)";
+  return "var(--status-done)";
+}
+
+const weekdayFmt = new Intl.DateTimeFormat(undefined, { weekday: "short" });
+const timeFmt = new Intl.DateTimeFormat(undefined, {
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+function formatReset(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return `${weekdayFmt.format(d)} ${timeFmt.format(d)}`;
+}
+
+function buildTooltip(providers: ProviderUsageSnapshot[]): string {
+  if (providers.length === 0) return "Provider usage limits";
+  return providers
+    .map((p) => {
+      if (p.windows.length === 0) {
+        return `${p.displayName}: ${p.status}${p.error ? ` — ${p.error}` : ""}`;
+      }
+      const parts = p.windows.map((w) => {
+        const reset = formatReset(w.resetsAt);
+        const value = w.utilization === null ? (w.detail ?? "—") : `${Math.round(w.utilization)}%`;
+        return `${w.label} ${value}${reset ? ` ↻ ${reset}` : ""}`;
+      });
+      return `${p.displayName}: ${parts.join(" · ")}`;
+    })
+    .join("\n");
+}

--- a/src/components/views/TerminalSettingsPage.tsx
+++ b/src/components/views/TerminalSettingsPage.tsx
@@ -64,6 +64,8 @@ export function TerminalSettingsPage() {
     claudeUsageLimitsEnabled: settings?.claudeUsageLimitsEnabled ?? false,
     claudeUsageLimitsShowSession: settings?.claudeUsageLimitsShowSession ?? true,
     claudeUsageLimitsShowWeekly: settings?.claudeUsageLimitsShowWeekly ?? true,
+    providerUsageEnabled: settings?.providerUsageEnabled ?? false,
+    providerUsageIds: settings?.providerUsageIds ?? ["claude", "codex", "cursor"],
     recallEnabled: settings?.recallEnabled ?? false,
     recallAutoCaptureEnabled: settings?.recallAutoCaptureEnabled ?? true,
     recallEngineEnabled: settings?.recallEngineEnabled ?? true,

--- a/src/components/views/ThemeSettingsPage.tsx
+++ b/src/components/views/ThemeSettingsPage.tsx
@@ -85,6 +85,8 @@ export function ThemeSettingsPage() {
     claudeUsageLimitsEnabled: settings?.claudeUsageLimitsEnabled ?? false,
     claudeUsageLimitsShowSession: settings?.claudeUsageLimitsShowSession ?? true,
     claudeUsageLimitsShowWeekly: settings?.claudeUsageLimitsShowWeekly ?? true,
+    providerUsageEnabled: settings?.providerUsageEnabled ?? false,
+    providerUsageIds: settings?.providerUsageIds ?? ["claude", "codex", "cursor"],
     recallEnabled: settings?.recallEnabled ?? false,
     recallAutoCaptureEnabled: settings?.recallAutoCaptureEnabled ?? true,
     recallEngineEnabled: settings?.recallEngineEnabled ?? true,

--- a/src/components/views/UsageSettingsPage.tsx
+++ b/src/components/views/UsageSettingsPage.tsx
@@ -1,22 +1,69 @@
+import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { Icon } from "~/components/ui/Icon";
 import { SettingsSection, ToggleRow } from "~/components/views/SettingsParts";
 import { api, type AppSettings } from "~/lib/api";
-import { queryKeys, useSettings } from "~/queries";
+import { queryKeys, useProviderUsage, useSettings } from "~/queries";
+import {
+  DEFAULT_PROVIDER_USAGE_IDS,
+  PROVIDER_USAGE_CATALOG,
+  type ProviderUsageId,
+  type ProviderUsageSnapshot,
+} from "~/shared/provider-usage";
 
 type UsagePatch = Partial<
   Pick<
     AppSettings,
-    "claudeUsageLimitsEnabled" | "claudeUsageLimitsShowSession" | "claudeUsageLimitsShowWeekly"
+    | "claudeUsageLimitsEnabled"
+    | "claudeUsageLimitsShowSession"
+    | "claudeUsageLimitsShowWeekly"
+    | "providerUsageEnabled"
+    | "providerUsageIds"
   >
 >;
+
+/** Default agent providers first, then the rest of the catalog alphabetically. */
+const SETTINGS_PROVIDER_ORDER: readonly (typeof PROVIDER_USAGE_CATALOG)[number][] = [
+  ...PROVIDER_USAGE_CATALOG.filter((p) => p.defaultEnabled),
+  ...PROVIDER_USAGE_CATALOG.filter((p) => !p.defaultEnabled).sort((a, b) =>
+    a.displayName.localeCompare(b.displayName),
+  ),
+];
 
 export function UsageSettingsPage() {
   const queryClient = useQueryClient();
   const { data: settings } = useSettings();
-  const claudeEnabled = settings?.claudeUsageLimitsEnabled ?? false;
+  const enabled = settings?.providerUsageEnabled ?? false;
+  const providerIds = settings?.providerUsageIds ?? DEFAULT_PROVIDER_USAGE_IDS;
   const claudeShowSession = settings?.claudeUsageLimitsShowSession ?? true;
   const claudeShowWeekly = settings?.claudeUsageLimitsShowWeekly ?? true;
+  const claudeOn = providerIds.includes("claude");
+  const [query, setQuery] = useState("");
+
+  // Live status shares the indicator's query, so this adds no extra polling.
+  const { data: usage } = useProviderUsage(enabled, providerIds);
+  const statusById = useMemo(() => {
+    const map = new Map<ProviderUsageId, ProviderUsageSnapshot>();
+    for (const p of usage?.providers ?? []) map.set(p.id, p);
+    return map;
+  }, [usage]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return SETTINGS_PROVIDER_ORDER;
+    return SETTINGS_PROVIDER_ORDER.filter(
+      (p) => p.displayName.toLowerCase().includes(q) || p.id.includes(q),
+    );
+  }, [query]);
+
+  const needsAuth = useMemo(
+    () =>
+      providerIds
+        .map((id) => statusById.get(id))
+        .filter((p): p is ProviderUsageSnapshot => !!p && p.status === "unauthenticated"),
+    [providerIds, statusById],
+  );
 
   const update = async (patch: UsagePatch) => {
     await queryClient.cancelQueries({ queryKey: queryKeys.settings });
@@ -33,41 +80,291 @@ export function UsageSettingsPage() {
     }
   };
 
+  const toggleProvider = (id: ProviderUsageId) => {
+    const on = providerIds.includes(id);
+    if (on && providerIds.length === 1) {
+      // The server coerces an empty list back to the defaults, which would
+      // silently re-enable three providers — block the last uncheck instead.
+      toast("At least one provider stays enabled — use the top-bar toggle to hide usage.");
+      return;
+    }
+    const next = on ? providerIds.filter((p) => p !== id) : [...providerIds, id];
+    void update({ providerUsageIds: next });
+  };
+
   return (
     <SettingsSection
       title="Usage"
-      subtitle="Surface your coding-agent usage limits in the top bar. More providers coming soon."
+      subtitle="Multi-provider usage limits in the top bar (CodexBar capability, Windows + macOS). Off by default so the chrome stays quiet."
       headingLevel="h1"
     >
+      <ToggleRow
+        title="Show usage in top bar"
+        description="One compact control — a ring plus the most-consumed window. Click it for per-provider windows and resets."
+        checked={enabled}
+        onChange={(next) => void update({ providerUsageEnabled: next })}
+        label="Show provider usage in top bar"
+      />
+
       <SettingsSection
-        title="Claude Code"
-        subtitle="Session (5h) and weekly usage with reset times. Reads your Claude login to fetch usage from Anthropic — off by default."
+        title="Providers"
+        subtitle="Every provider has a live adapter. Credentials come from env vars, ~/.codexbar/config.json, CLI auth files, or cookies; providers without credentials report “sign in”, never a dead stub."
         headingLevel="h2"
       >
-        <ToggleRow
-          title="Show usage limits in top bar"
-          description="Display Claude Code's rolling 5-hour session and weekly (all models) usage, each with the time it resets."
-          checked={claudeEnabled}
-          onChange={(next) => void update({ claudeUsageLimitsEnabled: next })}
-          label="Show Claude usage limits in top bar"
-        />
-        <ToggleRow
-          title="Session (5h)"
-          description="Show the rolling 5-hour session window."
-          checked={claudeShowSession}
-          disabled={!claudeEnabled}
-          onChange={(next) => void update({ claudeUsageLimitsShowSession: next })}
-          label="Show session usage"
-        />
-        <ToggleRow
-          title="Weekly"
-          description="Show the weekly (all models) window."
-          checked={claudeShowWeekly}
-          disabled={!claudeEnabled}
-          onChange={(next) => void update({ claudeUsageLimitsShowWeekly: next })}
-          label="Show weekly usage"
-        />
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            opacity: enabled ? 1 : 0.6,
+          }}
+        >
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              background: "var(--surface-0)",
+              border: "1px solid var(--border)",
+              borderRadius: 7,
+              padding: "7px 10px",
+            }}
+          >
+            <Icon name="search" size={12} style={{ color: "var(--text-faint)", flexShrink: 0 }} />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter providers…"
+              aria-label="Filter providers"
+              disabled={!enabled}
+              style={{
+                flex: 1,
+                background: "transparent",
+                border: "none",
+                outline: "none",
+                color: "var(--text)",
+                fontFamily: "var(--mono)",
+                fontSize: 12,
+              }}
+            />
+          </div>
+          <span
+            style={{
+              color: "var(--text-faint)",
+              fontFamily: "var(--mono)",
+              fontSize: 10.5,
+              fontVariantNumeric: "tabular-nums",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {providerIds.length} of {PROVIDER_USAGE_CATALOG.length} enabled
+          </span>
+        </div>
+
+        <div
+          role="group"
+          aria-label="Providers to show in the top bar"
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 6,
+            opacity: enabled ? 1 : 0.6,
+          }}
+        >
+          {filtered.map((meta) => {
+            const on = providerIds.includes(meta.id);
+            const snapshot = enabled && on ? statusById.get(meta.id) : undefined;
+            return (
+              <ProviderChip
+                key={meta.id}
+                name={meta.displayName}
+                on={on}
+                disabled={!enabled}
+                snapshot={snapshot}
+                onToggle={() => toggleProvider(meta.id)}
+              />
+            );
+          })}
+          {filtered.length === 0 && (
+            <span style={{ color: "var(--text-dim)", fontSize: 12, padding: "6px 2px" }}>
+              No providers match “{query}”.
+            </span>
+          )}
+        </div>
+
+        {enabled && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 14,
+              color: "var(--text-faint)",
+              fontFamily: "var(--mono)",
+              fontSize: 10.5,
+            }}
+          >
+            <LegendDot color="var(--status-done)" label="ok" />
+            <LegendDot color="var(--text-faint)" label="sign in" />
+            <LegendDot color="var(--status-warning)" label="rate-limited" />
+            <LegendDot color="var(--status-failed)" label="error" />
+          </div>
+        )}
       </SettingsSection>
+
+      {enabled && needsAuth.length > 0 && (
+        <SettingsSection
+          title="Needs sign-in"
+          subtitle="These enabled providers have no usable credentials yet. The hint names the env var, config entry, or auth file each adapter looks for."
+          headingLevel="h2"
+        >
+          {needsAuth.map((p) => (
+            <div
+              key={p.id}
+              style={{
+                display: "flex",
+                alignItems: "baseline",
+                gap: 10,
+                padding: "9px 12px",
+                background: "var(--surface-0)",
+                border: "1px solid var(--border)",
+                borderRadius: 7,
+              }}
+            >
+              <span
+                style={{
+                  color: "var(--text)",
+                  fontSize: 12.5,
+                  fontWeight: 600,
+                  flexShrink: 0,
+                  minWidth: 90,
+                }}
+              >
+                {p.displayName}
+              </span>
+              <span
+                style={{
+                  color: "var(--text-dim)",
+                  fontFamily: "var(--mono)",
+                  fontSize: 11,
+                  lineHeight: 1.5,
+                  wordBreak: "break-word",
+                }}
+              >
+                {p.error ?? "No credentials found."}
+              </span>
+            </div>
+          ))}
+        </SettingsSection>
+      )}
+
+      {claudeOn && (
+        <SettingsSection
+          title="Claude windows"
+          subtitle="Which Claude rate-limit windows appear when Claude is enabled."
+          headingLevel="h2"
+        >
+          <ToggleRow
+            title="Session (5h)"
+            description="Show the rolling 5-hour session window."
+            checked={claudeShowSession}
+            disabled={!enabled}
+            onChange={(next) => void update({ claudeUsageLimitsShowSession: next })}
+            label="Show session usage"
+          />
+          <ToggleRow
+            title="Weekly"
+            description="Show the weekly (all models) window."
+            checked={claudeShowWeekly}
+            disabled={!enabled}
+            onChange={(next) => void update({ claudeUsageLimitsShowWeekly: next })}
+            label="Show weekly usage"
+          />
+        </SettingsSection>
+      )}
     </SettingsSection>
+  );
+}
+
+function ProviderChip({
+  name,
+  on,
+  disabled,
+  snapshot,
+  onToggle,
+}: {
+  name: string;
+  on: boolean;
+  disabled: boolean;
+  snapshot?: ProviderUsageSnapshot;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={on}
+      aria-label={`Show ${name} usage`}
+      disabled={disabled}
+      onClick={onToggle}
+      title={snapshot?.error ? `${name}: ${snapshot.error}` : name}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        padding: "5px 10px",
+        borderRadius: 999,
+        border: `1px solid ${on ? "var(--accent-border)" : "var(--border)"}`,
+        background: on ? "var(--accent-faint)" : "var(--surface-0)",
+        color: on ? "var(--text)" : "var(--text-dim)",
+        fontFamily: "var(--mono)",
+        fontSize: 11.5,
+        lineHeight: 1,
+        cursor: disabled ? "default" : "pointer",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {snapshot && (
+        <span
+          aria-hidden
+          title={snapshot.status}
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: "50%",
+            flexShrink: 0,
+            background: statusDotColor(snapshot),
+          }}
+        />
+      )}
+      {name}
+      {on && <Icon name="check" size={10} style={{ color: "var(--accent-ink)", flexShrink: 0 }} />}
+    </button>
+  );
+}
+
+function statusDotColor(s: ProviderUsageSnapshot): string {
+  switch (s.status) {
+    case "ok":
+      return "var(--status-done)";
+    case "rate_limited":
+      return "var(--status-warning)";
+    case "error":
+      return "var(--status-failed)";
+    default:
+      return "var(--text-faint)";
+  }
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+      <span
+        aria-hidden
+        style={{ width: 6, height: 6, borderRadius: "50%", background: color }}
+      />
+      {label}
+    </span>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -19,6 +19,7 @@ import type { Binding, BindingMap, HotkeyAction } from "~/lib/keybindings/types"
 import type { AccentColorId } from "~/lib/accent-colors";
 import type { UsageSummary } from "~/shared/token-usage";
 import type { ClaudeUsageLimits } from "~/shared/claude-usage-limits";
+import type { ProviderUsageId, ProviderUsageResponse } from "~/shared/provider-usage";
 import type { PendingQuestion } from "~/shared/agent-questions";
 import type { PromptSearchResponse } from "~/shared/prompts";
 import type { WorktreeInfo } from "~/shared/worktrees";
@@ -135,10 +136,17 @@ export type AppSettings = {
    * Show Claude Code's live session (5h) + weekly usage limits in the top bar.
    * Off by default — enabling it makes the app fetch usage from Anthropic using
    * the user's Claude login. The two `show*` flags toggle each window.
+   * Kept for backward compatibility; multi-provider uses `providerUsage*`.
    */
   claudeUsageLimitsEnabled: boolean;
   claudeUsageLimitsShowSession: boolean;
   claudeUsageLimitsShowWeekly: boolean;
+  /**
+   * Multi-provider usage (CodexBar fork): master toggle + which providers appear
+   * in the compact top-bar control. Off by default so the chrome stays quiet.
+   */
+  providerUsageEnabled: boolean;
+  providerUsageIds: ProviderUsageId[];
   /**
    * Recall (project memory) controls. `recallEnabled` is the experimental
    * master switch — it ships off by default (opt in from Settings). When off
@@ -611,6 +619,8 @@ export const api = {
         | "claudeUsageLimitsEnabled"
         | "claudeUsageLimitsShowSession"
         | "claudeUsageLimitsShowWeekly"
+        | "providerUsageEnabled"
+        | "providerUsageIds"
         | "recallEnabled"
         | "recallAutoCaptureEnabled"
         | "recallEngineEnabled"
@@ -718,6 +728,13 @@ export const api = {
     req<UsageSummary>(`/api/usage?days=${days}`),
   getClaudeUsageLimits: () =>
     req<ClaudeUsageLimits>("/api/claude-usage-limits"),
+  getProviderUsage: (providerIds?: readonly string[]) => {
+    const q =
+      providerIds && providerIds.length > 0
+        ? `?providers=${encodeURIComponent(providerIds.join(","))}`
+        : "";
+    return req<ProviderUsageResponse>(`/api/provider-usage${q}`);
+  },
   searchPrompts: (query: string, limit?: number) =>
     req<PromptSearchResponse>(
       `/api/prompts?q=${encodeURIComponent(query)}${limit ? `&limit=${limit}` : ""}`,

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -45,6 +45,7 @@ export const queryKeys = {
     ] as const,
   usage: (days: number) => ["usage", days] as const,
   claudeUsageLimits: ["claude-usage-limits"] as const,
+  providerUsage: (idsKey: string) => ["provider-usage", idsKey] as const,
   promptSearch: (query: string) => ["prompt-search", query] as const,
   projectMemory: (projectId: string) => ["projects", projectId, "memory"] as const,
   archivedMemory: (projectId: string) => ["projects", projectId, "memory", "archived"] as const,
@@ -234,6 +235,23 @@ export const claudeUsageLimitsQueryOptions = (enabled: boolean) =>
     refetchInterval: enabled ? CLAUDE_USAGE_LIMITS_REFETCH_MS : false,
   });
 
+const PROVIDER_USAGE_STALE_MS = 20_000;
+const PROVIDER_USAGE_REFETCH_MS = 45_000;
+
+export const providerUsageQueryOptions = (
+  enabled: boolean,
+  providerIds: readonly string[],
+) => {
+  const idsKey = providerIds.join(",");
+  return queryOptions({
+    queryKey: queryKeys.providerUsage(idsKey),
+    queryFn: async () => api.getProviderUsage(providerIds),
+    enabled: enabled && providerIds.length > 0,
+    staleTime: PROVIDER_USAGE_STALE_MS,
+    refetchInterval: enabled ? PROVIDER_USAGE_REFETCH_MS : false,
+  });
+};
+
 const PROMPT_SEARCH_STALE_MS = 5_000;
 
 // `enabled` is caller-controlled so the query only runs while the palette is
@@ -274,5 +292,7 @@ export const useUsage = (days: number = DEFAULT_USAGE_DAYS) =>
   useQuery(usageQueryOptions(days));
 export const useClaudeUsageLimits = (enabled: boolean) =>
   useQuery(claudeUsageLimitsQueryOptions(enabled));
+export const useProviderUsage = (enabled: boolean, providerIds: readonly string[]) =>
+  useQuery(providerUsageQueryOptions(enabled, providerIds));
 export const usePromptSearch = (query: string, enabled: boolean) =>
   useQuery(promptSearchQueryOptions(query, enabled));

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -40,7 +40,7 @@ import { apiTokenQueryOptions, useSettings, useScopedProjects, useSandboxes } fr
 import { SandboxResumingOverlay } from "~/components/views/SandboxResumingOverlay";
 import { ScopeDropdown } from "~/components/views/ScopeDropdown";
 import { UpdateAvailableButton } from "~/components/ui/UpdateAvailableButton";
-import { ClaudeUsageLimitsIndicator } from "~/components/views/ClaudeUsageLimitsIndicator";
+import { ProviderUsageIndicator } from "~/components/views/ProviderUsageIndicator";
 import {
   ACCENT_CACHE_KEY,
   ACCENT_COLORS,
@@ -632,7 +632,7 @@ function Shell() {
           dragRegion
           right={
             <>
-              <ClaudeUsageLimitsIndicator />
+              <ProviderUsageIndicator />
               <UpdateAvailableButton />
               <HeaderBeforeSearchSlot />
               <PromptSearchButton />

--- a/src/server/__tests__/provider-usage-api.test.ts
+++ b/src/server/__tests__/provider-usage-api.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mc-provider-usage-api-"));
+process.env.MC_USER_DATA_DIR = tmpRoot;
+
+const { handleApiRequest } = await import("../api-router");
+const { getOrCreateApiToken } = await import("../services/settings");
+const {
+  _setTokenReaderForTests,
+  _resetClaudeUsageLimitsCache,
+  _setSharedLimitsFileForTests,
+} = await import("../services/claude-usage-limits");
+const {
+  _resetCodexUsageCache,
+  _resetCursorUsageCache,
+  _setCodexCredsReaderForTests,
+  _setCursorSessionReaderForTests,
+} = await import("../services/provider-usage");
+
+function authedRequest(input: string): Request {
+  return new Request(input, {
+    headers: { authorization: `Bearer ${getOrCreateApiToken()}` },
+  });
+}
+
+describe("GET /api/provider-usage", () => {
+  beforeEach(() => {
+    _resetClaudeUsageLimitsCache();
+    _resetCodexUsageCache();
+    _resetCursorUsageCache();
+    _setSharedLimitsFileForTests(path.join(tmpRoot, "limits.json"));
+    fs.rmSync(path.join(tmpRoot, "limits.json"), { force: true });
+    _setTokenReaderForTests(() => null);
+    _setCodexCredsReaderForTests(() => null);
+    _setCursorSessionReaderForTests(() => null);
+  });
+
+  afterEach(() => {
+    _setTokenReaderForTests(null);
+    _setCodexCredsReaderForTests(null);
+    _setCursorSessionReaderForTests(null);
+    _setSharedLimitsFileForTests(null);
+    _resetClaudeUsageLimitsCache();
+    _resetCodexUsageCache();
+    _resetCursorUsageCache();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns structured multi-provider payload (not Claude-only legacy shape)", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+
+    const response = await handleApiRequest(
+      authedRequest("http://localhost/api/provider-usage?providers=claude,codex,cursor"),
+    );
+    expect(response?.status).toBe(200);
+    const body = await response!.json();
+    expect(body).toMatchObject({
+      providers: expect.any(Array),
+      fetchedAt: expect.any(Number),
+    });
+    expect(body.providers).toHaveLength(3);
+    for (const p of body.providers) {
+      expect(p).toMatchObject({
+        id: expect.any(String),
+        displayName: expect.any(String),
+        status: expect.stringMatching(/^(ok|unauthenticated|rate_limited|error|unavailable)$/),
+        windows: expect.any(Array),
+        fetchedAt: expect.any(Number),
+      });
+    }
+    // Explicit multi-provider shape — not a flat Claude-only object.
+    expect(body.session).toBeUndefined();
+    expect(body.weekly).toBeUndefined();
+  });
+
+  it("maps successful Claude + Codex fetch through the real API entry", async () => {
+    _setTokenReaderForTests(() => "test-token");
+    _setCodexCredsReaderForTests(() => ({ accessToken: "codex-tok", accountId: null }));
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (String(url).includes("anthropic.com")) {
+          return new Response(
+            JSON.stringify({
+              five_hour: { utilization: 11, resets_at: "2026-07-10T06:49:00Z" },
+              seven_day: { utilization: 22, resets_at: "2026-07-13T15:59:00Z" },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (String(url).includes("wham/usage")) {
+          return new Response(
+            JSON.stringify({
+              rate_limit: {
+                primary_window: {
+                  used_percent: 33,
+                  reset_at: 1_720_000_000,
+                  limit_window_seconds: 18_000,
+                },
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("", { status: 404 });
+      }),
+    );
+
+    const response = await handleApiRequest(
+      authedRequest("http://localhost/api/provider-usage?providers=claude,codex"),
+    );
+    expect(response?.status).toBe(200);
+    const body = await response!.json();
+    const claude = body.providers.find((p: { id: string }) => p.id === "claude");
+    const codex = body.providers.find((p: { id: string }) => p.id === "codex");
+    expect(claude.status).toBe("ok");
+    expect(claude.windows.some((w: { utilization: number }) => w.utilization === 11)).toBe(true);
+    expect(codex.status).toBe("ok");
+    expect(codex.windows.some((w: { utilization: number }) => w.utilization === 33)).toBe(true);
+  });
+});

--- a/src/server/__tests__/settings-api.test.ts
+++ b/src/server/__tests__/settings-api.test.ts
@@ -75,6 +75,8 @@ describe("settings API", () => {
       claudeUsageLimitsEnabled: false,
       claudeUsageLimitsShowSession: true,
       claudeUsageLimitsShowWeekly: true,
+      providerUsageEnabled: false,
+      providerUsageIds: ["claude", "codex", "cursor"],
     });
   });
 
@@ -98,6 +100,29 @@ describe("settings API", () => {
       claudeUsageLimitsEnabled: true,
       claudeUsageLimitsShowSession: true,
       claudeUsageLimitsShowWeekly: false,
+    });
+  });
+
+  it("persists multi-provider usage toggles", async () => {
+    const update = await handleApiRequest(
+      authedRequest("http://localhost/api/settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          providerUsageEnabled: true,
+          providerUsageIds: ["claude", "codex"],
+        }),
+      }),
+    );
+    expect(update?.status).toBe(200);
+
+    const read = await handleApiRequest(
+      authedRequest("http://localhost/api/settings"),
+    );
+    expect(await jsonBody(read!)).toMatchObject({
+      providerUsageEnabled: true,
+      providerUsageIds: ["claude", "codex"],
+      claudeUsageLimitsEnabled: true,
     });
   });
 

--- a/src/server/api-router.ts
+++ b/src/server/api-router.ts
@@ -25,6 +25,7 @@ import * as projectMemoryController from "./controllers/project-memory.controlle
 import * as codeGraphController from "./controllers/code-graph.controller";
 import * as usageController from "./controllers/usage.controller";
 import * as claudeUsageLimitsController from "./controllers/claude-usage-limits.controller";
+import * as providerUsageController from "./controllers/provider-usage.controller";
 import * as eventsController from "./controllers/events.controller";
 import * as gitController from "./controllers/git.controller";
 import * as commitCliController from "./controllers/commit-cli.controller";
@@ -449,6 +450,9 @@ async function dispatch(
   if (pathname === "/api/usage" && method === "GET") return usageController.read(url);
   if (pathname === "/api/claude-usage-limits" && method === "GET") {
     return claudeUsageLimitsController.read();
+  }
+  if (pathname === "/api/provider-usage" && method === "GET") {
+    return providerUsageController.read(url);
   }
   if (pathname === "/api/events/ticket" && method === "POST") {
     return eventsController.issueTicket();

--- a/src/server/controllers/provider-usage.controller.ts
+++ b/src/server/controllers/provider-usage.controller.ts
@@ -1,0 +1,17 @@
+import { getProviderUsage } from "../services/provider-usage";
+import { json } from "./_helpers";
+
+/**
+ * GET /api/provider-usage — multi-provider usage limits (CodexBar fork).
+ * Optional `?providers=claude,codex,cursor` filters which adapters run.
+ */
+export async function read(url: URL): Promise<Response> {
+  const raw = url.searchParams.get("providers");
+  const ids = raw
+    ? raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : null;
+  return json(await getProviderUsage(ids));
+}

--- a/src/server/controllers/settings.controller.ts
+++ b/src/server/controllers/settings.controller.ts
@@ -46,6 +46,11 @@ import {
   type SurfaceTint,
 } from "~/shared/surface-tint";
 import {
+  DEFAULT_PROVIDER_USAGE_IDS,
+  normalizeProviderUsageIds,
+  type ProviderUsageId,
+} from "~/shared/provider-usage";
+import {
   DEFAULT_TERMINAL_ZOOM_LEVEL,
   TERMINAL_ZOOM_MAX,
   TERMINAL_ZOOM_MIN,
@@ -85,6 +90,8 @@ const VOICE_COMMAND_ALIASES_KEY = "voice_command_aliases";
 const CLAUDE_USAGE_LIMITS_ENABLED_KEY = "claude_usage_limits_enabled";
 const CLAUDE_USAGE_LIMITS_SHOW_SESSION_KEY = "claude_usage_limits_show_session";
 const CLAUDE_USAGE_LIMITS_SHOW_WEEKLY_KEY = "claude_usage_limits_show_weekly";
+const PROVIDER_USAGE_ENABLED_KEY = "provider_usage_enabled";
+const PROVIDER_USAGE_IDS_KEY = "provider_usage_ids";
 
 const voiceCommandAliasesBody = z.unknown().transform((value, ctx): VoiceCommandAliases => {
   try {
@@ -161,6 +168,8 @@ const updateSettingsBody = z
     claudeUsageLimitsEnabled: z.boolean(),
     claudeUsageLimitsShowSession: z.boolean(),
     claudeUsageLimitsShowWeekly: z.boolean(),
+    providerUsageEnabled: z.boolean(),
+    providerUsageIds: z.array(z.string()).transform((value) => normalizeProviderUsageIds(value)),
     recallEnabled: z.boolean(),
     recallAutoCaptureEnabled: z.boolean(),
     recallEngineEnabled: z.boolean(),
@@ -323,13 +332,37 @@ function settingsPayload() {
     shipModel: getShipModelSetting(),
     shipPrompt: getShipPromptSetting(),
     voiceCommandAliases: getVoiceCommandAliasesSetting(),
-    // Off by default: this is the only feature that reaches out to Anthropic
-    // (using the user's Claude login), so it's strictly opt-in.
+    // Off by default: usage reaches out to provider APIs using local logins.
     claudeUsageLimitsEnabled: getBooleanSetting(CLAUDE_USAGE_LIMITS_ENABLED_KEY, false),
     claudeUsageLimitsShowSession: getBooleanSetting(CLAUDE_USAGE_LIMITS_SHOW_SESSION_KEY, true),
     claudeUsageLimitsShowWeekly: getBooleanSetting(CLAUDE_USAGE_LIMITS_SHOW_WEEKLY_KEY, true),
+    // Multi-provider (CodexBar fork). If unset, fall back to legacy Claude-only toggle
+    // so existing users who already enabled Claude usage keep their indicator.
+    providerUsageEnabled: getProviderUsageEnabledSetting(),
+    providerUsageIds: getProviderUsageIdsSetting(),
     ...recallSettingsPayload(),
   };
+}
+
+function getProviderUsageEnabledSetting(): boolean {
+  const raw = getSetting(PROVIDER_USAGE_ENABLED_KEY);
+  if (raw !== null) return raw === "true" || raw === "1";
+  // Legacy: Claude-only toggle stood in for the master switch.
+  return getBooleanSetting(CLAUDE_USAGE_LIMITS_ENABLED_KEY, false);
+}
+
+function getProviderUsageIdsSetting(): ProviderUsageId[] {
+  const raw = getSetting(PROVIDER_USAGE_IDS_KEY);
+  if (raw === null) {
+    // If only Claude was enabled historically, keep Claude as the sole provider.
+    if (getBooleanSetting(CLAUDE_USAGE_LIMITS_ENABLED_KEY, false)) return ["claude"];
+    return [...DEFAULT_PROVIDER_USAGE_IDS];
+  }
+  try {
+    return normalizeProviderUsageIds(JSON.parse(raw));
+  } catch {
+    return [...DEFAULT_PROVIDER_USAGE_IDS];
+  }
 }
 
 function recallSettingsPayload() {
@@ -501,6 +534,19 @@ export async function update(request: Request): Promise<Response> {
   }
   if (body.claudeUsageLimitsShowWeekly !== undefined) {
     setBooleanSetting(CLAUDE_USAGE_LIMITS_SHOW_WEEKLY_KEY, body.claudeUsageLimitsShowWeekly);
+  }
+  if (body.providerUsageEnabled !== undefined) {
+    setBooleanSetting(PROVIDER_USAGE_ENABLED_KEY, body.providerUsageEnabled);
+    // Keep Claude legacy flag aligned when Claude is among enabled providers.
+    const ids =
+      body.providerUsageIds ??
+      getProviderUsageIdsSetting();
+    if (ids.includes("claude")) {
+      setBooleanSetting(CLAUDE_USAGE_LIMITS_ENABLED_KEY, body.providerUsageEnabled);
+    }
+  }
+  if (body.providerUsageIds !== undefined) {
+    setSetting(PROVIDER_USAGE_IDS_KEY, JSON.stringify(body.providerUsageIds));
   }
   writeRecallSettings({
     enabled: body.recallEnabled,

--- a/src/server/services/__tests__/provider-usage-smoke.test.ts
+++ b/src/server/services/__tests__/provider-usage-smoke.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getProviderUsage } from "../provider-usage";
+import { readCodexOAuthCredentials } from "../provider-usage/codex-usage";
+import { readCursorAppSession } from "../provider-usage/cursor-usage";
+import { readClaudeOAuthToken } from "../claude-usage-limits";
+
+/**
+ * Live smoke against local credentials when present. Writes evidence when
+ * SCRATCH (or default implementer scratch) is set. Does not fail the suite
+ * if providers are unauthenticated — that is a valid host outcome.
+ */
+describe("provider-usage live smoke", () => {
+  it("returns multi-provider payload on this host", async () => {
+    const scratch =
+      process.env.SCRATCH ||
+      path.join(
+        process.env.LOCALAPPDATA || process.env.TMP || ".",
+        "Temp",
+        "grok-goal-fbb5878009d5",
+        "implementer",
+      );
+    fs.mkdirSync(scratch, { recursive: true });
+    const log: string[] = [];
+    const line = (s: string) => log.push(s);
+    line("=== provider-usage smoke (Windows host) ===");
+    line("platform: " + process.platform);
+    line("claude token present: " + Boolean(readClaudeOAuthToken()));
+    line("codex creds present: " + Boolean(readCodexOAuthCredentials()));
+    line("cursor session present: " + Boolean(readCursorAppSession()));
+    const result = await getProviderUsage(["claude", "codex", "cursor", "openrouter"]);
+    fs.writeFileSync(path.join(scratch, "provider-usage-api.json"), JSON.stringify(result, null, 2));
+    line("wrote provider-usage-api.json");
+    for (const p of result.providers) {
+      line(
+        p.id +
+          ": status=" +
+          p.status +
+          " windows=" +
+          p.windows.length +
+          (p.error ? " error=" + p.error : ""),
+      );
+      for (const w of p.windows) {
+        line(
+          "  - " +
+            w.id +
+            " " +
+            (w.utilization === null ? (w.detail ?? "—") : Math.round(w.utilization) + "%") +
+            (w.resetsAt ? " resets=" + w.resetsAt : ""),
+        );
+      }
+    }
+    expect(Array.isArray(result.providers)).toBe(true);
+    expect(result.providers.length).toBeGreaterThanOrEqual(3);
+    expect(result.providers.every((p) => typeof p.status === "string")).toBe(true);
+    // not Claude-only legacy flat shape
+    expect((result as { session?: unknown }).session).toBeUndefined();
+    fs.writeFileSync(path.join(scratch, "provider-usage-smoke.log"), log.join("\n") + "\n");
+    console.log(log.join("\n"));
+  }, 60_000);
+});

--- a/src/server/services/__tests__/provider-usage.test.ts
+++ b/src/server/services/__tests__/provider-usage.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getProviderUsage,
+  _resetCodexUsageCache,
+  _resetCursorUsageCache,
+  _setCodexCredsReaderForTests,
+  _setCursorSessionReaderForTests,
+} from "../provider-usage";
+import {
+  _resetClaudeUsageLimitsCache,
+  _setSharedLimitsFileForTests,
+  _setTokenReaderForTests,
+} from "../claude-usage-limits";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("getProviderUsage aggregator", () => {
+  let tmpDir: string;
+  let sharedFile: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mc-provider-usage-"));
+    sharedFile = path.join(tmpDir, "limits.json");
+    _resetClaudeUsageLimitsCache();
+    _resetCodexUsageCache();
+    _resetCursorUsageCache();
+    _setSharedLimitsFileForTests(sharedFile);
+    _setTokenReaderForTests(() => null);
+    _setCodexCredsReaderForTests(() => null);
+    _setCursorSessionReaderForTests(() => null);
+  });
+
+  afterEach(() => {
+    _setTokenReaderForTests(null);
+    _setCodexCredsReaderForTests(null);
+    _setCursorSessionReaderForTests(null);
+    _setSharedLimitsFileForTests(null);
+    _resetClaudeUsageLimitsCache();
+    _resetCodexUsageCache();
+    _resetCursorUsageCache();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns multi-provider payload with status per provider (no network when unauthenticated)", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getProviderUsage(["claude", "codex", "cursor"]);
+    expect(result.providers).toHaveLength(3);
+    expect(result.providers.map((p) => p.id)).toEqual(["claude", "codex", "cursor"]);
+    for (const p of result.providers) {
+      expect(p.status).toBe("unauthenticated");
+      expect(p.windows).toEqual([]);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(typeof result.fetchedAt).toBe("number");
+  });
+
+  it("aggregates live normalize paths for Claude + Codex fixtures", async () => {
+    _setTokenReaderForTests(() => "claude-token");
+    _setCodexCredsReaderForTests(() => ({ accessToken: "codex-token", accountId: "acc-1" }));
+    _setCursorSessionReaderForTests(() => null);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (String(url).includes("anthropic.com")) {
+          return jsonResponse({
+            five_hour: { utilization: 48, resets_at: "2026-07-10T06:49:00Z" },
+            seven_day: { utilization: 36, resets_at: "2026-07-13T15:59:00Z" },
+          });
+        }
+        if (String(url).includes("wham/usage")) {
+          return jsonResponse({
+            rate_limit: {
+              primary_window: {
+                used_percent: 22,
+                reset_at: 1_720_000_000,
+                limit_window_seconds: 18_000,
+              },
+              secondary_window: {
+                used_percent: 8,
+                reset_at: 1_720_500_000,
+                limit_window_seconds: 604_800,
+              },
+            },
+          });
+        }
+        return new Response("", { status: 404 });
+      }),
+    );
+
+    const result = await getProviderUsage(["claude", "codex", "cursor"]);
+    const claude = result.providers.find((p) => p.id === "claude")!;
+    const codex = result.providers.find((p) => p.id === "codex")!;
+    const cursor = result.providers.find((p) => p.id === "cursor")!;
+
+    expect(claude.status).toBe("ok");
+    expect(claude.windows.find((w) => w.id === "session")?.utilization).toBe(48);
+    expect(codex.status).toBe("ok");
+    expect(codex.windows.find((w) => w.id === "session")?.utilization).toBe(22);
+    expect(cursor.status).toBe("unauthenticated");
+  });
+
+  it("marks token/oauth providers unauthenticated without credentials (no network)", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    // Clear ambient env keys and force empty CodexBar config so adapters skip HTTP.
+    const cleared = [
+      "OPENROUTER_API_KEY",
+      "OPENAI_API_KEY",
+      "OPENAI_ADMIN_KEY",
+      "DEEPSEEK_API_KEY",
+      "POE_API_KEY",
+      "ELEVENLABS_API_KEY",
+      "XI_API_KEY",
+    ] as const;
+    const prev: Record<string, string | undefined> = {};
+    for (const k of cleared) {
+      prev[k] = process.env[k];
+      delete process.env[k];
+    }
+    const creds = await import("../provider-usage/credentials");
+    creds._resetCodexBarConfigCache();
+    const loadSpy = vi.spyOn(creds, "loadCodexBarConfig").mockReturnValue(null);
+    const jsonHomeSpy = vi.spyOn(creds, "readJsonHome").mockReturnValue(null);
+    const textHomeSpy = vi.spyOn(creds, "readTextFileHome").mockReturnValue(null);
+    try {
+      const result = await getProviderUsage(["openrouter", "gemini", "deepseek"]);
+      expect(result.providers).toHaveLength(3);
+      for (const p of result.providers) {
+        expect(p.status).toBe("unauthenticated");
+        expect(p.status).not.toBe("unavailable");
+      }
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      loadSpy.mockRestore();
+      jsonHomeSpy.mockRestore();
+      textHomeSpy.mockRestore();
+      creds._resetCodexBarConfigCache();
+      for (const k of cleared) {
+        if (prev[k] === undefined) delete process.env[k];
+        else process.env[k] = prev[k];
+      }
+    }
+  });
+
+  it("drives Cursor normalize path via usage-summary body", async () => {
+    _setCursorSessionReaderForTests(() => ({
+      accessToken: "tok",
+      cookieHeader: "WorkosCursorSessionToken=user%3A%3Atok",
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          billingCycleEnd: "2026-08-01T00:00:00.000Z",
+          individualUsage: {
+            plan: { totalPercentUsed: 55, autoPercentUsed: 30, apiPercentUsed: 10 },
+          },
+        }),
+      ),
+    );
+
+    const result = await getProviderUsage(["cursor"]);
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0]!.status).toBe("ok");
+    expect(result.providers[0]!.windows[0]).toMatchObject({ id: "plan", utilization: 55 });
+  });
+});

--- a/src/server/services/claude-usage-limits.ts
+++ b/src/server/services/claude-usage-limits.ts
@@ -18,6 +18,9 @@ import { SHARED_LIMITS_FILE } from "~/shared/statusline-tap";
 // headers it already receives on its own API traffic.
 const USAGE_API_URL = "https://api.anthropic.com/api/oauth/usage";
 const OAUTH_BETA_HEADER = "oauth-2025-04-20";
+// CodexBar always identifies as the Claude Code client (detected version,
+// fallback claude-code/2.1.0); the endpoint may gate or shape responses on it.
+const USAGE_USER_AGENT = "claude-code/2.1.0";
 const REQUEST_TIMEOUT_MS = 5_000;
 
 // How long a statusline-tap snapshot counts as fresh. While any Claude session
@@ -53,13 +56,15 @@ let tokenReader: () => string | null = readClaudeOAuthToken;
 const EMPTY_WINDOWS = { session: null, weekly: null, weeklyOpus: null };
 
 /**
- * Read the Claude OAuth access token: macOS Keychain first (service
- * "Claude Code-credentials"), then ~/.claude/.credentials.json. Returns null
- * when the user isn't logged into Claude Code. Faithful to the reader in
- * electron/sandbox-manager.ts:831-876 — both read the same item.
+ * Read the Claude OAuth access token: ~/.claude/.credentials.json first, then
+ * the macOS Keychain (service "Claude Code-credentials"). CodexBar tries the
+ * file before the keychain; both hold the same credential. Returns null when
+ * the user isn't logged into Claude Code. Deliberate deviation from CodexBar:
+ * no token refresh here — the statusline tap is the primary source and Claude
+ * Code keeps the file fresh.
  */
 export function readClaudeOAuthToken(): string | null {
-  const raw = readKeychainSecret(KEYCHAIN_SERVICE) ?? readCredentialsFile();
+  const raw = readCredentialsFile() ?? readKeychainSecret(KEYCHAIN_SERVICE);
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as { claudeAiOauth?: { accessToken?: unknown } };
@@ -209,6 +214,8 @@ async function fetchFromApi(): Promise<FetchResult> {
       headers: {
         Authorization: `Bearer ${token}`,
         "anthropic-beta": OAUTH_BETA_HEADER,
+        Accept: "application/json",
+        "User-Agent": USAGE_USER_AGENT,
       },
       signal: controller.signal,
     });
@@ -246,7 +253,9 @@ async function fetchFromApi(): Promise<FetchResult> {
     };
   }
   consecutiveRateLimits = 0;
-  if (res.status === 401 || res.status === 403) {
+  // 401 = logged out. 403 is a scope/permission problem (e.g. token missing
+  // `user:profile`) — CodexBar surfaces it as a server error, not logged-out.
+  if (res.status === 401) {
     return {
       value: snapshot("unauthenticated", EMPTY_WINDOWS, `auth failed (${res.status})`),
       ttlMs: TRANSIENT_TTL_MS,
@@ -272,11 +281,13 @@ async function fetchFromApi(): Promise<FetchResult> {
     return { value: snapshot("error", EMPTY_WINDOWS, "invalid JSON response"), ttlMs: TRANSIENT_TTL_MS };
   }
   const b = body as Record<string, unknown>;
+  // Model-scoped weekly window: CodexBar prefers seven_day_sonnet over
+  // seven_day_opus (newer sonnet-scoped plans reuse the same slot).
   return {
     value: snapshot("ok", {
       session: parseWindow(b?.five_hour),
       weekly: parseWindow(b?.seven_day),
-      weeklyOpus: parseWindow(b?.seven_day_opus),
+      weeklyOpus: parseWindow(b?.seven_day_sonnet) ?? parseWindow(b?.seven_day_opus),
     }),
     ttlMs: SUCCESS_TTL_MS,
   };

--- a/src/server/services/provider-usage/all-adapters.ts
+++ b/src/server/services/provider-usage/all-adapters.ts
@@ -1,0 +1,2342 @@
+/**
+ * Live usage adapters for every CodexBar provider id.
+ * Each adapter resolves credentials (env / ~/.codexbar / local files) and attempts
+ * a real probe. Missing credentials → unauthenticated (never "unavailable" for missing adapters).
+ */
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ProviderUsageId, ProviderUsageSnapshot, ProviderUsageWindow } from "~/shared/provider-usage";
+import { emptyProviderSnapshot } from "~/shared/provider-usage";
+import {
+  claudeLimitsToProviderSnapshot,
+  formatAmount,
+  normalizeCrofUsagePayload,
+  normalizeDeepSeekUsagePayload,
+  normalizeElevenLabsUsagePayload,
+  normalizeKimiK2UsagePayload,
+  normalizeMoonshotUsagePayload,
+  normalizeOpenRouterUsagePayload,
+  normalizePoeUsagePayload,
+} from "~/shared/provider-usage-normalize";
+import { getClaudeUsageLimits } from "../claude-usage-limits";
+import {
+  configApiKey,
+  configCookie,
+  configEnterpriseHost,
+  envFirst,
+  pickString,
+  readJsonHome,
+  readTextFileHome,
+} from "./credentials";
+import { getCodexUsage } from "./codex-usage";
+import { getCursorUsage } from "./cursor-usage";
+import {
+  detailWindow,
+  httpGet,
+  httpPost,
+  isoFromIso,
+  isoFromSecOrMs,
+  mapHttpFailure,
+  num,
+  percentFromRemaining,
+  percentUsed,
+  snapshotOk,
+  windowOf,
+} from "./http";
+
+// ── shared helpers ──────────────────────────────────────────────────────────
+
+function unauth(id: ProviderUsageId, reason: string): ProviderUsageSnapshot {
+  return emptyProviderSnapshot(id, "unauthenticated", reason);
+}
+
+function errSnap(id: ProviderUsageId, message: string): ProviderUsageSnapshot {
+  return emptyProviderSnapshot(id, "error", message);
+}
+
+function balanceOnly(
+  id: ProviderUsageId,
+  remaining: number | null,
+  unit?: string,
+): ProviderUsageSnapshot {
+  if (remaining === null) return errSnap(id, "no balance");
+  // Prepaid balance with no meter — carry the value, never a fake 0% bar.
+  return snapshotOk(id, [detailWindow("balance", "bal", formatAmount(remaining, unit))]);
+}
+
+function usedLimitWindows(
+  id: ProviderUsageId,
+  windows: Array<{
+    id: string;
+    label: string;
+    used?: number | null;
+    limit?: number | null;
+    remaining?: number | null;
+    utilization?: number | null;
+    resetsAt?: string | null;
+    unit?: string;
+  }>,
+  note?: string,
+): ProviderUsageSnapshot {
+  const out: ProviderUsageWindow[] = [];
+  for (const w of windows) {
+    let util = w.utilization ?? null;
+    let detail: string | undefined;
+    if (util === null) {
+      if (w.used != null && w.limit != null && w.limit > 0) util = (w.used / w.limit) * 100;
+      else if (w.remaining != null && w.limit != null && w.limit > 0)
+        util = ((w.limit - w.remaining) / w.limit) * 100;
+      // No limit → meterless: surface the known value instead of fabricating 0%.
+      else if (w.remaining != null) detail = `${formatAmount(w.remaining, w.unit)} left`;
+      else if (w.used != null) detail = `${formatAmount(w.used, w.unit)} used`;
+    }
+    const win = windowOf(w.id, w.label, util, w.resetsAt ?? null, detail);
+    if (win) out.push(win);
+  }
+  if (out.length === 0) return errSnap(id, note ?? "no usage windows");
+  return snapshotOk(id, out, note);
+}
+
+function asRec(v: unknown): Record<string, unknown> {
+  return v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+}
+
+// Several dashboards are browser-gated (403 without a browser-like UA).
+const CHROME_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+/** Depth-first search for the first occurrence of a key anywhere in a JSON tree. */
+function deepFind(value: unknown, key: string, depth = 8): unknown {
+  if (depth < 0 || !value || typeof value !== "object") return undefined;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = deepFind(item, key, depth - 1);
+      if (found !== undefined) return found;
+    }
+    return undefined;
+  }
+  const rec = value as Record<string, unknown>;
+  if (key in rec && rec[key] !== undefined && rec[key] !== null) return rec[key];
+  for (const v of Object.values(rec)) {
+    const found = deepFind(v, key, depth - 1);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+function pickNum(obj: Record<string, unknown>, ...keys: string[]): number | null {
+  for (const k of keys) {
+    const n = num(obj[k]);
+    if (n !== null) return n;
+  }
+  return null;
+}
+
+async function bearerJson(
+  id: ProviderUsageId,
+  url: string,
+  token: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<{ ok: true; json: unknown } | { ok: false; snap: ProviderUsageSnapshot }> {
+  const res = await httpGet(url, { Authorization: `Bearer ${token}`, ...extraHeaders });
+  if (!res.ok) return { ok: false, snap: mapHttpFailure(id, res) };
+  return { ok: true, json: res.json };
+}
+
+async function cookieJson(
+  id: ProviderUsageId,
+  url: string,
+  cookie: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<{ ok: true; json: unknown; text: string } | { ok: false; snap: ProviderUsageSnapshot }> {
+  const res = await httpGet(url, { Cookie: cookie, ...extraHeaders });
+  if (!res.ok) return { ok: false, snap: mapHttpFailure(id, res) };
+  return { ok: true, json: res.json, text: res.text };
+}
+
+// ── built-in (existing) ─────────────────────────────────────────────────────
+
+async function fetchClaude(): Promise<ProviderUsageSnapshot> {
+  const limits = await getClaudeUsageLimits();
+  return claudeLimitsToProviderSnapshot(limits);
+}
+
+// ── API token providers ─────────────────────────────────────────────────────
+
+async function fetchOpenRouter(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("openrouter", ["OPENROUTER_API_KEY"]);
+  if (!key) return unauth("openrouter", "missing OPENROUTER_API_KEY / config apiKey");
+  const base = (envFirst(["OPENROUTER_API_URL"]) ?? "https://openrouter.ai/api/v1").replace(/\/$/, "");
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${key}`,
+    "HTTP-Referer": envFirst(["OPENROUTER_HTTP_REFERER"]) ?? "https://mission-control.local",
+    "X-Title": envFirst(["OPENROUTER_X_TITLE"]) ?? "MissionControl",
+  };
+  const credits = await httpGet(`${base}/credits`, headers);
+  if (!credits.ok) return mapHttpFailure("openrouter", credits);
+  const keyRes = await httpGet(`${base}/key`, headers);
+  return normalizeOpenRouterUsagePayload(credits.json, keyRes.ok ? keyRes.json : undefined);
+}
+
+async function fetchOpenAI(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("openai", ["OPENAI_ADMIN_KEY", "OPENAI_API_KEY"]);
+  if (!key) return unauth("openai", "missing OPENAI_ADMIN_KEY / OPENAI_API_KEY");
+  // Prefer org costs (admin); fall back to legacy credit grants.
+  const now = Math.floor(Date.now() / 1000);
+  const start = now - 7 * 86400;
+  const costs = await httpGet(
+    `https://api.openai.com/v1/organization/costs?start_time=${start}&limit=1`,
+    { Authorization: `Bearer ${key}` },
+  );
+  if (costs.ok) {
+    const root = asRec(costs.json);
+    const data = Array.isArray(root.data) ? root.data : [];
+    let spend = 0;
+    for (const row of data) {
+      const r = asRec(row);
+      const results = Array.isArray(r.results) ? r.results : [];
+      for (const item of results) {
+        const amount = asRec(asRec(item).amount);
+        const v = num(amount.value);
+        if (v !== null) spend += v;
+      }
+    }
+    // Org costs have no hard limit — surface the spend value, not a fake 0%.
+    return snapshotOk("openai", [detailWindow("spend7d", "7d", `$${formatAmount(spend)} spent`)]);
+  }
+  const grants = await httpGet("https://api.openai.com/v1/dashboard/billing/credit_grants", {
+    Authorization: `Bearer ${key}`,
+  });
+  if (!grants.ok) return mapHttpFailure("openai", grants);
+  const g = asRec(grants.json);
+  const total = pickNum(g, "total_granted", "totalGranted");
+  const used = pickNum(g, "total_used", "totalUsed");
+  const available = pickNum(g, "total_available", "totalAvailable");
+  return usedLimitWindows(
+    "openai",
+    [{ id: "credits", label: "credits", used, limit: total, remaining: available }],
+    available !== null ? `available=${available}` : undefined,
+  );
+}
+
+async function fetchAzureOpenAI(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("azureopenai", ["AZURE_OPENAI_API_KEY"]);
+  const endpoint = envFirst(["AZURE_OPENAI_ENDPOINT"]) ?? configEnterpriseHost("azureopenai");
+  const deployment = envFirst(["AZURE_OPENAI_DEPLOYMENT_NAME", "AZURE_OPENAI_DEPLOYMENT"]);
+  if (!key || !endpoint) {
+    return unauth("azureopenai", "missing AZURE_OPENAI_API_KEY / AZURE_OPENAI_ENDPOINT");
+  }
+  if (!deployment) return unauth("azureopenai", "missing AZURE_OPENAI_DEPLOYMENT_NAME");
+  const host = endpoint.replace(/\/$/, "").replace(/^http:\/\//i, "https://");
+  const version = envFirst(["AZURE_OPENAI_API_VERSION"]) ?? "2024-02-15-preview";
+  const url =
+    version === "v1"
+      ? `${host}/openai/v1/chat/completions`
+      : `${host}/openai/deployments/${deployment}/chat/completions?api-version=${encodeURIComponent(version)}`;
+  const res = await httpPost(
+    url,
+    { "api-key": key },
+    JSON.stringify({
+      messages: [{ role: "user", content: "ping" }],
+      max_tokens: 1,
+      model: deployment,
+    }),
+  );
+  if (!res.ok) return mapHttpFailure("azureopenai", res);
+  // Probe-only: Azure exposes no spend/quota surface here — honest text.
+  return snapshotOk("azureopenai", [detailWindow("deployment", "deploy", "reachable")]);
+}
+
+async function fetchDeepSeek(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("deepseek", ["DEEPSEEK_API_KEY", "DEEPSEEK_KEY"]);
+  if (!key) return unauth("deepseek", "missing DEEPSEEK_API_KEY");
+  const res = await bearerJson("deepseek", "https://api.deepseek.com/user/balance", key);
+  if (!res.ok) return res.snap;
+  return normalizeDeepSeekUsagePayload(res.json);
+}
+
+async function fetchMoonshot(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("moonshot", ["MOONSHOT_API_KEY", "MOONSHOT_KEY"]);
+  if (!key) return unauth("moonshot", "missing MOONSHOT_API_KEY");
+  const region = (envFirst(["MOONSHOT_REGION"]) ?? "international").toLowerCase();
+  const host = region.includes("cn") || region.includes("china") ? "api.moonshot.cn" : "api.moonshot.ai";
+  const res = await bearerJson("moonshot", `https://${host}/v1/users/me/balance`, key);
+  if (!res.ok) return res.snap;
+  return normalizeMoonshotUsagePayload(res.json);
+}
+
+async function fetchZai(): Promise<ProviderUsageSnapshot> {
+  // ZaiUsageStats: response is data.limits[] of typed entries — `usage` is the
+  // LIMIT, `currentValue` the used amount, plus remaining / percentage /
+  // nextResetTime (epoch ms). Team mode (Bigmodel-* headers) is not ported.
+  const key = configApiKey("zai", ["Z_AI_API_KEY"]);
+  if (!key) return unauth("zai", "missing Z_AI_API_KEY");
+  let quotaUrl =
+    envFirst(["Z_AI_QUOTA_URL"]) ??
+    `${(envFirst(["Z_AI_API_HOST"]) ?? "https://api.z.ai").replace(/\/$/, "")}/api/monitor/usage/quota/limit`;
+  // Team mode: ?type=2 plus Bigmodel-Organization/Project headers.
+  const org = envFirst(["Z_AI_BIGMODEL_ORGANIZATION"]);
+  const project = envFirst(["Z_AI_BIGMODEL_PROJECT"]);
+  const headers: Record<string, string> = { Authorization: `Bearer ${key}` };
+  if (org && project) {
+    quotaUrl += quotaUrl.includes("?") ? "&type=2" : "?type=2";
+    headers["Bigmodel-Organization"] = org;
+    headers["Bigmodel-Project"] = project;
+  }
+  const res = await httpGet(quotaUrl, headers);
+  if (!res.ok) return mapHttpFailure("zai", res);
+  const root = asRec(res.json);
+  const code = pickNum(root, "code");
+  if (root.success === false || (code !== null && code !== 200)) {
+    return errSnap("zai", `quota API returned code ${code ?? "?"}: ${pickString(root, "msg") ?? ""}`);
+  }
+  const data = asRec(root.data ?? root);
+  const limits = Array.isArray(data.limits) ? data.limits : [];
+  // Unit enum: 1=days, 3=hours, 5=minutes, 6=weeks (ZaiLimitRaw).
+  const windowMinutes = (entry: Record<string, unknown>): number | null => {
+    const n = pickNum(entry, "number");
+    const unit = pickNum(entry, "unit");
+    if (n === null || n <= 0 || unit === null) return null;
+    const factor = unit === 5 ? 1 : unit === 3 ? 60 : unit === 1 ? 1440 : unit === 6 ? 10080 : null;
+    return factor === null ? null : n * factor;
+  };
+  const windows: ProviderUsageWindow[] = [];
+  for (const raw of limits) {
+    const entry = asRec(raw);
+    const type = String(entry.type ?? "").toUpperCase();
+    const limit = pickNum(entry, "usage"); // field literally named `usage` is the limit
+    const used = pickNum(entry, "currentValue", "current_value");
+    const remaining = pickNum(entry, "remaining");
+    const pct = pickNum(entry, "percentage", "percent");
+    const util =
+      limit !== null && limit > 0 && remaining !== null
+        ? (Math.max(0, Math.min(limit, limit - remaining)) / limit) * 100
+        : (percentUsed(used, limit) ?? pct);
+    const resetsAt = isoFromSecOrMs(entry.nextResetTime ?? entry.next_reset_time);
+    const minutes = windowMinutes(entry);
+    const id =
+      type === "TIME_LIMIT"
+        ? "time"
+        : minutes !== null && minutes <= 300
+          ? "session"
+          : "tokens";
+    const label = id === "time" ? "time" : id === "session" ? "session" : "tokens";
+    const win = windowOf(id, label, util, resetsAt);
+    if (win && !windows.some((w) => w.id === win.id)) windows.push(win);
+  }
+  if (windows.length === 0) return errSnap("zai", "no limits[] entries in quota response");
+  return snapshotOk("zai", windows);
+}
+
+async function fetchElevenLabs(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("elevenlabs", ["ELEVENLABS_API_KEY", "XI_API_KEY"]);
+  if (!key) return unauth("elevenlabs", "missing ELEVENLABS_API_KEY / XI_API_KEY");
+  const base = (envFirst(["ELEVENLABS_API_URL"]) ?? "https://api.elevenlabs.io").replace(/\/$/, "");
+  const res = await httpGet(`${base}/v1/user/subscription`, { "xi-api-key": key });
+  if (!res.ok) return mapHttpFailure("elevenlabs", res);
+  return normalizeElevenLabsUsagePayload(res.json);
+}
+
+async function fetchPoe(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("poe", ["POE_API_KEY"]);
+  if (!key) return unauth("poe", "missing POE_API_KEY");
+  const res = await bearerJson("poe", "https://api.poe.com/usage/current_balance", key);
+  if (!res.ok) return res.snap;
+  return normalizePoeUsagePayload(res.json);
+}
+
+async function fetchCrof(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("crof", ["CROF_API_KEY", "CROFAI_API_KEY"]);
+  if (!key) return unauth("crof", "missing CROF_API_KEY");
+  const res = await bearerJson("crof", "https://crof.ai/usage_api/", key);
+  if (!res.ok) return res.snap;
+  return normalizeCrofUsagePayload(res.json);
+}
+
+async function fetchVenice(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("venice", ["VENICE_API_KEY", "VENICE_KEY"]);
+  if (!key) return unauth("venice", "missing VENICE_API_KEY");
+  const res = await bearerJson("venice", "https://api.venice.ai/api/v1/billing/balance", key);
+  if (!res.ok) return res.snap;
+  const root = asRec(res.json);
+  const balances = asRec(root.balances ?? root);
+  const diem = pickNum(balances, "diemBalance", "diem_balance", "DIEM");
+  const usd = pickNum(balances, "usdBalance", "usd_balance", "USD");
+  const allocation = pickNum(balances, "diemEpochAllocation", "diem_epoch_allocation");
+  if (diem !== null && allocation !== null && allocation > 0) {
+    return usedLimitWindows(
+      "venice",
+      [{ id: "diem", label: "diem", remaining: diem, limit: allocation }],
+      `DIEM ${diem}/${allocation}`,
+    );
+  }
+  const remaining = usd ?? diem;
+  return balanceOnly("venice", remaining, remaining !== null ? `balance=${remaining}` : undefined);
+}
+
+/** Kimi usage/detail bucket: {limit, used, remaining, resetTime} — often string-typed. */
+function kimiWindowFrom(
+  bucket: Record<string, unknown>,
+  id: string,
+  label: string,
+): ProviderUsageWindow | null {
+  const limit = num(bucket.limit);
+  const used = num(bucket.used);
+  const remaining = num(bucket.remaining);
+  const util =
+    percentUsed(used, limit) ??
+    (limit !== null && limit > 0 && remaining !== null ? ((limit - remaining) / limit) * 100 : null);
+  const resetsAt = isoFromIso(bucket.resetTime ?? bucket.reset_time) ?? isoFromSecOrMs(bucket.resetTime);
+  return windowOf(id, label, util, resetsAt);
+}
+
+function parseKimiUsages(body: unknown): ProviderUsageWindow[] {
+  // KimiUsageSnapshot: top-level `usage` is the weekly primary; limits[]
+  // entries carry a `detail` bucket (the 300-minute entry is the session).
+  const root = asRec(body);
+  const data = asRec(root.data ?? root);
+  const windows: ProviderUsageWindow[] = [];
+  const weekly = kimiWindowFrom(asRec(data.usage ?? root.usage), "weekly", "week");
+  const limits = Array.isArray(data.limits) ? data.limits : Array.isArray(root.limits) ? root.limits : [];
+  for (const raw of limits) {
+    const lim = asRec(raw);
+    const detail = asRec(lim.detail ?? lim);
+    const minutes = num(lim.window_minutes ?? lim.windowMinutes ?? lim.duration ?? detail.window_minutes);
+    const name = String(lim.name ?? detail.name ?? "");
+    const isSession = minutes === 300 || /5.?hour|session|300/i.test(name) || limits.length === 1;
+    const win = kimiWindowFrom(detail, isSession ? "session" : name || "quota", isSession ? "session" : "quota");
+    if (win && !windows.some((w) => w.id === win.id)) windows.push(win);
+  }
+  if (weekly) windows.push(weekly);
+  return windows;
+}
+
+async function fetchKimi(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("kimi", ["KIMI_CODE_API_KEY", "KIMI_API_KEY"]);
+  if (key) {
+    const res = await bearerJson("kimi", "https://api.kimi.com/coding/v1/usages", key);
+    if (res.ok) {
+      const windows = parseKimiUsages(res.json);
+      if (windows.length === 0) return errSnap("kimi", "no usage/limits fields in response");
+      return snapshotOk("kimi", windows);
+    }
+    if (res.snap.status !== "unauthenticated") return res.snap;
+  }
+  // Web-gateway fallback: kimi-auth token, Connect-style POST with the
+  // FEATURE_CODING scope body (KimiUsageFetcher).
+  const cookie = configCookie("kimi", ["KIMI_AUTH_TOKEN", "KIMI_COOKIE"], "kimi-auth");
+  if (!cookie) return unauth("kimi", "missing KIMI_CODE_API_KEY / KIMI_AUTH_TOKEN");
+  const token = cookie.match(/(?:^|;\s*)kimi-auth=([^;]+)/i)?.[1] ?? cookie;
+  const res = await httpPost(
+    "https://www.kimi.com/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages",
+    {
+      Authorization: `Bearer ${token}`,
+      Cookie: cookie,
+      Origin: "https://www.kimi.com",
+      Referer: "https://www.kimi.com/code/console",
+      "connect-protocol-version": "1",
+      "x-msh-platform": "web",
+      "x-language": "en-US",
+      "User-Agent": CHROME_UA,
+    },
+    JSON.stringify({ scope: ["FEATURE_CODING"] }),
+  );
+  if (!res.ok) return mapHttpFailure("kimi", res);
+  // Gateway shape: usages[] of {scope, detail, limits[]} — detail is the
+  // weekly primary; limits[0].detail is the 5-hour session window.
+  const root = asRec(res.json);
+  const usages = Array.isArray(root.usages) ? root.usages : [];
+  const windows: ProviderUsageWindow[] = [];
+  for (const raw of usages) {
+    const entry = asRec(raw);
+    const scope = String(entry.scope ?? "");
+    if (scope && scope !== "FEATURE_CODING") continue;
+    const weekly = kimiWindowFrom(asRec(entry.detail), "weekly", "week");
+    if (weekly && !windows.some((w) => w.id === "weekly")) windows.push(weekly);
+    const limits = Array.isArray(entry.limits) ? entry.limits : [];
+    const sessionDetail = asRec(asRec(limits[0]).detail);
+    const session = kimiWindowFrom(sessionDetail, "session", "session");
+    if (session && !windows.some((w) => w.id === "session")) windows.push(session);
+  }
+  if (windows.length === 0) {
+    const parsed = parseKimiUsages(res.json);
+    if (parsed.length > 0) return snapshotOk("kimi", parsed);
+    return errSnap("kimi", "no usages[] entries in gateway response");
+  }
+  return snapshotOk("kimi", windows);
+}
+
+async function fetchKimiK2(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("kimik2", ["KIMI_K2_API_KEY", "KIMI_API_KEY", "KIMI_KEY"]);
+  if (!key) return unauth("kimik2", "missing KIMI_K2_API_KEY");
+  const res = await bearerJson("kimik2", "https://kimi-k2.ai/api/user/credits", key);
+  if (!res.ok) return res.snap;
+  return normalizeKimiK2UsagePayload(res.json);
+}
+
+async function fetchCopilot(): Promise<ProviderUsageSnapshot> {
+  // CopilotUsageFetcher: GET /copilot_internal/user with the GitHub OAuth
+  // token directly (no exchange) — but the endpoint expects Copilot editor
+  // headers. Config token first (CodexBar's device-flow token), then env /
+  // gh-cli files as port extensions. Zero-entitlement snapshots are dropped.
+  const ghToken =
+    envFirst(["COPILOT_API_TOKEN"]) ??
+    configApiKey("copilot") ??
+    envFirst(["GITHUB_TOKEN", "GH_TOKEN", "COPILOT_GITHUB_TOKEN"]) ??
+    readTextFileHome(".config", "github-copilot", "hosts.json")?.match(/"oauth_token"\s*:\s*"([^"]+)"/)?.[1] ??
+    readTextFileHome(".config", "gh", "hosts.yml")?.match(/oauth_token:\s*(\S+)/)?.[1] ??
+    null;
+  if (!ghToken) return unauth("copilot", "missing GitHub token (codexbar config / GITHUB_TOKEN / gh cli)");
+  const host = configEnterpriseHost("copilot") ?? "api.github.com";
+  const base = host.includes("://") ? host.replace(/\/$/, "") : `https://${host}`;
+  const url = base.includes("api.github.com")
+    ? "https://api.github.com/copilot_internal/user"
+    : `${base}/copilot_internal/user`;
+  const res = await httpGet(url, {
+    Authorization: `token ${ghToken}`,
+    Accept: "application/json",
+    "Editor-Version": "vscode/1.96.2",
+    "Editor-Plugin-Version": "copilot-chat/0.26.7",
+    "User-Agent": "GitHubCopilotChat/0.26.7",
+    "X-Github-Api-Version": "2025-04-01",
+  });
+  if (!res.ok) return mapHttpFailure("copilot", res);
+  const root = asRec(res.json);
+  const quota = asRec(root.quota_snapshots ?? root.quotaSnapshots);
+  const resetsAt = isoFromIso(root.quota_reset_date ?? root.quotaResetDate);
+  const windows: ProviderUsageWindow[] = [];
+  for (const [key, label] of [
+    ["premium_interactions", "premium"],
+    ["premiumInteractions", "premium"],
+    ["chat", "chat"],
+    ["completions", "comp"],
+  ] as const) {
+    const snap = asRec(quota[key]);
+    if (!snap || Object.keys(snap).length === 0) continue;
+    if (windows.some((w) => w.id === label)) continue;
+    const entitlement = pickNum(snap, "entitlement");
+    if (snap.unlimited === true) {
+      windows.push(detailWindow(label, label, "unlimited"));
+      continue;
+    }
+    // CopilotUsageModels drops zero-entitlement placeholder snapshots.
+    if (entitlement !== null && entitlement <= 0) continue;
+    const usedPct = pickNum(snap, "percent_used", "percentUsed");
+    const remainingPct = pickNum(snap, "percent_remaining", "percentRemaining");
+    const remaining = pickNum(snap, "remaining");
+    const util =
+      usedPct ??
+      (remainingPct !== null
+        ? 100 - remainingPct
+        : entitlement !== null && entitlement > 0 && remaining !== null
+          ? ((entitlement - remaining) / entitlement) * 100
+          : null);
+    const win = windowOf(label, label, util, resetsAt);
+    if (win) windows.push(win);
+  }
+  if (windows.length === 0) return errSnap("copilot", "no usable quota snapshots in response");
+  return snapshotOk("copilot", windows);
+}
+
+async function fetchChutes(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("chutes", ["CHUTES_API_KEY"]);
+  if (!key) return unauth("chutes", "missing CHUTES_API_KEY");
+  const base = (envFirst(["CHUTES_API_URL"]) ?? "https://api.chutes.ai").replace(/\/$/, "");
+  const res = await bearerJson("chutes", `${base}/users/me/subscription_usage`, key);
+  if (!res.ok) return res.snap;
+  // ChutesUsageStats: rolling-4h + monthly windows matched with broad,
+  // underscore-insensitive keys; fractional percents (≤1) are ×100. The
+  // pay-as-you-go /users/me/quotas fallback endpoints are not ported.
+  const root = asRec(res.json);
+  const data = asRec(root.data ?? root);
+  const normalizeKey = (k: string) => k.toLowerCase().replace(/[_-]/g, "");
+  const findBucket = (...names: string[]): Record<string, unknown> => {
+    const targets = names.map(normalizeKey);
+    for (const source of [data, root]) {
+      for (const [k, v] of Object.entries(source)) {
+        if (targets.includes(normalizeKey(k)) && v && typeof v === "object") return asRec(v);
+      }
+    }
+    return {};
+  };
+  // ChutesUsageStats: |value| < 1 treated as a fraction (strict).
+  const asPct = (v: number | null): number | null =>
+    v === null ? null : Math.abs(v) < 1 ? v * 100 : v;
+  const windows: ProviderUsageWindow[] = [];
+  const buckets: Array<[Record<string, unknown>, string, string]> = [
+    [
+      findBucket("rolling", "rolling_window", "rolling_4h", "four_hour", "four_hour_usage", "window_4h"),
+      "rolling",
+      "4h",
+    ],
+    [
+      findBucket("monthly", "monthly_usage", "subscription", "subscription_usage", "billing_period"),
+      "monthly",
+      "month",
+    ],
+  ];
+  for (const [bucket, id, label] of buckets) {
+    if (Object.keys(bucket).length === 0) continue;
+    const util =
+      asPct(pickNum(bucket, "utilization", "used_percent", "usedPercent", "percent_used", "percent")) ??
+      percentUsed(pickNum(bucket, "used", "usage"), pickNum(bucket, "limit", "quota", "total"));
+    const reset = bucket.resets_at ?? bucket.resetsAt ?? bucket.reset_at;
+    const win = windowOf(id, label, util, isoFromIso(reset) ?? isoFromSecOrMs(reset));
+    if (win) windows.push(win);
+  }
+  if (windows.length === 0) {
+    return usedLimitWindows("chutes", [
+      {
+        id: "usage",
+        label: "usage",
+        used: pickNum(data, "used", "usage"),
+        limit: pickNum(data, "limit", "quota"),
+        remaining: pickNum(data, "remaining"),
+      },
+    ]);
+  }
+  return snapshotOk("chutes", windows);
+}
+
+async function fetchCrossModel(): Promise<ProviderUsageSnapshot> {
+  // CrossModelUsageStats: `balance_micro` / `uncollected_micro` integers in
+  // micro-USD (÷1e6). Prepaid wallet — the value is the point, not a percent.
+  const key = configApiKey("crossmodel", ["CROSSMODEL_API_KEY"]);
+  if (!key) return unauth("crossmodel", "missing CROSSMODEL_API_KEY");
+  const base = (envFirst(["CROSSMODEL_API_URL"]) ?? "https://api.crossmodel.ai/v1").replace(/\/$/, "");
+  const credits = await bearerJson("crossmodel", `${base}/credits`, key);
+  if (!credits.ok) return credits.snap;
+  const root = asRec(credits.json);
+  const data = asRec(root.data ?? root);
+  const balanceMicro = pickNum(data, "balance_micro", "balanceMicro");
+  const uncollectedMicro = pickNum(data, "uncollected_micro", "uncollectedMicro");
+  if (balanceMicro === null) return errSnap("crossmodel", "no balance_micro in credits response");
+  const windows: ProviderUsageWindow[] = [
+    detailWindow("balance", "bal", `$${formatAmount(balanceMicro / 1e6)}`),
+  ];
+  if (uncollectedMicro !== null && uncollectedMicro > 0) {
+    windows.push(detailWindow("uncollected", "pending", `$${formatAmount(uncollectedMicro / 1e6)}`));
+  }
+  return snapshotOk("crossmodel", windows);
+}
+
+async function fetchCodebuff(): Promise<ProviderUsageSnapshot> {
+  // CodebuffSettingsReader: CLI token lives at `default.authToken` (or
+  // top-level `authToken`) in ~/.config/manicode/credentials.json; the usage
+  // POST body carries a fingerprintId.
+  let key = configApiKey("codebuff", ["CODEBUFF_API_KEY"]);
+  if (!key) {
+    const creds = readJsonHome(".config", "manicode", "credentials.json");
+    if (creds) {
+      key =
+        pickString(asRec(creds.default), "authToken", "auth_token") ??
+        pickString(creds, "authToken", "auth_token");
+    }
+  }
+  if (!key) return unauth("codebuff", "missing CODEBUFF_API_KEY / manicode credentials (default.authToken)");
+  const base = (envFirst(["CODEBUFF_API_URL"]) ?? "https://www.codebuff.com").replace(/\/$/, "");
+  const res = await httpPost(
+    `${base}/api/v1/usage`,
+    { Authorization: `Bearer ${key}` },
+    JSON.stringify({ fingerprintId: "missioncontrol-usage" }),
+  );
+  if (!res.ok) return mapHttpFailure("codebuff", res);
+  const root = asRec(res.json);
+  const remaining = pickNum(root, "remainingBalance", "remaining");
+  const limit = pickNum(root, "quota", "limit");
+  const used = pickNum(root, "usage", "used");
+  const reset = isoFromIso(root.next_quota_reset ?? root.nextQuotaReset);
+  return usedLimitWindows("codebuff", [
+    { id: "credits", label: "credits", used, limit, remaining, resetsAt: reset, unit: "credits" },
+  ]);
+}
+
+async function fetchDeepgram(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("deepgram", ["DEEPGRAM_API_KEY"]);
+  if (!key) return unauth("deepgram", "missing DEEPGRAM_API_KEY");
+  const base = (envFirst(["DEEPGRAM_API_URL"]) ?? "https://api.deepgram.com/v1").replace(/\/$/, "");
+  const projects = await httpGet(`${base}/projects`, { Authorization: `Token ${key}` });
+  if (!projects.ok) return mapHttpFailure("deepgram", projects);
+  const root = asRec(projects.json);
+  const list = Array.isArray(root.projects) ? root.projects : [];
+  const projectId =
+    envFirst(["DEEPGRAM_PROJECT_ID"]) ??
+    (list[0] ? pickString(asRec(list[0]), "project_id", "projectId", "id") : null);
+  if (!projectId) return errSnap("deepgram", "no Deepgram projects on this key");
+  const balances = await httpGet(`${base}/projects/${projectId}/balances`, {
+    Authorization: `Token ${key}`,
+  });
+  if (!balances.ok) return mapHttpFailure("deepgram", balances);
+  const balRoot = asRec(balances.json);
+  const balList = Array.isArray(balRoot.balances) ? balRoot.balances : [];
+  let amount = 0;
+  let sawAmount = false;
+  for (const raw of balList) {
+    const v = pickNum(asRec(raw), "amount", "balance");
+    if (v !== null) {
+      amount += v;
+      sawAmount = true;
+    }
+  }
+  if (!sawAmount) return errSnap("deepgram", "no balances on project");
+  return snapshotOk("deepgram", [detailWindow("balance", "bal", `$${formatAmount(amount)}`)]);
+}
+
+async function fetchGroq(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("groq", ["GROQ_API_KEY"]);
+  if (!key) return unauth("groq", "missing GROQ_API_KEY");
+  const base = (envFirst(["GROQ_API_URL"]) ?? "https://api.groq.com/openai/v1").replace(/\/$/, "");
+  // Validate key; Prometheus enterprise metrics often unavailable on free keys.
+  const res = await bearerJson("groq", `${base}/models`, key);
+  if (!res.ok) return res.snap;
+  return snapshotOk("groq", [detailWindow("api", "api", "key ok (no quota API)")]);
+}
+
+async function fetchWarp(): Promise<ProviderUsageSnapshot> {
+  // CodexBar's Warp fetcher drives the app's private GraphQL schema (nested
+  // user{...} query, anti-bot client headers). Deliberately not ported —
+  // resolve the credential honestly and report the gap.
+  const key = configApiKey("warp", ["WARP_API_KEY", "WARP_TOKEN"]);
+  if (!key) return unauth("warp", "missing WARP_API_KEY / WARP_TOKEN");
+  return errSnap("warp", "Warp usage uses the app's private GraphQL schema; not supported by this port");
+}
+
+async function fetchSynthetic(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("synthetic", ["SYNTHETIC_API_KEY"]);
+  if (!key) return unauth("synthetic", "missing SYNTHETIC_API_KEY");
+  const res = await bearerJson("synthetic", "https://api.synthetic.new/v2/quotas", key);
+  if (!res.ok) return res.snap;
+  // SyntheticUsageStats slot names: rollingFiveHourLimit, weeklyTokenLimit,
+  // and nested search.hourly.
+  const root = asRec(res.json);
+  const data = asRec(root.data ?? root);
+  const windows: ProviderUsageWindow[] = [];
+  const buckets: Array<[Record<string, unknown>, string, string]> = [
+    [asRec(data.rollingFiveHourLimit ?? root.rollingFiveHourLimit), "session", "session"],
+    [asRec(data.weeklyTokenLimit ?? root.weeklyTokenLimit), "weekly", "week"],
+    [asRec(asRec(data.search ?? root.search).hourly), "search", "search"],
+  ];
+  for (const [bucket, id, label] of buckets) {
+    if (Object.keys(bucket).length === 0) continue;
+    // SyntheticUsageStats: percents ≤1 are fractions; percentRemaining inverts.
+    const asPct = (v: number | null): number | null => (v === null ? null : v <= 1 ? v * 100 : v);
+    const remainingPct = asPct(
+      pickNum(bucket, "percentRemaining", "remainingPercent", "remaining_percent", "percent_remaining"),
+    );
+    const util =
+      asPct(
+        pickNum(bucket, "percentUsed", "usedPercent", "usagePercent", "usage_percent", "used_percent", "percent_used", "percent", "utilization"),
+      ) ??
+      (remainingPct !== null ? 100 - remainingPct : null) ??
+      percentUsed(
+        pickNum(bucket, "used", "usage", "requests", "consumed", "spent"),
+        pickNum(bucket, "limit", "quota", "max", "total", "capacity", "allowance"),
+      );
+    const reset =
+      bucket.resetAt ?? bucket.reset_at ?? bucket.resetsAt ?? bucket.resets_at ?? bucket.periodEnd ?? bucket.period_end;
+    const win = windowOf(id, label, util, isoFromIso(reset) ?? isoFromSecOrMs(reset));
+    if (win && !windows.some((w) => w.id === id)) windows.push(win);
+  }
+  if (windows.length === 0) return errSnap("synthetic", "no quota slots in response");
+  return snapshotOk("synthetic", windows);
+}
+
+async function fetchAmp(): Promise<ProviderUsageSnapshot> {
+  // AmpUsageFetcher: POST {"method":"userDisplayBalanceInfo","params":{}} —
+  // the response is {ok, result:{displayText}} where displayText is human
+  // text ("$12.34", "Amp Free: 42% used") parsed textually.
+  const key = configApiKey("amp", ["AMP_API_KEY"]);
+  if (!key) return unauth("amp", "missing AMP_API_KEY");
+  const res = await httpPost(
+    "https://ampcode.com/api/internal?userDisplayBalanceInfo",
+    { Authorization: `Bearer ${key}` },
+    JSON.stringify({ method: "userDisplayBalanceInfo", params: {} }),
+  );
+  if (!res.ok) return mapHttpFailure("amp", res);
+  const root = asRec(res.json);
+  if (root.ok !== true) {
+    const code = pickString(asRec(root.error), "code");
+    if (code === "auth-required") return unauth("amp", "Amp token rejected (auth-required)");
+    return errSnap("amp", `balance RPC failed${code ? ` (${code})` : ""}`);
+  }
+  const displayText = pickString(asRec(root.result), "displayText") ?? "";
+  if (!displayText) return errSnap("amp", "no displayText in balance response");
+  // AmpUsageParser: "Amp Free: $<remaining> / $<quota> remaining (replenishes
+  // +$<hourly> / hour)" and "Individual credits: $<n> remaining".
+  const amount = "([0-9][0-9,]*(?:\\.[0-9]+)?)";
+  const windows: ProviderUsageWindow[] = [];
+  const numOf = (s: string | undefined): number | null =>
+    s == null ? null : num(s.replace(/,/g, ""));
+  const free = displayText.match(
+    new RegExp(`^\\s*Amp Free:\\s*\\$?${amount}\\s*/\\s*\\$?${amount}\\s+remaining`, "im"),
+  );
+  const freeRemaining = numOf(free?.[1]);
+  const freeQuota = numOf(free?.[2]);
+  if (freeRemaining !== null && freeQuota !== null && freeQuota > 0) {
+    const used = Math.max(0, freeQuota - freeRemaining);
+    const win = windowOf("free", "free", (used / freeQuota) * 100);
+    if (win) windows.push(win);
+  }
+  const credits = numOf(
+    displayText.match(new RegExp(`^\\s*Individual credits:\\s*\\$?${amount}\\s+remaining`, "im"))?.[1],
+  );
+  if (credits !== null) windows.push(detailWindow("balance", "bal", `$${formatAmount(credits)}`));
+  if (windows.length === 0) windows.push(detailWindow("balance", "bal", displayText.slice(0, 40)));
+  return snapshotOk("amp", windows);
+}
+
+async function fetchKilo(): Promise<ProviderUsageSnapshot> {
+  // KiloUsageFetcher: tRPC batch GET on app.kilo.ai/api/trpc — creditBlocks[]
+  // carry amount_mUsd (total) and balance_mUsd (remaining) in micro-USD.
+  let key = configApiKey("kilo", ["KILO_API_KEY"]);
+  if (!key) {
+    const auth = readJsonHome(".local", "share", "kilo", "auth.json");
+    if (auth) key = pickString(asRec(auth.kilo), "access", "token") ?? pickString(auth, "access", "token");
+  }
+  if (!key) return unauth("kilo", "missing KILO_API_KEY / ~/.local/share/kilo/auth.json");
+  const procedures = ["user.getCreditBlocks", "kiloPass.getState", "user.getAutoTopUpPaymentMethod"];
+  const input = encodeURIComponent(
+    JSON.stringify(Object.fromEntries(procedures.map((_, i) => [String(i), { json: null }]))),
+  );
+  const base = (envFirst(["KILO_API_URL"]) ?? "https://app.kilo.ai/api/trpc").replace(/\/$/, "");
+  const res = await httpGet(`${base}/${procedures.join(",")}?batch=1&input=${input}`, {
+    Authorization: `Bearer ${key}`,
+    Accept: "application/json",
+  });
+  if (!res.ok) return mapHttpFailure("kilo", res);
+  const entries = Array.isArray(res.json) ? res.json : [res.json];
+  const payloadOf = (entry: unknown): unknown => {
+    const result = asRec(asRec(entry).result);
+    const data = asRec(result.data);
+    return data.json ?? (Object.keys(data).length > 0 ? data : asRec(result).json);
+  };
+  const creditPayload = payloadOf(entries[0]);
+  const blocks = deepFind(creditPayload, "creditBlocks");
+  let total = 0;
+  let remaining = 0;
+  let sawTotal = false;
+  let sawRemaining = false;
+  if (Array.isArray(blocks)) {
+    for (const raw of blocks) {
+      const block = asRec(raw);
+      const amount = pickNum(block, "amount_mUsd");
+      const balance = pickNum(block, "balance_mUsd");
+      if (amount !== null) {
+        total += amount / 1e6;
+        sawTotal = true;
+      }
+      if (balance !== null) {
+        remaining += balance / 1e6;
+        sawRemaining = true;
+      }
+    }
+  }
+  if (!sawTotal || !sawRemaining) {
+    const balanceMicro = num(deepFind(creditPayload, "totalBalance_mUsd"));
+    if (balanceMicro !== null) {
+      return snapshotOk("kilo", [detailWindow("balance", "bal", `$${formatAmount(balanceMicro / 1e6)}`)]);
+    }
+    return errSnap("kilo", "no creditBlocks in tRPC response");
+  }
+  return usedLimitWindows("kilo", [
+    { id: "credits", label: "credits", used: total - remaining, limit: total, unit: "USD" },
+  ]);
+}
+
+async function fetchLlmProxy(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("llmproxy", ["LLM_PROXY_API_KEY", "LLMPROXY_API_KEY"]);
+  const base =
+    envFirst(["LLM_PROXY_BASE_URL", "LLMPROXY_BASE_URL"]) ??
+    configEnterpriseHost("llmproxy") ??
+    null;
+  if (!key || !base) return unauth("llmproxy", "missing LLM_PROXY_API_KEY / LLM_PROXY_BASE_URL");
+  // LLMProxyUsageFetcher: remaining lives nested per provider →
+  // quota_groups[].remaining_percent; utilization = 100 − min(remaining).
+  let host = base.replace(/\/$/, "").replace(/\/v1$/, "");
+  if (!host.startsWith("http")) host = `https://${host}`;
+  const res = await bearerJson("llmproxy", `${host}/v1/quota-stats`, key);
+  if (!res.ok) return res.snap;
+  const root = asRec(res.json);
+  const providers = asRec(root.providers);
+  let lowest: number | null = null;
+  let earliestReset: number | null = null;
+  for (const value of Object.values(providers)) {
+    const rawGroups = asRec(value).quota_groups ?? asRec(value).quotaGroups;
+    // quota_groups decodes as an array or a name-keyed object.
+    const groups = Array.isArray(rawGroups)
+      ? rawGroups
+      : rawGroups && typeof rawGroups === "object"
+        ? Object.values(rawGroups)
+        : [];
+    for (const raw of groups) {
+      const group = asRec(raw);
+      const remaining = pickNum(group, "remaining_percent", "remainingPercent");
+      if (remaining !== null) lowest = lowest === null ? remaining : Math.min(lowest, remaining);
+      const reset = isoFromIso(group.reset_time) ?? isoFromSecOrMs(group.reset_time);
+      if (reset) {
+        const t = Date.parse(reset);
+        if (earliestReset === null || t < earliestReset) earliestReset = t;
+      }
+    }
+  }
+  if (lowest === null) return errSnap("llmproxy", "no quota_groups remaining_percent in response");
+  return usedLimitWindows("llmproxy", [
+    {
+      id: "quota",
+      label: "quota",
+      utilization: 100 - lowest,
+      resetsAt: earliestReset !== null ? new Date(earliestReset).toISOString() : null,
+    },
+  ]);
+}
+
+async function fetchLiteLlm(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("litellm", ["LITELLM_API_KEY"]);
+  const base = envFirst(["LITELLM_BASE_URL"]) ?? configEnterpriseHost("litellm");
+  if (!key || !base) return unauth("litellm", "missing LITELLM_API_KEY / LITELLM_BASE_URL");
+  // LiteLLMUsageFetcher: /key/info only has spend; max_budget comes from
+  // /user/info?user_id= or /team/info?team_id= depending on key ownership.
+  let host = base.replace(/\/$/, "").replace(/\/v1$/, "");
+  if (!host.startsWith("http")) host = `https://${host}`;
+  const res = await bearerJson("litellm", `${host}/key/info`, key);
+  if (!res.ok) return res.snap;
+  const keyInfo = asRec(asRec(res.json).info ?? asRec(res.json).data ?? res.json);
+  let spend = pickNum(keyInfo, "spend", "total_spend");
+  let maxBudget = pickNum(keyInfo, "max_budget", "maxBudget");
+  const userId = pickString(keyInfo, "user_id", "userId");
+  const teamId = pickString(keyInfo, "team_id", "teamId");
+  if (maxBudget === null) {
+    const scoped = userId
+      ? await bearerJson("litellm", `${host}/user/info?user_id=${encodeURIComponent(userId)}`, key)
+      : teamId
+        ? await bearerJson("litellm", `${host}/team/info?team_id=${encodeURIComponent(teamId)}`, key)
+        : null;
+    if (scoped?.ok) {
+      const scopedInfo = asRec(deepFind(scoped.json, "user_info") ?? deepFind(scoped.json, "team_info") ?? asRec(scoped.json).info ?? scoped.json);
+      maxBudget = pickNum(scopedInfo, "max_budget", "maxBudget");
+      spend = pickNum(scopedInfo, "spend", "total_spend") ?? spend;
+    }
+  }
+  return usedLimitWindows("litellm", [
+    { id: "budget", label: "budget", used: spend, limit: maxBudget, unit: "USD" },
+  ]);
+}
+
+async function fetchClawRouter(): Promise<ProviderUsageSnapshot> {
+  const key = configApiKey("clawrouter", ["CLAWROUTER_API_KEY"]);
+  if (!key) return unauth("clawrouter", "missing CLAWROUTER_API_KEY");
+  const base =
+    envFirst(["CLAWROUTER_BASE_URL"]) ??
+    configEnterpriseHost("clawrouter") ??
+    "https://clawrouter.openclaw.ai";
+  let host = base.replace(/\/$/, "").replace(/\/v1$/, "");
+  if (!host.startsWith("http")) host = `https://${host}`;
+  const res = await bearerJson("clawrouter", `${host}/v1/usage`, key);
+  if (!res.ok) return res.snap;
+  const root = asRec(res.json);
+  const budget = asRec(root.budget ?? root);
+  const limitMicros = pickNum(budget, "limitMicros", "limit_micros");
+  const remainingMicros = pickNum(budget, "remainingMicros", "remaining_micros");
+  const spentMicros = pickNum(budget, "spentMicros", "spent_micros", "used_micros");
+  const limit = limitMicros !== null ? limitMicros / 1e6 : pickNum(budget, "limit", "limitUSD");
+  const remaining =
+    remainingMicros !== null ? remainingMicros / 1e6 : pickNum(budget, "remaining", "remainingUSD");
+  const used = spentMicros !== null ? spentMicros / 1e6 : pickNum(budget, "spent", "used");
+  // ClawRouterUsageFetcher derives the reset from budget.windowKey ("YYYY-MM"):
+  // the window resets at the start of the following month (UTC).
+  let resetsAt: string | null = null;
+  const windowKey = pickString(budget, "windowKey", "window_key");
+  const wk = windowKey?.match(/^(\d{4})-(\d{2})$/);
+  if (wk) {
+    resetsAt = new Date(Date.UTC(Number(wk[1]), Number(wk[2]), 1)).toISOString();
+  }
+  return usedLimitWindows("clawrouter", [
+    { id: "budget", label: "budget", used, limit, remaining, resetsAt, unit: "USD" },
+  ]);
+}
+
+// ── Cookie / web providers ──────────────────────────────────────────────────
+
+async function cookieProvider(
+  id: ProviderUsageId,
+  envKeys: string[],
+  url: string,
+  parse: (json: unknown, text: string) => ProviderUsageSnapshot,
+  extraHeaders: Record<string, string> = {},
+): Promise<ProviderUsageSnapshot> {
+  const cookie = configCookie(id, envKeys);
+  if (!cookie) return unauth(id, `missing cookie/env (${envKeys.join(", ") || "config"})`);
+  const res = await cookieJson(id, url, cookie, extraHeaders);
+  if (!res.ok) return res.snap;
+  return parse(res.json, res.text);
+}
+
+async function fetchOpenCode(): Promise<ProviderUsageSnapshot> {
+  // CodexBar's OpenCode source is browser cookies driving a two-step TanStack
+  // `/_server` function protocol (text/javascript responses) — deliberately not
+  // ported (web-scrape tier). Report honestly instead of probing invented URLs.
+  const cookie = configCookie("opencode", ["OPENCODE_COOKIE"]);
+  if (!cookie) {
+    return unauth("opencode", "missing OPENCODE_COOKIE / config cookie (browser session)");
+  }
+  return errSnap(
+    "opencode",
+    "OpenCode web usage uses the opencode.ai /_server function protocol, which this port does not implement",
+  );
+}
+
+// OpenCodeGoLocalUsageReader: hardcoded plan limits (USD) per window.
+const OPENCODEGO_LIMITS = { session: 12, weekly: 30, monthly: 60 } as const;
+
+async function fetchOpenCodeGo(): Promise<ProviderUsageSnapshot> {
+  // OpenCodeGoLocalUsageReader: parse ~/.local/share/opencode/opencode.db —
+  // sum assistant-message costs per window against the hardcoded plan limits.
+  const dbPath = path.join(os.homedir(), ".local", "share", "opencode", "opencode.db");
+  if (!fs.existsSync(dbPath)) {
+    return unauth("opencodego", "no local OpenCode Go database (~/.local/share/opencode/opencode.db)");
+  }
+  try {
+    const { default: Database } = await import("better-sqlite3");
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true, timeout: 250 });
+    try {
+      const rows = db
+        .prepare(
+          "SELECT json_extract(data,'$.time.created') AS created, json_extract(data,'$.cost') AS cost " +
+            "FROM message WHERE json_extract(data,'$.providerID')='opencode-go' AND json_extract(data,'$.role')='assistant'",
+        )
+        .all() as Array<{ created: unknown; cost: unknown }>;
+      const now = Date.now();
+      const sums = { session: 0, weekly: 0, monthly: 0 };
+      for (const row of rows) {
+        const created = num(row.created);
+        const cost = num(row.cost);
+        if (created === null || cost === null) continue;
+        const ms = created > 1e12 ? created : created * 1000;
+        const age = now - ms;
+        if (age < 0) continue;
+        if (age <= 5 * 3600_000) sums.session += cost;
+        if (age <= 7 * 86400_000) sums.weekly += cost;
+        if (age <= 30 * 86400_000) sums.monthly += cost;
+      }
+      return usedLimitWindows("opencodego", [
+        { id: "session", label: "session", used: sums.session, limit: OPENCODEGO_LIMITS.session },
+        { id: "weekly", label: "week", used: sums.weekly, limit: OPENCODEGO_LIMITS.weekly },
+        { id: "monthly", label: "month", used: sums.monthly, limit: OPENCODEGO_LIMITS.monthly },
+      ]);
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    return errSnap(
+      "opencodego",
+      `opencode.db read failed: ${err instanceof Error ? err.message : "unknown"}`,
+    );
+  }
+}
+
+async function fetchFactory(): Promise<ProviderUsageSnapshot> {
+  // FactoryStatusProbe: browser session cookies → GET /api/app/auth/me for the
+  // user id, then GET /api/organization/subscription/usage?useCache=true&userId=.
+  // All requests need Origin/Referer plus `x-factory-client: web-app`.
+  const cookie = configCookie("factory", ["FACTORY_COOKIE"]);
+  if (!cookie) return unauth("factory", "missing FACTORY_COOKIE / config cookie (browser session)");
+  const headers: Record<string, string> = {
+    Cookie: cookie,
+    Origin: "https://app.factory.ai",
+    Referer: "https://app.factory.ai/",
+    "x-factory-client": "web-app",
+    "User-Agent": CHROME_UA,
+  };
+  // Preferred source: billing limits (fiveHour/weekly/monthly usedPercent).
+  const limitsRes = await httpGet("https://api.factory.ai/api/billing/limits", headers);
+  if (limitsRes.ok) {
+    const pool = asRec(asRec(asRec(limitsRes.json).limits).standard ?? asRec(asRec(limitsRes.json).limits).core);
+    const winFrom = (bucket: Record<string, unknown>, id: string, label: string) => {
+      const pct = pickNum(bucket, "usedPercent");
+      const secs = pickNum(bucket, "secondsRemaining");
+      const resetsAt =
+        secs !== null && secs > 0
+          ? new Date(Date.now() + secs * 1000).toISOString()
+          : (isoFromIso(bucket.windowEnd) ?? isoFromSecOrMs(bucket.windowEnd));
+      return windowOf(id, label, pct, resetsAt);
+    };
+    const windows = [
+      winFrom(asRec(pool.fiveHour), "session", "session"),
+      winFrom(asRec(pool.weekly), "weekly", "week"),
+      winFrom(asRec(pool.monthly), "monthly", "month"),
+    ].filter((w): w is ProviderUsageWindow => w !== null);
+    if (windows.length > 0) return snapshotOk("factory", windows);
+  } else if (limitsRes.status === 401 || limitsRes.status === 403) {
+    return mapHttpFailure("factory", limitsRes);
+  }
+
+  // Fallback: subscription usage ratios (userId from auth/me when available).
+  const me = await httpGet("https://app.factory.ai/api/app/auth/me", headers);
+  if (!me.ok) return mapHttpFailure("factory", me);
+  const meRoot = asRec(me.json);
+  const userId =
+    pickString(meRoot, "id", "userId", "user_id") ??
+    pickString(asRec(meRoot.user), "id", "userId", "user_id");
+  const usageUrl = userId
+    ? `https://app.factory.ai/api/organization/subscription/usage?useCache=true&userId=${encodeURIComponent(userId)}`
+    : "https://app.factory.ai/api/organization/subscription/usage?useCache=true";
+  const usage = await httpGet(usageUrl, headers);
+  if (!usage.ok) return mapHttpFailure("factory", usage);
+  const root = asRec(usage.json);
+  const usageRec = asRec(root.usage ?? root);
+  const ratioPct = (o: Record<string, unknown>): number | null => {
+    const r = pickNum(o, "usedRatio", "used_ratio");
+    return r === null ? null : r * 100;
+  };
+  const endDate = num(asRec(root.usage ?? root).endDate) ?? num(deepFind(root, "endDate"));
+  const resetsAt = endDate !== null ? isoFromSecOrMs(endDate) : isoFromIso(deepFind(root, "endDate"));
+  return usedLimitWindows("factory", [
+    { id: "standard", label: "std", utilization: ratioPct(asRec(usageRec.standard)), resetsAt },
+    { id: "premium", label: "premium", utilization: ratioPct(asRec(usageRec.premium)), resetsAt },
+  ]);
+}
+
+async function fetchDevin(): Promise<ProviderUsageSnapshot> {
+  // DevinUsageFetcher: Bearer token only (no cookie mode); org from
+  // DEVIN_ORGANIZATION / DEVIN_ORG, tried as org/<slug>, organizations/<id>,
+  // and bare internal id (bare ids also send `x-cog-org-id`).
+  const token = configApiKey("devin", ["DEVIN_BEARER_TOKEN", "DEVIN_AUTHORIZATION"]);
+  if (!token) return unauth("devin", "missing DEVIN_BEARER_TOKEN / DEVIN_AUTHORIZATION");
+  const org = envFirst(["DEVIN_ORGANIZATION", "DEVIN_ORG"]);
+  if (!org) return unauth("devin", "missing DEVIN_ORGANIZATION / DEVIN_ORG");
+  const bearer = token.startsWith("Bearer ") ? token.slice(7) : token;
+  const cleaned = org.replace(/^\/+|\/+$/g, "");
+  const candidates = cleaned.includes("/")
+    ? [cleaned]
+    : [`org/${cleaned}`, `organizations/${cleaned}`, cleaned];
+
+  // DevinUsageSnapshot scales primary percentages with a strict < 1 check.
+  const pct = (v: number | null): number | null => (v === null ? null : v < 1 ? v * 100 : v);
+  let last: ProviderUsageSnapshot | null = null;
+  for (const candidate of candidates) {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${bearer}`,
+      "Accept-Language": "en-US,en;q=0.9",
+      "User-Agent": CHROME_UA,
+    };
+    if (!candidate.includes("/")) headers["x-cog-org-id"] = candidate;
+    const res = await httpGet(`https://app.devin.ai/api/${candidate}/billing/quota/usage`, headers);
+    if (!res.ok) {
+      last = mapHttpFailure("devin", res);
+      continue;
+    }
+    const root = asRec(res.json);
+    const daily = pct(pickNum(root, "daily_percentage", "dailyPercentage"));
+    const weekly = pct(pickNum(root, "weekly_percentage", "weeklyPercentage"));
+    const remaining = pickNum(root, "remaining_percent", "remainingPercent");
+    const fallback = remaining !== null ? 100 - (remaining <= 1 ? remaining * 100 : remaining) : null;
+    return usedLimitWindows("devin", [
+      {
+        id: "daily",
+        label: "day",
+        utilization: daily ?? fallback,
+        resetsAt: isoFromIso(root.daily_reset_at) ?? isoFromSecOrMs(root.daily_reset_at),
+      },
+      {
+        id: "weekly",
+        label: "week",
+        utilization: weekly,
+        resetsAt: isoFromIso(root.weekly_reset_at) ?? isoFromSecOrMs(root.weekly_reset_at),
+      },
+    ]);
+  }
+  return last ?? errSnap("devin", "no usable org path");
+}
+
+async function fetchMinimax(): Promise<ProviderUsageSnapshot> {
+  // MiniMaxUsageFetcher: GET /v1/token_plan/remains, falling back to
+  // /v1/api/openplatform/coding_plan/remains. `current_interval_usage_count`
+  // in model_remains[] is REMAINING (inverted), not used.
+  const key = configApiKey("minimax", ["MINIMAX_CODING_API_KEY", "MINIMAX_API_KEY"]);
+  if (!key) {
+    return unauth(
+      "minimax",
+      "missing MINIMAX_CODING_API_KEY / MINIMAX_API_KEY (web-cookie HTML path not ported)",
+    );
+  }
+  const host = (envFirst(["MINIMAX_HOST"]) ?? "https://api.minimax.io").replace(/\/$/, "");
+  const headers = { Authorization: `Bearer ${key}`, "MM-API-Source": "MissionControl" };
+  let res = await httpGet(`${host}/v1/token_plan/remains`, headers);
+  if (!res.ok) {
+    res = await httpGet(`${host}/v1/api/openplatform/coding_plan/remains`, headers);
+  }
+  if (!res.ok) return mapHttpFailure("minimax", res);
+  const root = asRec(res.json);
+  const remains = deepFind(root, "model_remains");
+  const windows: ProviderUsageWindow[] = [];
+  // Per entry: `*_usage_count` is REMAINING; prefer the explicit
+  // `*_remaining_percent`; reset = end_time if future else now + remains_time.
+  const entryWindow = (
+    entry: Record<string, unknown>,
+    prefix: "current_interval" | "current_weekly",
+    id: string,
+    label: string,
+  ): ProviderUsageWindow | null => {
+    const remainingPct = pickNum(entry, `${prefix}_remaining_percent`);
+    const remaining = pickNum(entry, `${prefix}_usage_count`);
+    const total = pickNum(entry, `${prefix}_total_count`);
+    const util =
+      remainingPct !== null
+        ? 100 - remainingPct
+        : remaining !== null && total !== null && total > 0
+          ? ((total - remaining) / total) * 100
+          : null;
+    const endKey = prefix === "current_interval" ? "end_time" : "weekly_end_time";
+    const remainsKey = prefix === "current_interval" ? "remains_time" : "weekly_remains_time";
+    let resetsAt = isoFromSecOrMs(entry[endKey]) ?? isoFromIso(entry[endKey]);
+    if (!resetsAt || Date.parse(resetsAt) <= Date.now()) {
+      const remainsSec = num(entry[remainsKey]);
+      if (remainsSec !== null) {
+        const sec = remainsSec > 1e6 ? remainsSec / 1000 : remainsSec;
+        resetsAt = new Date(Date.now() + sec * 1000).toISOString();
+      }
+    }
+    return windowOf(id, label, util, resetsAt);
+  };
+  if (Array.isArray(remains)) {
+    for (const raw of remains) {
+      const entry = asRec(raw);
+      const name = (pickString(entry, "model_name", "modelName", "name") ?? "plan").slice(0, 10);
+      const interval = entryWindow(entry, "current_interval", name, name);
+      if (interval) windows.push(interval);
+      const weekly = entryWindow(entry, "current_weekly", `${name}-wk`, `${name} wk`);
+      if (weekly) windows.push(weekly);
+    }
+  }
+  if (windows.length === 0) return errSnap("minimax", "no model_remains entries in response");
+  return snapshotOk("minimax", windows.slice(0, 4));
+}
+
+async function fetchManus(): Promise<ProviderUsageSnapshot> {
+  // ManusUsageFetcher: session_id cookie value used as a Bearer token on a
+  // Connect-RPC endpoint (no Cookie header). Monthly gauge only when
+  // proMonthlyCredits > 0; refresh window gated on maxRefreshCredits > 0.
+  const raw = configCookie("manus", ["MANUS_SESSION_TOKEN", "MANUS_SESSION_ID", "MANUS_COOKIE"]);
+  if (!raw) return unauth("manus", "missing MANUS_SESSION_TOKEN / MANUS_COOKIE");
+  const session = raw.includes("=") ? raw.match(/(?:^|;\s*)session_id=([^;]+)/i)?.[1] : raw;
+  if (!session) return unauth("manus", "session_id not found in cookie header");
+  const res = await httpPost(
+    "https://api.manus.im/user.v1.UserService/GetAvailableCredits",
+    {
+      Authorization: `Bearer ${session}`,
+      "Connect-Protocol-Version": "1",
+      Origin: "https://manus.im",
+      Referer: "https://manus.im/",
+    },
+    "{}",
+  );
+  if (!res.ok) return mapHttpFailure("manus", res);
+  const root = asRec(res.json);
+  const total = pickNum(root, "totalCredits", "total_credits");
+  const periodic = pickNum(root, "periodicCredits", "periodic_credits");
+  const proMonthly = pickNum(root, "proMonthlyCredits", "pro_monthly_credits");
+  const refresh = pickNum(root, "refreshCredits", "refresh_credits");
+  const maxRefresh = pickNum(root, "maxRefreshCredits", "max_refresh_credits");
+  const resetsAt = isoFromIso(root.nextRefreshTime ?? root.next_refresh_time);
+  const windows: ProviderUsageWindow[] = [];
+  if (proMonthly !== null && proMonthly > 0 && periodic !== null) {
+    const win = windowOf("monthly", "month", ((proMonthly - periodic) / proMonthly) * 100, resetsAt);
+    if (win) windows.push(win);
+  }
+  if (maxRefresh !== null && maxRefresh > 0 && refresh !== null) {
+    const win = windowOf("refresh", "refresh", ((maxRefresh - refresh) / maxRefresh) * 100, resetsAt);
+    if (win) windows.push(win);
+  }
+  if (total !== null) {
+    windows.push(detailWindow("credits", "credits", formatAmount(total, "credits")));
+  }
+  if (windows.length === 0) return errSnap("manus", "no credit fields in response");
+  return snapshotOk("manus", windows);
+}
+
+async function fetchPerplexity(): Promise<ProviderUsageSnapshot> {
+  // PerplexityUsageFetcher: credit-grants/cents model — balance_cents,
+  // total_usage_cents, credit_grants[{type, amount_cents, expires_at_ts}],
+  // renewal_date_ts (unix seconds). Session cookie is
+  // `__Secure-next-auth.session-token` (bare env tokens are wrapped as such).
+  const cookie = configCookie(
+    "perplexity",
+    ["PERPLEXITY_SESSION_TOKEN", "PERPLEXITY_COOKIE"],
+    "__Secure-next-auth.session-token",
+  );
+  if (!cookie) return unauth("perplexity", "missing PERPLEXITY_SESSION_TOKEN / PERPLEXITY_COOKIE");
+  const res = await httpGet(
+    "https://www.perplexity.ai/rest/billing/credits?version=2.18&source=default",
+    {
+      Cookie: cookie,
+      Origin: "https://www.perplexity.ai",
+      Referer: "https://www.perplexity.ai/account/usage",
+      "User-Agent": CHROME_UA,
+    },
+  );
+  if (!res.ok) return mapHttpFailure("perplexity", res);
+  const root = asRec(res.json);
+  const balanceCents = pickNum(root, "balance_cents", "balanceCents");
+  const usedCents = pickNum(root, "total_usage_cents", "totalUsageCents") ?? 0;
+  const purchasedPeriodCents = pickNum(root, "current_period_purchased_cents") ?? 0;
+  const grants = Array.isArray(root.credit_grants) ? root.credit_grants : [];
+  // PerplexityUsageSnapshot: group grants by type (promos filtered to
+  // non-expired), then attribute total_usage_cents recurring → purchased →
+  // promotional.
+  const nowSec = Date.now() / 1000;
+  let recurringSum = 0;
+  let promoSum = 0;
+  let purchasedFromGrants = 0;
+  for (const raw of grants) {
+    const grant = asRec(raw);
+    const amount = pickNum(grant, "amount_cents", "amountCents");
+    if (amount === null) continue;
+    const type = String(grant.type ?? "");
+    if (type === "recurring") recurringSum += amount;
+    else if (type === "promotional") {
+      const expires = pickNum(grant, "expires_at_ts");
+      if (expires === null || expires > nowSec) promoSum += amount;
+    } else if (type === "purchased") purchasedFromGrants += amount;
+  }
+  const purchasedSum = Math.max(purchasedFromGrants, purchasedPeriodCents);
+  let remaining = usedCents;
+  const usedFromRecurring = Math.min(remaining, recurringSum);
+  remaining -= usedFromRecurring;
+  const usedFromPurchased = Math.min(remaining, purchasedSum);
+  remaining -= usedFromPurchased;
+  const usedFromPromo = Math.min(remaining, promoSum);
+
+  const resetsAt = isoFromSecOrMs(root.renewal_date_ts ?? root.renewalDateTs);
+  const clampPct = (used: number, total: number) => Math.min(100, Math.max(0, (used / total) * 100));
+  const windows: ProviderUsageWindow[] = [];
+  if (recurringSum > 0) {
+    const win = windowOf("credits", "monthly", clampPct(usedFromRecurring, recurringSum), resetsAt);
+    if (win) windows.push(win);
+  }
+  if (promoSum > 0) {
+    const win = windowOf("promo", "bonus", clampPct(usedFromPromo, promoSum));
+    if (win) windows.push(win);
+  }
+  if (purchasedSum > 0) {
+    const win = windowOf("purchased", "purchased", clampPct(usedFromPurchased, purchasedSum));
+    if (win) windows.push(win);
+  }
+  if (balanceCents !== null) {
+    windows.push(detailWindow("balance", "bal", `$${formatAmount(balanceCents / 100)}`, resetsAt));
+  }
+  if (windows.length === 0) return errSnap("perplexity", "no credit fields in response");
+  return snapshotOk("perplexity", windows);
+}
+
+async function fetchMistral(): Promise<ProviderUsageSnapshot> {
+  // MistralUsageFetcher: the only real %-gauge is the Vibe window on
+  // console.mistral.ai (usage_percentage + reset_at); the admin credits
+  // endpoint gives wallet_amount/credit_notes_amount/ongoing_usage_balance
+  // (available = wallet + credit_notes − ongoing). The v2/usage per-token
+  // spend computation (token counts × price table) is not ported.
+  const cookie = configCookie("mistral", ["MISTRAL_COOKIE"]);
+  if (!cookie) return unauth("mistral", "missing MISTRAL_COOKIE (ory_session_* + csrftoken cookies)");
+  const csrf = cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/i)?.[1];
+  const windows: ProviderUsageWindow[] = [];
+  // MistralUsageFetcher: exact tRPC batch query string; header is X-CSRFToken
+  // on the console host, X-CSRFTOKEN on admin.
+  const vibeHeaders: Record<string, string> = { Accept: "*/*", Cookie: cookie };
+  if (csrf) vibeHeaders["X-CSRFToken"] = csrf;
+  const vibe = await httpGet(
+    "https://console.mistral.ai/api-ui/trpc/billing.vibeUsage?batch=1&input=%7B%220%22%3A%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%2C%22v%22%3A1%7D%7D%7D",
+    vibeHeaders,
+  );
+  if (vibe.ok) {
+    const pct = num(deepFind(vibe.json, "usage_percentage") ?? deepFind(vibe.json, "vibe_usage"));
+    const reset = deepFind(vibe.json, "reset_at");
+    const win = windowOf("vibe", "vibe", pct, isoFromIso(reset) ?? isoFromSecOrMs(reset));
+    if (win) windows.push(win);
+  }
+  const creditHeaders: Record<string, string> = {
+    Accept: "*/*",
+    Cookie: cookie,
+    Origin: "https://admin.mistral.ai",
+    Referer: "https://admin.mistral.ai/organization/billing",
+  };
+  if (csrf) creditHeaders["X-CSRFTOKEN"] = csrf;
+  const credits = await httpGet("https://admin.mistral.ai/api/billing/credits", creditHeaders);
+  if (credits.ok) {
+    const c = asRec(credits.json);
+    const wallet = pickNum(c, "wallet_amount", "walletAmount");
+    const notes = pickNum(c, "credit_notes_amount", "creditNotesAmount");
+    const ongoing = pickNum(c, "ongoing_usage_balance", "ongoingUsageBalance");
+    if (wallet !== null || notes !== null) {
+      const available = (wallet ?? 0) + (notes ?? 0) - (ongoing ?? 0);
+      windows.push(detailWindow("credits", "credits", formatAmount(available, "EUR")));
+    }
+  }
+  if (windows.length === 0) {
+    if (!vibe.ok && (vibe.status === 401 || vibe.status === 403)) return mapHttpFailure("mistral", vibe);
+    return errSnap("mistral", "no vibe usage or credits fields in response");
+  }
+  return snapshotOk("mistral", windows);
+}
+
+async function fetchT3Chat(): Promise<ProviderUsageSnapshot> {
+  // T3ChatUsageFetcher: tRPC batch GET (JSONL response) with web-client
+  // headers; fields usageFourHourPercentage / usageMonthPercentage.
+  const cookie = configCookie("t3chat", ["T3CHAT_COOKIE", "T3_COOKIE"]);
+  if (!cookie) return unauth("t3chat", "missing T3CHAT_COOKIE (full browser cookie header)");
+  const input = encodeURIComponent(
+    JSON.stringify({ "0": { json: { sessionId: null }, meta: { values: { sessionId: ["undefined"] } } } }),
+  );
+  const res = await httpGet(`https://t3.chat/api/trpc/getCustomerData?batch=1&input=${input}`, {
+    Cookie: cookie,
+    "trpc-accept": "application/jsonl",
+    "x-trpc-source": "web-client",
+    "x-trpc-batch": "true",
+    Origin: "https://t3.chat",
+    Referer: "https://t3.chat/",
+    "User-Agent": CHROME_UA,
+  });
+  if (!res.ok) return mapHttpFailure("t3chat", res);
+  // JSONL: parse every line, search the trees for the usage fields.
+  const parsed: unknown[] = [];
+  if (res.json) parsed.push(res.json);
+  for (const line of res.text.split("\n")) {
+    const t = line.trim();
+    if (!t.startsWith("{") && !t.startsWith("[")) continue;
+    try {
+      parsed.push(JSON.parse(t));
+    } catch {
+      /* skip non-JSON lines */
+    }
+  }
+  const find = (key: string): unknown => {
+    for (const p of parsed) {
+      const v = deepFind(p, key);
+      if (v !== undefined) return v;
+    }
+    return undefined;
+  };
+  const fourHour = num(find("usageFourHourPercentage"));
+  const fourHourReset = isoFromIso(find("usageFourHourNextResetAt")) ?? isoFromSecOrMs(find("usageFourHourNextResetAt"));
+  const month = num(find("usageMonthPercentage")) ?? num(find("usagePeriodPercentage"));
+  const monthReset = isoFromIso(find("currentPeriodEnd")) ?? isoFromSecOrMs(find("currentPeriodEnd"));
+  return usedLimitWindows("t3chat", [
+    { id: "base", label: "4h", utilization: fourHour, resetsAt: fourHourReset },
+    { id: "month", label: "month", utilization: month, resetsAt: monthReset },
+  ]);
+}
+
+async function fetchWindsurf(): Promise<ProviderUsageSnapshot> {
+  // WindsurfStatusProbe: parse `windsurf.settings.cachedPlanInfo` from the
+  // local state.vscdb — quotaUsage.{daily,weekly}RemainingPercent are
+  // REMAINING (util = 100 − remaining), resets are unix seconds. CodexBar's
+  // path is macOS-only; the %APPDATA% candidate is a port extension for the
+  // same VSCode-fork layout. The web GetPlanStatus endpoint is Connect-RPC
+  // protobuf and is not ported.
+  const home = os.homedir();
+  const candidates =
+    process.platform === "win32"
+      ? [path.join(process.env.APPDATA || path.join(home, "AppData", "Roaming"), "Windsurf", "User", "globalStorage", "state.vscdb")]
+      : process.platform === "darwin"
+        ? [path.join(home, "Library", "Application Support", "Windsurf", "User", "globalStorage", "state.vscdb")]
+        : [path.join(process.env.XDG_CONFIG_HOME?.trim() || path.join(home, ".config"), "Windsurf", "User", "globalStorage", "state.vscdb")];
+  const dbPath = candidates.find((p) => fs.existsSync(p));
+  if (!dbPath) {
+    return unauth("windsurf", "no local Windsurf state.vscdb (web plan-status endpoint is protobuf-only, not ported)");
+  }
+  try {
+    const { default: Database } = await import("better-sqlite3");
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true, timeout: 250 });
+    let raw: string | null = null;
+    try {
+      const row = db
+        .prepare("SELECT value FROM ItemTable WHERE key = 'windsurf.settings.cachedPlanInfo' LIMIT 1")
+        .get() as { value?: unknown } | undefined;
+      if (typeof row?.value === "string") raw = row.value;
+      else if (Buffer.isBuffer(row?.value)) raw = row.value.toString("utf8");
+    } finally {
+      db.close();
+    }
+    if (!raw) return unauth("windsurf", "no cachedPlanInfo in Windsurf state — sign in to Windsurf first");
+    const info = asRec(JSON.parse(raw));
+    const quota = asRec(info.quotaUsage);
+    const usage = asRec(info.usage);
+    const windows: ProviderUsageWindow[] = [];
+    const dailyRemaining = pickNum(quota, "dailyRemainingPercent");
+    const weeklyRemaining = pickNum(quota, "weeklyRemainingPercent");
+    const daily = windowOf("daily", "day", dailyRemaining === null ? null : 100 - dailyRemaining, isoFromSecOrMs(quota.dailyResetAtUnix));
+    if (daily) windows.push(daily);
+    const weekly = windowOf("weekly", "week", weeklyRemaining === null ? null : 100 - weeklyRemaining, isoFromSecOrMs(quota.weeklyResetAtUnix));
+    if (weekly) windows.push(weekly);
+    if (windows.length === 0) {
+      const credits = windowOf(
+        "credits",
+        "credits",
+        percentUsed(pickNum(usage, "usedFlexCredits"), pickNum(usage, "flexCredits")) ??
+          percentUsed(pickNum(usage, "usedMessages"), pickNum(usage, "messages")),
+        isoFromSecOrMs(info.endTimestamp),
+      );
+      if (credits) windows.push(credits);
+    }
+    if (windows.length === 0) return errSnap("windsurf", "cachedPlanInfo had no quota fields");
+    return snapshotOk("windsurf", windows);
+  } catch (err) {
+    return errSnap("windsurf", `state.vscdb read failed: ${err instanceof Error ? err.message : "unknown"}`);
+  }
+}
+
+async function fetchMimo(): Promise<ProviderUsageSnapshot> {
+  // MiMoUsageFetcher: needs `api-platform_serviceToken` + `userId` cookies.
+  // Real utilization comes from /tokenPlan/usage (monthUsage.items[0]);
+  // /balance is a currency string shown as a detail line.
+  const cookie = configCookie("mimo", ["MIMO_COOKIE"]);
+  if (!cookie) {
+    return unauth("mimo", "missing MIMO_COOKIE (api-platform_serviceToken + userId cookies)");
+  }
+  if (!cookie.includes("api-platform_serviceToken=")) {
+    return unauth("mimo", "MIMO_COOKIE must contain api-platform_serviceToken and userId cookies");
+  }
+  const base = (envFirst(["MIMO_API_URL"]) ?? "https://platform.xiaomimimo.com/api/v1").replace(/\/$/, "");
+  const headers: Record<string, string> = {
+    Cookie: cookie,
+    Origin: "https://platform.xiaomimimo.com",
+    Referer: "https://platform.xiaomimimo.com/",
+    "x-timeZone": Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+    "User-Agent": CHROME_UA,
+  };
+  const windows: ProviderUsageWindow[] = [];
+  const usage = await httpGet(`${base}/tokenPlan/usage`, headers);
+  if (usage.ok) {
+    const month = asRec(deepFind(usage.json, "monthUsage"));
+    const item = asRec(Array.isArray(month.items) ? month.items[0] : null);
+    const used = pickNum(item, "used");
+    const limit = pickNum(item, "limit");
+    const pctRaw = pickNum(item, "percent");
+    const pct = pctRaw !== null ? (pctRaw <= 1 ? pctRaw * 100 : pctRaw) : percentUsed(used, limit);
+    const win = windowOf("monthly", "month", pct);
+    if (win) windows.push(win);
+  } else if (usage.status === 401 || usage.status === 403) {
+    return mapHttpFailure("mimo", usage);
+  }
+  const bal = await httpGet(`${base}/balance`, headers);
+  if (bal.ok) {
+    const data = asRec(asRec(bal.json).data ?? bal.json);
+    const balance = pickString(data, "balance") ?? String(pickNum(data, "balance") ?? "");
+    const currency = pickString(data, "currency") ?? "";
+    if (balance) windows.push(detailWindow("balance", "bal", `${balance}${currency ? ` ${currency}` : ""}`));
+  }
+  if (windows.length === 0) return errSnap("mimo", "no tokenPlan usage or balance in response");
+  return snapshotOk("mimo", windows);
+}
+
+async function fetchDoubao(): Promise<ProviderUsageSnapshot> {
+  // DoubaoUsageFetcher: minimal (paid) chat-completions probe purely for the
+  // x-ratelimit-* RESPONSE HEADERS; tries CodexBar's model candidates in
+  // order. Unreliable limits → omit the gauge (never fake 0%). The SigV4
+  // coding-plan quota path is not ported.
+  const key = configApiKey("doubao", ["ARK_API_KEY", "VOLCENGINE_API_KEY", "DOUBAO_API_KEY"]);
+  if (!key) return unauth("doubao", "missing ARK_API_KEY / DOUBAO_API_KEY");
+  const models = [
+    envFirst(["DOUBAO_MODEL"]),
+    "doubao-seed-2.0-code",
+    "doubao-1.5-pro-32k",
+    "doubao-lite-32k",
+  ].filter((m): m is string => !!m);
+  let last: ProviderUsageSnapshot | null = null;
+  for (const model of models) {
+    const res = await httpPost(
+      "https://ark.cn-beijing.volces.com/api/coding/v3/chat/completions",
+      { Authorization: `Bearer ${key}` },
+      JSON.stringify({ model, max_tokens: 1, messages: [{ role: "user", content: "hi" }] }),
+    );
+    // DoubaoUsageFetcher accepts 200 AND 429 — a throttled response still
+    // carries the limit headers (429 needs only the limit to be reliable).
+    const is429 = !res.ok && res.status === 429;
+    if (!res.ok && !is429) {
+      last = mapHttpFailure("doubao", res);
+      if (res.status === 401 || res.status === 403) return last;
+      continue;
+    }
+    const limit = num(res.headers["x-ratelimit-limit-requests"]);
+    const remaining = num(res.headers["x-ratelimit-remaining-requests"]);
+    const reset = res.headers["x-ratelimit-reset-requests"];
+    const reliable = is429 ? limit !== null : limit !== null && remaining !== null;
+    if (reliable && limit !== null && limit > 0) {
+      const used = Math.max(0, limit - (remaining ?? 0));
+      return usedLimitWindows("doubao", [
+        {
+          id: "requests",
+          label: "req",
+          used,
+          limit,
+          resetsAt: isoFromIso(reset) ?? isoFromSecOrMs(reset),
+        },
+      ]);
+    }
+    if (is429) return emptyProviderSnapshot("doubao", "rate_limited", "HTTP 429 without limit headers");
+    // Key works but the limiter headers are unreliable — honest text, no gauge.
+    return snapshotOk("doubao", [detailWindow("api", "api", "key ok, no quota headers")]);
+  }
+  return last ?? errSnap("doubao", "no Doubao model accepted the probe");
+}
+
+async function fetchSakana(): Promise<ProviderUsageSnapshot> {
+  // SakanaUsageFetcher: HTML billing page scrape — split <p> structure
+  // (<p>5-hour</p> … <p>N% used</p>). A page without those markers is a
+  // failure (likely the login page), never a fake-healthy window.
+  const cookie = configCookie("sakana", ["SAKANA_COOKIE"]);
+  if (!cookie) return unauth("sakana", "missing SAKANA_COOKIE (browser session)");
+  const res = await httpGet("https://console.sakana.ai/billing", {
+    Cookie: cookie,
+    Accept: "text/html,application/xhtml+xml",
+    "Accept-Language": "en-US,en;q=0.9",
+    "User-Agent": CHROME_UA,
+  });
+  if (!res.ok) return mapHttpFailure("sakana", res);
+  const text = res.text;
+  const scrape = (marker: string): number | null => {
+    const re = new RegExp(
+      `<p[^>]*>\\s*${marker}\\s*</p>[\\s\\S]{0,400}?<p[^>]*>\\s*(\\d+(?:\\.\\d+)?)\\s*%\\s*used\\s*</p>`,
+      "i",
+    );
+    const m = text.match(re);
+    return m?.[1] != null ? Number(m[1]) : null;
+  };
+  const session = scrape("5-hour");
+  const weekly = scrape("Weekly");
+  if (session === null && weekly === null) {
+    if (/sign\s*in|log\s*in/i.test(text)) return unauth("sakana", "billing page redirected to login");
+    return errSnap("sakana", "billing page had no usage markers");
+  }
+  return usedLimitWindows("sakana", [
+    { id: "session", label: "session", utilization: session },
+    { id: "weekly", label: "week", utilization: weekly },
+  ]);
+}
+
+async function fetchAbacus(): Promise<ProviderUsageSnapshot> {
+  // AbacusUsageFetcher: {success, result:{totalComputePoints, computePointsLeft}}.
+  return cookieProvider(
+    "abacus",
+    ["ABACUS_COOKIE"],
+    "https://apps.abacus.ai/api/_getOrganizationComputePoints",
+    (json) => {
+      const root = asRec(json);
+      if (root.success !== true) {
+        return errSnap("abacus", "compute points request unsuccessful");
+      }
+      const result = asRec(root.result);
+      const total = pickNum(result, "totalComputePoints");
+      const left = pickNum(result, "computePointsLeft");
+      if (total === null || left === null || total <= 0) {
+        return errSnap("abacus", "missing totalComputePoints/computePointsLeft");
+      }
+      return usedLimitWindows("abacus", [
+        { id: "compute", label: "pts", used: total - left, limit: total },
+      ]);
+    },
+  );
+}
+
+// CommandCodePlanCatalog: planId → monthly USD allowance.
+const COMMANDCODE_PLANS: Record<string, number> = {
+  "individual-go": 10,
+  "individual-pro": 30,
+  "individual-max": 150,
+  "individual-ultra": 300,
+};
+
+async function fetchCommandCode(): Promise<ProviderUsageSnapshot> {
+  // CommandCodeUsageFetcher: GET /internal/billing/credits (+ best-effort
+  // /internal/billing/subscriptions for the plan limit). monthlyCredits is
+  // REMAINING USD; plan catalog supplies the monthly total.
+  const cookie = configCookie(
+    "commandcode",
+    ["COMMANDCODE_COOKIE", "COMMAND_CODE_COOKIE"],
+    "__Secure-better-auth.session_token",
+  );
+  if (!cookie) return unauth("commandcode", "missing COMMANDCODE_COOKIE (browser session)");
+  const headers = {
+    Cookie: cookie,
+    Accept: "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+    Origin: "https://commandcode.ai",
+    Referer: "https://commandcode.ai/",
+    "User-Agent": CHROME_UA,
+  };
+  const res = await httpGet("https://api.commandcode.ai/internal/billing/credits", headers);
+  if (!res.ok) return mapHttpFailure("commandcode", res);
+  const credits = asRec(asRec(res.json).credits ?? res.json);
+  const monthly = pickNum(credits, "monthlyCredits", "monthly_credits");
+  const purchased = pickNum(credits, "purchasedCredits", "purchased_credits");
+  const premium = pickNum(credits, "premiumMonthlyCredits", "premium_monthly_credits");
+  if (monthly === null) return errSnap("commandcode", "no credits fields in response");
+
+  // Best-effort plan lookup for a real percent window.
+  let planLimit: number | null = null;
+  let resetsAt: string | null = null;
+  const subs = await httpGet("https://api.commandcode.ai/internal/billing/subscriptions", headers);
+  if (subs.ok) {
+    const subsRoot = asRec(subs.json);
+    const data = asRec(subsRoot.data);
+    const planId = pickString(data, "planId", "plan_id")?.toLowerCase();
+    if (planId && COMMANDCODE_PLANS[planId] !== undefined) planLimit = COMMANDCODE_PLANS[planId]!;
+    resetsAt = isoFromIso(data.currentPeriodEnd ?? data.current_period_end);
+  }
+  const windows: ProviderUsageWindow[] = [];
+  if (planLimit !== null && planLimit > 0) {
+    const used = Math.max(0, Math.min(planLimit, planLimit - monthly));
+    const win = windowOf("monthly", "month", (used / planLimit) * 100, resetsAt);
+    if (win) windows.push(win);
+  } else {
+    windows.push(detailWindow("monthly", "month", `$${formatAmount(monthly)} left`, resetsAt));
+  }
+  if (premium !== null && premium > 0) {
+    windows.push(detailWindow("premium", "premium", `$${formatAmount(premium)} left`));
+  }
+  if (purchased !== null && purchased > 0) {
+    windows.push(detailWindow("purchased", "extra", `$${formatAmount(purchased)}`));
+  }
+  return snapshotOk("commandcode", windows);
+}
+
+async function fetchQoder(): Promise<ProviderUsageSnapshot> {
+  // QoderUsageFetcher: browser-gated (X-Requested-With + Bx-V headers);
+  // values nested at totalQuota.quotaSummary (+ optional sharedQuota merge).
+  const cookie = configCookie("qoder", ["QODER_COOKIE"]);
+  if (!cookie) return unauth("qoder", "missing QODER_COOKIE (browser session)");
+  const res = await httpGet("https://qoder.com/api/v2/me/usages/big_model_credits", {
+    Cookie: cookie,
+    "X-Requested-With": "XMLHttpRequest",
+    "Bx-V": "2.5.35",
+    "Accept-Language": "en-US,en;q=0.9",
+    Origin: "https://qoder.com",
+    Referer: "https://qoder.com/account/usage",
+    "User-Agent": CHROME_UA,
+  });
+  if (!res.ok) return mapHttpFailure("qoder", res);
+  const root = asRec(res.json);
+  const data = asRec(root.data ?? root);
+  const summary = (camel: string, snake: string) =>
+    asRec(asRec(data[camel] ?? data[snake]).quotaSummary ?? asRec(data[camel] ?? data[snake]).quota_summary);
+  const total = summary("totalQuota", "total_quota");
+  const shared = summary("sharedQuota", "shared_quota");
+  let used = pickNum(total, "usedValue", "used_value");
+  let limit = pickNum(total, "limitValue", "limit_value");
+  const sharedUsed = pickNum(shared, "usedValue", "used_value");
+  const sharedLimit = pickNum(shared, "limitValue", "limit_value");
+  if (sharedUsed !== null) used = (used ?? 0) + sharedUsed;
+  if (sharedLimit !== null) limit = (limit ?? 0) + sharedLimit;
+  const pct = pickNum(total, "usagePercentage", "usage_percentage");
+  const reset = data.nextResetAt ?? data.next_reset_at;
+  const resetsAt = isoFromIso(reset) ?? isoFromSecOrMs(reset);
+  return usedLimitWindows("qoder", [
+    { id: "credits", label: "credits", used, limit, utilization: used !== null && limit !== null && limit > 0 ? null : pct, resetsAt },
+  ]);
+}
+
+async function fetchStepFun(): Promise<ProviderUsageSnapshot> {
+  // StepFunUsageFetcher: Oasis-Token cookie + oasis-* headers; success gate
+  // `status == 1`; *_left_rate fields are remaining fractions (0..1).
+  const token =
+    envFirst(["STEPFUN_TOKEN"]) ??
+    configApiKey("stepfun", ["STEPFUN_TOKEN", "STEPFUN_API_KEY"]) ??
+    configCookie("stepfun", ["STEPFUN_COOKIE"]);
+  if (!token) {
+    return unauth("stepfun", "missing STEPFUN_TOKEN (Oasis token; password login not ported)");
+  }
+  const oasis = token.includes("Oasis-Token=")
+    ? token
+    : token.includes("=")
+      ? token
+      : `Oasis-Token=${token}`;
+  const webId = oasis.match(/(?:^|;\s*)Oasis-Webid=([^;]+)/i)?.[1] ?? envFirst(["STEPFUN_WEBID"]);
+  const headers: Record<string, string> = {
+    Cookie: webId && !oasis.includes("Oasis-Webid=") ? `${oasis}; Oasis-Webid=${webId}` : oasis,
+    "Content-Type": "application/json",
+    "oasis-appid": "10300",
+    "oasis-platform": "web",
+    Origin: "https://platform.stepfun.com",
+    Referer: "https://platform.stepfun.com/",
+    "User-Agent": CHROME_UA,
+  };
+  if (webId) headers["oasis-webid"] = webId;
+  const res = await httpPost(
+    "https://platform.stepfun.com/api/step.openapi.devcenter.Dashboard/QueryStepPlanRateLimit",
+    headers,
+    "{}",
+  );
+  if (!res.ok) return mapHttpFailure("stepfun", res);
+  const root = asRec(res.json);
+  const status = pickNum(root, "status");
+  if (status !== null && status !== 1) {
+    return errSnap("stepfun", `dashboard RPC returned status ${status}`);
+  }
+  const fiveLeft = pickNum(root, "five_hour_usage_left_rate", "fiveHourUsageLeftRate");
+  const weekLeft = pickNum(root, "weekly_usage_left_rate", "weeklyUsageLeftRate");
+  return usedLimitWindows("stepfun", [
+    {
+      id: "session",
+      label: "session",
+      utilization: percentFromRemaining(fiveLeft),
+      resetsAt: isoFromIso(root.five_hour_usage_reset_time) ?? isoFromSecOrMs(root.five_hour_usage_reset_time),
+    },
+    {
+      id: "weekly",
+      label: "week",
+      utilization: percentFromRemaining(weekLeft),
+      resetsAt: isoFromIso(root.weekly_usage_reset_time) ?? isoFromSecOrMs(root.weekly_usage_reset_time),
+    },
+  ]);
+}
+
+async function fetchAlibaba(): Promise<ProviderUsageSnapshot> {
+  // AlibabaCodingPlanUsageFetcher: the DashScope path POSTs a signed
+  // queryCodingPlanInstanceInfoV2 RPC and the console path needs a scraped
+  // sec_token + CSRF form POST — both beyond this port's web-scrape tier.
+  // Resolve credentials honestly and report the gap instead of probing
+  // invented endpoints.
+  const key = configApiKey("alibaba", ["ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY"]);
+  const cookie = configCookie("alibaba", ["ALIBABA_CODING_PLAN_COOKIE", "ALIBABA_COOKIE"]);
+  if (!key && !cookie) {
+    return unauth("alibaba", "missing ALIBABA_CODING_PLAN_API_KEY / DASHSCOPE_API_KEY / console cookie");
+  }
+  return errSnap(
+    "alibaba",
+    "Alibaba coding-plan quota needs the signed console RPC (sec_token + CSRF); not supported by this port",
+  );
+}
+
+async function fetchAlibabaTokenPlan(): Promise<ProviderUsageSnapshot> {
+  // AlibabaTokenPlanUsageFetcher: GetSubscriptionSummary is a sec_token +
+  // CSRF form POST on the console — same unported tier as the coding plan.
+  const cookie = configCookie("alibabatokenplan", ["ALIBABA_TOKEN_PLAN_COOKIE", "ALIBABA_COOKIE"]);
+  if (!cookie) return unauth("alibabatokenplan", "missing ALIBABA_TOKEN_PLAN_COOKIE (console session)");
+  return errSnap(
+    "alibabatokenplan",
+    "Alibaba token-plan quota needs the signed console RPC (sec_token + CSRF); not supported by this port",
+  );
+}
+
+async function fetchAugment(): Promise<ProviderUsageSnapshot> {
+  // AugmentStatusProbe: GET /api/credits → usageUnits* fields;
+  // limit = usageUnitsAvailable, else remaining + consumed.
+  return cookieProvider(
+    "augment",
+    ["AUGMENT_COOKIE"],
+    "https://app.augmentcode.com/api/credits",
+    (json) => {
+      const root = asRec(json);
+      const remaining = pickNum(root, "usageUnitsRemaining");
+      const consumed = pickNum(root, "usageUnitsConsumedThisBillingCycle");
+      const available = pickNum(root, "usageUnitsAvailable");
+      const limit =
+        available ?? (remaining !== null && consumed !== null ? remaining + consumed : null);
+      return usedLimitWindows("augment", [
+        { id: "credits", label: "credits", used: consumed, limit, remaining, unit: "units" },
+      ]);
+    },
+  );
+}
+
+async function fetchGrok(): Promise<ProviderUsageSnapshot> {
+  // CodexBar's Grok sources are the grok CLI JSON-RPC (`x.ai/billing`) and a
+  // gRPC-web protobuf endpoint — neither speaks plain JSON, so this port does
+  // not fetch usage. It resolves credentials honestly: a valid ~/.grok/auth.json
+  // entry (map keyed by scope URL; prefer the OIDC scope, respect expiry)
+  // reports the protocol gap; anything else is unauthenticated. CodexBar
+  // likewise never projects ~/.grok/sessions into a usage window.
+  const auth = readJsonHome(".grok", "auth.json");
+  let token: string | null = null;
+  if (auth) {
+    const entries = Object.entries(auth)
+      .filter(([, v]) => v && typeof v === "object")
+      .sort(([a], [b]) => {
+        const rank = (k: string) => (k.includes("auth.x.ai") ? 0 : 1);
+        return rank(a) - rank(b);
+      });
+    for (const [, v] of entries) {
+      const entry = v as Record<string, unknown>;
+      const expires = num(entry.expires_at ?? entry.expiresAt);
+      if (expires !== null && expires * (expires > 1e12 ? 1 : 1000) < Date.now()) continue;
+      token = pickString(entry, "key", "access_token", "token");
+      if (token) break;
+    }
+    token ??= pickString(auth, "key", "access_token", "token");
+  }
+  if (!token) return unauth("grok", "missing ~/.grok/auth.json (run `grok` and sign in)");
+  return errSnap(
+    "grok",
+    "Grok billing requires the grok CLI JSON-RPC or gRPC-web protobuf endpoint; not supported by this port",
+  );
+}
+
+async function fetchBedrock(): Promise<ProviderUsageSnapshot> {
+  const access = envFirst(["AWS_ACCESS_KEY_ID"]);
+  const secret = envFirst(["AWS_SECRET_ACCESS_KEY"]);
+  const profile = envFirst(["AWS_PROFILE"]);
+  if (!access && !profile) {
+    return unauth("bedrock", "missing AWS_ACCESS_KEY_ID or AWS_PROFILE");
+  }
+  if (access && !secret) return unauth("bedrock", "missing AWS_SECRET_ACCESS_KEY");
+  const budget = num(envFirst(["CODEXBAR_BEDROCK_BUDGET", "BEDROCK_BUDGET"]));
+  // Optional CodexBar-compatible override: CODEXBAR_BEDROCK_API_URL points at
+  // a cost endpoint/mock returning spend JSON.
+  const costUrl = envFirst(["CODEXBAR_BEDROCK_API_URL"]);
+  if (costUrl) {
+    const res = await httpGet(costUrl, {});
+    if (!res.ok) return mapHttpFailure("bedrock", res);
+    const root = asRec(res.json);
+    const spend = pickNum(root, "spend", "amount", "BlendedCost");
+    return usedLimitWindows("bedrock", [
+      { id: "month", label: "month", used: spend, limit: budget, utilization: percentUsed(spend, budget), unit: "USD" },
+    ]);
+  }
+  // Cost Explorer needs an AWS SigV4 client — not ported. Credentials exist,
+  // so this is a capability gap, not a login problem.
+  return errSnap("bedrock", "Bedrock spend needs AWS Cost Explorer (SigV4); set CODEXBAR_BEDROCK_API_URL or use the AWS console");
+}
+
+async function fetchVertexAI(): Promise<ProviderUsageSnapshot> {
+  // ADC file probe
+  const adc =
+    readJsonHome(".config", "gcloud", "application_default_credentials.json") ??
+    (() => {
+      const p = process.env.GOOGLE_APPLICATION_CREDENTIALS?.trim();
+      if (!p) return null;
+      try {
+        const raw = fs.readFileSync(p, "utf8");
+        return JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })();
+  if (!adc) return unauth("vertexai", "missing Google ADC (~/.config/gcloud/application_default_credentials.json)");
+  const token = pickString(adc, "access_token", "accessToken", "token");
+  // Refresh tokens alone mean we have credentials but may need refresh — still not unauthenticated.
+  const refresh = pickString(adc, "refresh_token", "refreshToken");
+  if (!token && !refresh) return unauth("vertexai", "ADC file missing tokens");
+  // Quota metrics need a live access token + Cloud Monitoring time-series
+  // parsing (and usually a token refresh) — not ported. Credentials exist,
+  // so report the gap rather than a fake-healthy gauge.
+  return errSnap(
+    "vertexai",
+    "Vertex AI quota needs Cloud Monitoring metrics with a refreshed ADC token; not supported by this port",
+  );
+}
+
+async function fetchKiro(): Promise<ProviderUsageSnapshot> {
+  // CodexBar drives the kiro CLI for quota — the CLI probe is not ported.
+  const auth =
+    readJsonHome(".kiro", "auth.json") ??
+    readJsonHome(".config", "kiro", "auth.json") ??
+    readJsonHome(".kiro", "settings.json");
+  if (!auth) return unauth("kiro", "missing kiro auth (run kiro-cli login)");
+  return errSnap("kiro", "Kiro quota is read via the kiro CLI; not supported by this port");
+}
+
+// ── Local probes ────────────────────────────────────────────────────────────
+
+async function fetchGemini(): Promise<ProviderUsageSnapshot> {
+  const creds =
+    readJsonHome(".gemini", "oauth_creds.json") ??
+    readJsonHome(".config", "gemini", "oauth_creds.json") ??
+    readJsonHome(".gemini", "credentials.json");
+  if (!creds) return unauth("gemini", "missing ~/.gemini/oauth_creds.json");
+  let access =
+    pickString(creds, "access_token", "accessToken", "token") ??
+    pickString(asRec(creds.tokens), "access_token", "accessToken");
+  const refresh =
+    pickString(creds, "refresh_token", "refreshToken") ??
+    pickString(asRec(creds.tokens), "refresh_token", "refreshToken");
+  if (!access && refresh) {
+    // Best-effort refresh via Google OAuth is not ported (gemini-cli client id
+    // not embedded) — an expired access token means we genuinely can't fetch.
+    return unauth("gemini", "gemini access token expired — run the gemini CLI once to refresh it");
+  }
+  if (!access) return unauth("gemini", "gemini oauth creds missing access_token");
+  const res = await httpPost(
+    "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota",
+    { Authorization: `Bearer ${access}` },
+    JSON.stringify({}),
+  );
+  if (!res.ok) return mapHttpFailure("gemini", res);
+  const root = asRec(res.json);
+  const windows: ProviderUsageWindow[] = [];
+  const buckets = Array.isArray(root.buckets)
+    ? root.buckets
+    : Array.isArray(root.quotas)
+      ? root.quotas
+      : [root];
+  for (const raw of buckets) {
+    const b = asRec(raw);
+    const util =
+      pickNum(b, "utilization", "used_percent", "usedPercent") ??
+      percentFromRemaining(pickNum(b, "remainingFraction", "remaining_fraction")) ??
+      percentUsed(pickNum(b, "used"), pickNum(b, "limit", "quota"));
+    const name = String(b.name ?? b.id ?? b.model ?? "quota");
+    const win = windowOf(name, name.slice(0, 12), util, isoFromIso(b.resetTime ?? b.resets_at));
+    if (win) windows.push(win);
+  }
+  if (windows.length === 0) return errSnap("gemini", "no quota buckets in retrieveUserQuota response");
+  return snapshotOk("gemini", windows.slice(0, 6));
+}
+
+async function fetchAntigravity(): Promise<ProviderUsageSnapshot> {
+  // Keep probe set small — sequential localhost timeouts add up quickly.
+  const candidates = [
+    "http://127.0.0.1:7242",
+    "https://127.0.0.1:7242",
+    "http://127.0.0.1:4500",
+  ];
+  let reachable: string | null = null;
+  for (const base of candidates) {
+    for (const pathSuffix of ["/healthz", "/health"]) {
+      const res = await httpGet(`${base}${pathSuffix}`, {}, 800);
+      if (res.ok && res.json) {
+        const root = asRec(res.json);
+        const util =
+          pickNum(root, "utilization", "used_percent") ??
+          percentFromRemaining(pickNum(root, "remainingFraction", "remaining_fraction"));
+        if (util !== null) {
+          return snapshotOk("antigravity", [
+            { id: "local", label: "local", utilization: util, resetsAt: null },
+          ]);
+        }
+      }
+      if (res.ok || res.status === 404 || res.status === 401) reachable = base;
+    }
+  }
+  if (reachable) {
+    return errSnap("antigravity", `local Antigravity server at ${reachable} exposes no usage data`);
+  }
+  return unauth("antigravity", "no local Antigravity server / oauth creds");
+}
+
+async function fetchJetBrains(): Promise<ProviderUsageSnapshot> {
+  const home = os.homedir();
+  const roots: string[] = [];
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA || path.join(home, "AppData", "Roaming");
+    const local = process.env.LOCALAPPDATA || path.join(home, "AppData", "Local");
+    roots.push(path.join(appData, "JetBrains"), path.join(local, "JetBrains"));
+  } else if (process.platform === "darwin") {
+    roots.push(path.join(home, "Library", "Application Support", "JetBrains"));
+  } else {
+    roots.push(path.join(home, ".config", "JetBrains"), path.join(home, ".local", "share", "JetBrains"));
+  }
+
+  const xmlFiles: { file: string; mtime: number }[] = [];
+  const walk = (dir: string, depth: number) => {
+    if (depth > 4) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const ent of entries) {
+      const full = path.join(dir, ent.name);
+      if (ent.isDirectory()) walk(full, depth + 1);
+      else if (ent.isFile() && /AIAssistantQuotaManager2\.xml$/i.test(ent.name)) {
+        try {
+          xmlFiles.push({ file: full, mtime: fs.statSync(full).mtimeMs });
+        } catch {
+          /* skip */
+        }
+      }
+    }
+  };
+  for (const r of roots) {
+    if (fs.existsSync(r)) walk(r, 0);
+  }
+  xmlFiles.sort((a, b) => b.mtime - a.mtime);
+  const best = xmlFiles[0];
+  if (!best) return unauth("jetbrains", "AIAssistantQuotaManager2.xml not found");
+
+  let xml: string;
+  try {
+    xml = fs.readFileSync(best.file, "utf8");
+  } catch (e) {
+    return errSnap("jetbrains", e instanceof Error ? e.message : "read failed");
+  }
+
+  // JetBrainsStatusProbe: option values are HTML-entity-escaped JSON blobs —
+  // quotaInfo {type, current, maximum, until, tariffQuota:{available}} and
+  // nextRefill {next, …}; numbers are string-typed.
+  const optionValue = (name: string): Record<string, unknown> | null => {
+    const m = xml.match(new RegExp(`<option\\s+name="${name}"\\s+value="([^"]*)"`, "i"));
+    if (!m?.[1]) return null;
+    const decoded = m[1]
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&apos;/g, "'");
+    try {
+      const parsed = JSON.parse(decoded);
+      return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+    } catch {
+      return null;
+    }
+  };
+  const quotaInfo = optionValue("quotaInfo");
+  if (!quotaInfo) return errSnap("jetbrains", "no quotaInfo option in AIAssistantQuotaManager2.xml");
+  const used = num(quotaInfo.current);
+  const maximum = num(quotaInfo.maximum);
+  const refill = optionValue("nextRefill");
+  const resetsAt =
+    isoFromIso(refill?.next) ?? isoFromIso(quotaInfo.until) ?? null;
+  return usedLimitWindows("jetbrains", [
+    { id: "quota", label: "quota", used, limit: maximum, resetsAt },
+  ]);
+}
+
+async function fetchWayfinder(): Promise<ProviderUsageSnapshot> {
+  const configured =
+    envFirst(["WAYFINDER_GATEWAY_URL"]) ?? configEnterpriseHost("wayfinder") ?? "http://127.0.0.1:8088";
+  let base = configured.replace(/\/$/, "");
+  if (!base.startsWith("http")) base = `http://${base}`;
+  const health = await httpGet(`${base}/healthz`, {}, 2000);
+  if (!health.ok && health.status === 0) {
+    return unauth("wayfinder", `gateway unreachable at ${base}`);
+  }
+  // Unauthenticated loopback is expected; treat reachable gateway as ok.
+  const savings = await httpGet(`${base}/v1/savings?period=30d`, {}, 3000);
+  const models = await httpGet(`${base}/router/models`, {}, 3000);
+  const note: string[] = [];
+  if (health.ok) note.push("healthy");
+  if (savings.ok) note.push("savings");
+  if (models.ok) note.push("models");
+  if (!health.ok && !savings.ok && !models.ok) {
+    return errSnap("wayfinder", `gateway ${base} returned errors`);
+  }
+  // A local gateway has no quota — "healthy" is its honest state.
+  return snapshotOk("wayfinder", [detailWindow("gateway", "gw", note.join(", ") || "healthy")]);
+}
+
+async function fetchOllama(): Promise<ProviderUsageSnapshot> {
+  // Local Ollama has no quota — the honest state is model availability.
+  const local = await httpGet("http://127.0.0.1:11434/api/tags", {}, 2000);
+  if (local.ok) {
+    const root = asRec(local.json);
+    const models = Array.isArray(root.models) ? root.models.length : 0;
+    return snapshotOk("ollama", [detailWindow("local", "local", `${models} models`)]);
+  }
+  const key = configApiKey("ollama", ["OLLAMA_API_KEY"]);
+  if (key) {
+    const res = await bearerJson("ollama", "https://ollama.com/api/tags", key);
+    if (!res.ok) return res.snap;
+    return snapshotOk("ollama", [detailWindow("cloud", "cloud", "key ok")]);
+  }
+  return unauth("ollama", "ollama not running locally and no OLLAMA_API_KEY");
+}
+
+function readZedKeychainCredentials(): { userId: string; token: string } | null {
+  // ZedKeychainCredentialsReader: internet-password item for https://zed.dev —
+  // account = user id, password = access token. macOS only.
+  if (process.platform !== "darwin") return null;
+  try {
+    const password = execFileSync(
+      "security",
+      ["find-internet-password", "-s", "zed.dev", "-w"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).replace(/\r?\n$/, "");
+    const meta = execFileSync("security", ["find-internet-password", "-s", "zed.dev"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const account = meta.match(/"acct"<blob>="([^"]+)"/)?.[1];
+    if (!password || !account) return null;
+    return { userId: account, token: password };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchZed(): Promise<ProviderUsageSnapshot> {
+  // ZedStatusProbe: GET cloud.zed.dev/client/users/me with
+  // `Authorization: <userID> <accessToken>` (not Bearer). Response:
+  // plan.usage.edit_predictions {used, limit: int | "unlimited"},
+  // plan.subscription_period.ended_at, plan.plan_v3.
+  let userId = envFirst(["ZED_USER_ID"]);
+  let token = configApiKey("zed", ["ZED_API_TOKEN", "ZED_TOKEN"]);
+  if (token?.includes(" ") && !userId) {
+    const [id, ...rest] = token.split(" ");
+    userId = id ?? null;
+    token = rest.join(" ") || null;
+  }
+  if (!userId || !token) {
+    const kc = readZedKeychainCredentials();
+    if (kc) {
+      userId = kc.userId;
+      token = kc.token;
+    }
+  }
+  if (!userId || !token) {
+    return unauth(
+      "zed",
+      process.platform === "darwin"
+        ? "missing Zed keychain credentials / ZED_USER_ID + ZED_API_TOKEN"
+        : "missing ZED_USER_ID + ZED_API_TOKEN (Zed keychain is macOS-only)",
+    );
+  }
+  const res = await httpGet("https://cloud.zed.dev/client/users/me", {
+    Authorization: `${userId} ${token}`,
+  });
+  if (!res.ok) return mapHttpFailure("zed", res);
+  const root = asRec(res.json);
+  const plan = asRec(root.plan);
+  const edit = asRec(asRec(plan.usage).edit_predictions);
+  const resetsAt = isoFromIso(asRec(plan.subscription_period).ended_at);
+  const planName = pickString(plan, "plan_v3") ?? "plan";
+  const used = pickNum(edit, "used");
+  const rawLimit = edit.limit;
+  const limit = num(rawLimit) ?? num(asRec(rawLimit).limited);
+  const windows: ProviderUsageWindow[] = [];
+  if (rawLimit === "unlimited") {
+    windows.push(detailWindow("edit", "edit", "unlimited", resetsAt));
+  } else {
+    const win = windowOf("edit", "edit", percentUsed(used, limit), resetsAt);
+    if (win) windows.push(win);
+  }
+  windows.push(detailWindow("plan", "plan", planName.replace(/^zed_/, ""), resetsAt));
+  return snapshotOk("zed", windows);
+}
+
+// ── dispatcher ──────────────────────────────────────────────────────────────
+
+export async function fetchProviderUsage(id: ProviderUsageId): Promise<ProviderUsageSnapshot> {
+  try {
+    switch (id) {
+      case "claude":
+        return await fetchClaude();
+      case "codex":
+        return await getCodexUsage();
+      case "cursor":
+        return await getCursorUsage();
+      case "openai":
+        return await fetchOpenAI();
+      case "azureopenai":
+        return await fetchAzureOpenAI();
+      case "opencode":
+        return await fetchOpenCode();
+      case "opencodego":
+        return await fetchOpenCodeGo();
+      case "alibaba":
+        return await fetchAlibaba();
+      case "alibabatokenplan":
+        return await fetchAlibabaTokenPlan();
+      case "factory":
+        return await fetchFactory();
+      case "gemini":
+        return await fetchGemini();
+      case "antigravity":
+        return await fetchAntigravity();
+      case "copilot":
+        return await fetchCopilot();
+      case "devin":
+        return await fetchDevin();
+      case "zai":
+        return await fetchZai();
+      case "minimax":
+        return await fetchMinimax();
+      case "manus":
+        return await fetchManus();
+      case "kimi":
+        return await fetchKimi();
+      case "kilo":
+        return await fetchKilo();
+      case "kiro":
+        return await fetchKiro();
+      case "vertexai":
+        return await fetchVertexAI();
+      case "augment":
+        return await fetchAugment();
+      case "jetbrains":
+        return await fetchJetBrains();
+      case "kimik2":
+        return await fetchKimiK2();
+      case "moonshot":
+        return await fetchMoonshot();
+      case "amp":
+        return await fetchAmp();
+      case "t3chat":
+        return await fetchT3Chat();
+      case "ollama":
+        return await fetchOllama();
+      case "synthetic":
+        return await fetchSynthetic();
+      case "warp":
+        return await fetchWarp();
+      case "openrouter":
+        return await fetchOpenRouter();
+      case "elevenlabs":
+        return await fetchElevenLabs();
+      case "windsurf":
+        return await fetchWindsurf();
+      case "zed":
+        return await fetchZed();
+      case "perplexity":
+        return await fetchPerplexity();
+      case "mimo":
+        return await fetchMimo();
+      case "doubao":
+        return await fetchDoubao();
+      case "sakana":
+        return await fetchSakana();
+      case "abacus":
+        return await fetchAbacus();
+      case "mistral":
+        return await fetchMistral();
+      case "deepseek":
+        return await fetchDeepSeek();
+      case "codebuff":
+        return await fetchCodebuff();
+      case "crof":
+        return await fetchCrof();
+      case "venice":
+        return await fetchVenice();
+      case "commandcode":
+        return await fetchCommandCode();
+      case "qoder":
+        return await fetchQoder();
+      case "stepfun":
+        return await fetchStepFun();
+      case "bedrock":
+        return await fetchBedrock();
+      case "grok":
+        return await fetchGrok();
+      case "groq":
+        return await fetchGroq();
+      case "llmproxy":
+        return await fetchLlmProxy();
+      case "litellm":
+        return await fetchLiteLlm();
+      case "deepgram":
+        return await fetchDeepgram();
+      case "poe":
+        return await fetchPoe();
+      case "chutes":
+        return await fetchChutes();
+      case "crossmodel":
+        return await fetchCrossModel();
+      case "clawrouter":
+        return await fetchClawRouter();
+      case "wayfinder":
+        return await fetchWayfinder();
+      default: {
+        // Exhaustiveness: if a new id is added to the catalog, TypeScript should error above.
+        const _exhaustive: never = id;
+        return emptyProviderSnapshot(_exhaustive, "error", "unknown provider id");
+      }
+    }
+  } catch (err) {
+    return emptyProviderSnapshot(
+      id,
+      "error",
+      err instanceof Error ? err.message : "provider fetch failed",
+    );
+  }
+}

--- a/src/server/services/provider-usage/codex-usage.ts
+++ b/src/server/services/provider-usage/codex-usage.ts
@@ -1,0 +1,187 @@
+/**
+ * Codex (OpenAI) usage adapter — OAuth via ~/.codex/auth.json → wham/usage.
+ * Cross-platform file credentials (Windows + macOS). No Swift / Keychain required.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ProviderUsageSnapshot } from "~/shared/provider-usage";
+import { emptyProviderSnapshot } from "~/shared/provider-usage";
+import { normalizeCodexUsagePayload } from "~/shared/provider-usage-normalize";
+
+const DEFAULT_BASE_URL = "https://chatgpt.com/backend-api";
+const REQUEST_TIMEOUT_MS = 8_000;
+const SUCCESS_TTL_MS = 180_000;
+const TRANSIENT_TTL_MS = 60_000;
+const MAX_AUTH_BYTES = 1_000_000;
+
+type CodexCreds = { accessToken: string; accountId: string | null };
+
+type CacheEntry = { value: ProviderUsageSnapshot; expiresAt: number };
+let cache: CacheEntry | null = null;
+let inflight: Promise<ProviderUsageSnapshot> | null = null;
+let credsReader: () => CodexCreds | null = readCodexOAuthCredentials;
+
+function codexHome(): string {
+  return process.env.CODEX_HOME?.trim() || path.join(os.homedir(), ".codex");
+}
+
+/**
+ * Resolve the usage endpoint like CodexOAuthUsageFetcher: honor
+ * `chatgpt_base_url` from ~/.codex/config.toml; bases that already point at
+ * `/backend-api` use `/wham/usage`, other bases use `/api/codex/usage`.
+ */
+export function resolveCodexUsageUrl(): string {
+  let base = DEFAULT_BASE_URL;
+  try {
+    const toml = fs.readFileSync(path.join(codexHome(), "config.toml"), "utf8");
+    const m = toml.match(/^\s*chatgpt_base_url\s*=\s*"([^"]+)"/m);
+    if (m?.[1]?.trim()) base = m[1].trim().replace(/\/+$/, "");
+  } catch {
+    /* no config.toml — default base */
+  }
+  return base.includes("/backend-api") ? `${base}/wham/usage` : `${base}/api/codex/usage`;
+}
+
+export function readCodexOAuthCredentials(): CodexCreds | null {
+  const full = path.join(codexHome(), "auth.json");
+  try {
+    const st = fs.lstatSync(full);
+    if (!st.isFile() || st.size > MAX_AUTH_BYTES) return null;
+    const raw = fs.readFileSync(full, "utf8");
+    const json = JSON.parse(raw) as Record<string, unknown>;
+
+    if (typeof json.OPENAI_API_KEY === "string" && json.OPENAI_API_KEY.trim()) {
+      return { accessToken: json.OPENAI_API_KEY.trim(), accountId: null };
+    }
+
+    const tokens =
+      json.tokens && typeof json.tokens === "object"
+        ? (json.tokens as Record<string, unknown>)
+        : null;
+    if (!tokens) return null;
+    const accessToken =
+      (typeof tokens.access_token === "string" && tokens.access_token) ||
+      (typeof tokens.accessToken === "string" && tokens.accessToken) ||
+      null;
+    if (!accessToken) return null;
+    const accountId =
+      (typeof tokens.account_id === "string" && tokens.account_id) ||
+      (typeof tokens.accountId === "string" && tokens.accountId) ||
+      null;
+    return { accessToken, accountId };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchCodexUsage(): Promise<{ value: ProviderUsageSnapshot; ttlMs: number }> {
+  const creds = credsReader();
+  if (!creds) {
+    return {
+      value: emptyProviderSnapshot("codex", "unauthenticated", "no Codex credentials found (~/.codex/auth.json)"),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  let res: Response;
+  try {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${creds.accessToken}`,
+      Accept: "application/json",
+      "User-Agent": "MissionControl",
+    };
+    if (creds.accountId) headers["ChatGPT-Account-Id"] = creds.accountId;
+
+    res = await fetch(resolveCodexUsageUrl(), {
+      method: "GET",
+      headers,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    return {
+      value: emptyProviderSnapshot(
+        "codex",
+        "error",
+        err instanceof Error ? err.message : "request failed",
+      ),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (res.status === 429) {
+    return {
+      value: emptyProviderSnapshot("codex", "rate_limited", "HTTP 429 from Codex usage API"),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  }
+  if (res.status === 401 || res.status === 403) {
+    return {
+      value: emptyProviderSnapshot("codex", "unauthenticated", `auth failed (${res.status})`),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  }
+  if (!res.ok) {
+    let detail = "";
+    try {
+      detail = (await res.text()).slice(0, 200);
+    } catch {
+      /* ignore */
+    }
+    return {
+      value: emptyProviderSnapshot(
+        "codex",
+        "error",
+        `unexpected status ${res.status}${detail ? `: ${detail}` : ""}`,
+      ),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    return {
+      value: emptyProviderSnapshot("codex", "error", "invalid JSON response"),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  }
+
+  const snapshot = normalizeCodexUsagePayload(body);
+  return { value: snapshot, ttlMs: SUCCESS_TTL_MS };
+}
+
+/** Cached single-flight Codex usage. Never throws. */
+export function getCodexUsage(): Promise<ProviderUsageSnapshot> {
+  const now = Date.now();
+  if (cache && cache.expiresAt > now) return Promise.resolve(cache.value);
+  if (inflight) return inflight;
+
+  const p = fetchCodexUsage()
+    .then(({ value, ttlMs }) => {
+      const lastGood = cache?.value.status === "ok" ? cache.value : null;
+      const served = value.status === "ok" ? value : lastGood ?? value;
+      cache = { value: served, expiresAt: Date.now() + ttlMs };
+      return served;
+    })
+    .finally(() => {
+      if (inflight === p) inflight = null;
+    });
+  inflight = p;
+  return p;
+}
+
+export function _resetCodexUsageCache(): void {
+  cache = null;
+  inflight = null;
+}
+
+export function _setCodexCredsReaderForTests(fn: (() => CodexCreds | null) | null): void {
+  credsReader = fn ?? readCodexOAuthCredentials;
+}

--- a/src/server/services/provider-usage/credentials.ts
+++ b/src/server/services/provider-usage/credentials.ts
@@ -1,0 +1,161 @@
+/**
+ * Cross-platform credential resolution for CodexBar-forked providers.
+ * Sources: process env, ~/.codexbar/config.json, ~/.config/codexbar/config.json,
+ * and common CLI auth files. Never throws.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const MAX_BYTES = 2_000_000;
+
+type CodexBarProviderConfig = {
+  id?: string;
+  apiKey?: string;
+  cookie?: string;
+  cookieHeader?: string;
+  enterpriseHost?: string;
+  tokenAccounts?: Array<{ apiKey?: string; selected?: boolean }>;
+};
+
+type CodexBarConfig = {
+  providers?: CodexBarProviderConfig[];
+};
+
+let cachedConfig: CodexBarConfig | null | undefined;
+
+function readJsonFile(full: string): unknown | null {
+  try {
+    const st = fs.lstatSync(full);
+    if (!st.isFile() || st.size > MAX_BYTES) return null;
+    return JSON.parse(fs.readFileSync(full, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function codexBarConfigPaths(): string[] {
+  const home = os.homedir();
+  return [
+    path.join(home, ".config", "codexbar", "config.json"),
+    path.join(home, ".codexbar", "config.json"),
+  ];
+}
+
+export function loadCodexBarConfig(): CodexBarConfig | null {
+  if (cachedConfig !== undefined) return cachedConfig;
+  for (const p of codexBarConfigPaths()) {
+    const raw = readJsonFile(p);
+    if (raw && typeof raw === "object") {
+      cachedConfig = raw as CodexBarConfig;
+      return cachedConfig;
+    }
+  }
+  cachedConfig = null;
+  return null;
+}
+
+/** Test seam. */
+export function _resetCodexBarConfigCache(): void {
+  cachedConfig = undefined;
+}
+
+function firstNonEmpty(...values: Array<string | undefined | null>): string | null {
+  for (const v of values) {
+    if (typeof v === "string") {
+      const t = v.trim();
+      if (t) return t;
+    }
+  }
+  return null;
+}
+
+export function envFirst(keys: string[]): string | null {
+  for (const k of keys) {
+    const v = process.env[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return null;
+}
+
+export function configApiKey(providerId: string, envKeys: string[] = []): string | null {
+  const fromEnv = envFirst(envKeys);
+  if (fromEnv) return fromEnv;
+  const cfg = loadCodexBarConfig();
+  const entry = cfg?.providers?.find((p) => p.id === providerId);
+  if (!entry) return null;
+  if (entry.tokenAccounts?.length) {
+    const selected = entry.tokenAccounts.find((a) => a.selected && a.apiKey?.trim());
+    if (selected?.apiKey?.trim()) return selected.apiKey.trim();
+    const first = entry.tokenAccounts.find((a) => a.apiKey?.trim());
+    if (first?.apiKey?.trim()) return first.apiKey.trim();
+  }
+  return firstNonEmpty(entry.apiKey);
+}
+
+/**
+ * Cookie-header credential. A bare token (no `=`) is wrapped as
+ * `<bareCookieName>=<token>` when the caller names the provider's real session
+ * cookie; with no name it is returned raw (never guess a cookie name like
+ * `session=` — no audited provider uses that).
+ */
+export function configCookie(
+  providerId: string,
+  envKeys: string[] = [],
+  bareCookieName?: string,
+): string | null {
+  const wrap = (value: string): string => {
+    if (value.includes("=") || !bareCookieName) return value;
+    return `${bareCookieName}=${value}`;
+  };
+  const fromEnv = envFirst(envKeys);
+  if (fromEnv) return wrap(fromEnv);
+  const cfg = loadCodexBarConfig();
+  const entry = cfg?.providers?.find((p) => p.id === providerId);
+  if (!entry) return null;
+  const value = firstNonEmpty(entry.cookieHeader, entry.cookie);
+  return value ? wrap(value) : null;
+}
+
+export function configEnterpriseHost(providerId: string, envKeys: string[] = []): string | null {
+  const fromEnv = envFirst(envKeys);
+  if (fromEnv) return fromEnv.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+  const cfg = loadCodexBarConfig();
+  const entry = cfg?.providers?.find((p) => p.id === providerId);
+  const h = entry?.enterpriseHost?.trim();
+  if (!h) return null;
+  return h.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+}
+
+export function readTextFileHome(...segments: string[]): string | null {
+  const full = path.join(os.homedir(), ...segments);
+  try {
+    const st = fs.lstatSync(full);
+    if (!st.isFile() || st.size > MAX_BYTES) return null;
+    const t = fs.readFileSync(full, "utf8").trim();
+    return t || null;
+  } catch {
+    return null;
+  }
+}
+
+export function readJsonHome(...segments: string[]): Record<string, unknown> | null {
+  const raw = readTextFileHome(...segments);
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw);
+    return v && typeof v === "object" ? (v as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Pick string field from object by snake/camel keys. */
+export function pickString(obj: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return null;
+}

--- a/src/server/services/provider-usage/cursor-usage.ts
+++ b/src/server/services/provider-usage/cursor-usage.ts
@@ -1,0 +1,252 @@
+/**
+ * Cursor usage adapter — app local auth (state.vscdb / cursor-agent auth.json)
+ * → cursor.com/api/usage-summary. Works on Windows + macOS without browser cookies.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import Database from "better-sqlite3";
+import type { ProviderUsageSnapshot } from "~/shared/provider-usage";
+import { emptyProviderSnapshot } from "~/shared/provider-usage";
+import { normalizeCursorUsagePayload } from "~/shared/provider-usage-normalize";
+
+const USAGE_SUMMARY_URL = "https://cursor.com/api/usage-summary";
+const REQUEST_TIMEOUT_MS = 8_000;
+const SUCCESS_TTL_MS = 180_000;
+const TRANSIENT_TTL_MS = 60_000;
+const MAX_AUTH_BYTES = 1_000_000;
+
+type CursorSession = { accessToken: string; cookieHeader: string };
+
+type CacheEntry = { value: ProviderUsageSnapshot; expiresAt: number };
+let cache: CacheEntry | null = null;
+let inflight: Promise<ProviderUsageSnapshot> | null = null;
+let sessionReader: () => CursorSession | null = readCursorAppSession;
+
+function cursorStateDbPaths(): string[] {
+  const home = os.homedir();
+  const paths: string[] = [];
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA || path.join(home, "AppData", "Roaming");
+    paths.push(path.join(appData, "Cursor", "User", "globalStorage", "state.vscdb"));
+  } else if (process.platform === "darwin") {
+    paths.push(
+      path.join(home, "Library", "Application Support", "Cursor", "User", "globalStorage", "state.vscdb"),
+    );
+  } else {
+    const xdg = process.env.XDG_CONFIG_HOME?.trim() || path.join(home, ".config");
+    paths.push(path.join(xdg, "Cursor", "User", "globalStorage", "state.vscdb"));
+  }
+  return paths;
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split(".");
+  if (parts.length < 2) return null;
+  try {
+    let payload = parts[1]!.replace(/-/g, "+").replace(/_/g, "/");
+    payload += "=".repeat((4 - (payload.length % 4)) % 4);
+    return JSON.parse(Buffer.from(payload, "base64").toString("utf8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function userIdFromAccessToken(accessToken: string): string | null {
+  const json = decodeJwtPayload(accessToken);
+  if (!json) return null;
+  const sub = typeof json.sub === "string" ? json.sub : null;
+  if (!sub) return null;
+  const segments = sub.split("|").filter(Boolean);
+  const userID = segments[segments.length - 1] ?? null;
+  if (!userID || !/^[A-Za-z0-9._-]+$/.test(userID)) return null;
+  return userID;
+}
+
+function readAccessTokenFromVscdb(dbPath: string): string | null {
+  try {
+    if (!fs.existsSync(dbPath)) return null;
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true, timeout: 250 });
+    try {
+      const row = db
+        .prepare("SELECT value FROM ItemTable WHERE key = ? LIMIT 1")
+        .get("cursorAuth/accessToken") as { value?: unknown } | undefined;
+      if (!row) return null;
+      if (typeof row.value === "string" && row.value.trim()) return row.value.trim();
+      if (Buffer.isBuffer(row.value)) {
+        const s = row.value.toString("utf8").trim();
+        return s || null;
+      }
+      return null;
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+function readCursorAgentAuthFile(): string | null {
+  const candidates = [
+    path.join(os.homedir(), ".config", "cursor-agent", "auth.json"),
+    path.join(os.homedir(), ".cursor", "auth.json"),
+  ];
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming");
+    candidates.unshift(path.join(appData, "cursor-agent", "auth.json"));
+  }
+  for (const full of candidates) {
+    try {
+      const st = fs.lstatSync(full);
+      if (!st.isFile() || st.size > MAX_AUTH_BYTES) continue;
+      const json = JSON.parse(fs.readFileSync(full, "utf8")) as Record<string, unknown>;
+      const token =
+        (typeof json.accessToken === "string" && json.accessToken) ||
+        (typeof json.access_token === "string" && json.access_token) ||
+        null;
+      if (token?.trim()) return token.trim();
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+function tokenIsUsable(accessToken: string): boolean {
+  // CursorAppAuthSession.isUsable: skip app tokens expiring within 60s so an
+  // expired local session degrades to unauthenticated instead of a 401 loop.
+  const payload = decodeJwtPayload(accessToken);
+  const exp = payload && typeof payload.exp === "number" ? payload.exp : null;
+  if (exp === null) return true;
+  return exp * 1000 > Date.now() + 60_000;
+}
+
+export function readCursorAppSession(): CursorSession | null {
+  let accessToken: string | null = null;
+  for (const dbPath of cursorStateDbPaths()) {
+    accessToken = readAccessTokenFromVscdb(dbPath);
+    if (accessToken) break;
+  }
+  // Port-only extension beyond CodexBar: cursor-agent CLI auth files.
+  if (!accessToken) accessToken = readCursorAgentAuthFile();
+  if (!accessToken) return null;
+  if (!tokenIsUsable(accessToken)) return null;
+
+  const userID = userIdFromAccessToken(accessToken);
+  if (!userID) return null;
+
+  // WorkosCursorSessionToken = userID%3A%3AaccessToken (CodexBar CursorAppAuthSession)
+  const cookieHeader = `WorkosCursorSessionToken=${userID}%3A%3A${accessToken}`;
+  return { accessToken, cookieHeader };
+}
+
+async function fetchCursorUsage(): Promise<{ value: ProviderUsageSnapshot; ttlMs: number }> {
+  const session = sessionReader();
+  if (!session) {
+    return {
+      value: emptyProviderSnapshot(
+        "cursor",
+        "unauthenticated",
+        "no Cursor app session (state.vscdb / cursor-agent auth)",
+      ),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(USAGE_SUMMARY_URL, {
+      method: "GET",
+      headers: {
+        Cookie: session.cookieHeader,
+        Accept: "application/json",
+        "User-Agent": "MissionControl",
+      },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    return {
+      value: emptyProviderSnapshot(
+        "cursor",
+        "error",
+        err instanceof Error ? err.message : "request failed",
+      ),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (res.status === 429) {
+    return {
+      value: emptyProviderSnapshot("cursor", "rate_limited", "HTTP 429 from Cursor usage API"),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  }
+  if (res.status === 401 || res.status === 403) {
+    return {
+      value: emptyProviderSnapshot("cursor", "unauthenticated", `auth failed (${res.status})`),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  }
+  if (!res.ok) {
+    let detail = "";
+    try {
+      detail = (await res.text()).slice(0, 200);
+    } catch {
+      /* ignore */
+    }
+    return {
+      value: emptyProviderSnapshot(
+        "cursor",
+        "error",
+        `unexpected status ${res.status}${detail ? `: ${detail}` : ""}`,
+      ),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    return {
+      value: emptyProviderSnapshot("cursor", "error", "invalid JSON response"),
+      ttlMs: TRANSIENT_TTL_MS,
+    };
+  }
+
+  return { value: normalizeCursorUsagePayload(body), ttlMs: SUCCESS_TTL_MS };
+}
+
+/** Cached single-flight Cursor usage. Never throws. */
+export function getCursorUsage(): Promise<ProviderUsageSnapshot> {
+  const now = Date.now();
+  if (cache && cache.expiresAt > now) return Promise.resolve(cache.value);
+  if (inflight) return inflight;
+
+  const p = fetchCursorUsage()
+    .then(({ value, ttlMs }) => {
+      const lastGood = cache?.value.status === "ok" ? cache.value : null;
+      const served = value.status === "ok" ? value : lastGood ?? value;
+      cache = { value: served, expiresAt: Date.now() + ttlMs };
+      return served;
+    })
+    .finally(() => {
+      if (inflight === p) inflight = null;
+    });
+  inflight = p;
+  return p;
+}
+
+export function _resetCursorUsageCache(): void {
+  cache = null;
+  inflight = null;
+}
+
+export function _setCursorSessionReaderForTests(fn: (() => CursorSession | null) | null): void {
+  sessionReader = fn ?? readCursorAppSession;
+}

--- a/src/server/services/provider-usage/http.ts
+++ b/src/server/services/provider-usage/http.ts
@@ -1,0 +1,173 @@
+/**
+ * Shared HTTP helpers for provider usage adapters.
+ */
+
+import type { ProviderUsageId, ProviderUsageSnapshot, ProviderUsageWindow } from "~/shared/provider-usage";
+import { emptyProviderSnapshot, providerDisplayName } from "~/shared/provider-usage";
+
+export const REQUEST_TIMEOUT_MS = 8_000;
+
+export type HttpResult =
+  | { ok: true; status: number; json: unknown; text: string; headers: Record<string, string> }
+  | { ok: false; status: number; text: string; error: string; headers: Record<string, string> };
+
+function headerMap(res: Response): Record<string, string> {
+  const out: Record<string, string> = {};
+  res.headers.forEach((value, key) => {
+    out[key.toLowerCase()] = value;
+  });
+  return out;
+}
+
+async function request(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<HttpResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    const text = await res.text().catch(() => "");
+    const headers = headerMap(res);
+    if (!res.ok) {
+      return { ok: false, status: res.status, text: text.slice(0, 400), error: `HTTP ${res.status}`, headers };
+    }
+    let json: unknown = null;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch {
+      json = null;
+    }
+    return { ok: true, status: res.status, json, text, headers };
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      text: "",
+      error: err instanceof Error ? err.message : "request failed",
+      headers: {},
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function httpGet(
+  url: string,
+  headers: Record<string, string>,
+  timeoutMs = REQUEST_TIMEOUT_MS,
+): Promise<HttpResult> {
+  // Caller headers spread last so per-provider User-Agent/Accept overrides win.
+  return request(
+    url,
+    { method: "GET", headers: { Accept: "application/json", "User-Agent": "MissionControl", ...headers } },
+    timeoutMs,
+  );
+}
+
+export async function httpPost(
+  url: string,
+  headers: Record<string, string>,
+  body: string,
+  timeoutMs = REQUEST_TIMEOUT_MS,
+): Promise<HttpResult> {
+  return request(
+    url,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "MissionControl",
+        "Content-Type": "application/json",
+        ...headers,
+      },
+      body,
+    },
+    timeoutMs,
+  );
+}
+
+export function mapHttpFailure(
+  id: ProviderUsageId,
+  result: Extract<HttpResult, { ok: false }>,
+): ProviderUsageSnapshot {
+  if (result.status === 401 || result.status === 403) {
+    return emptyProviderSnapshot(id, "unauthenticated", result.error);
+  }
+  if (result.status === 429) {
+    return emptyProviderSnapshot(id, "rate_limited", result.error);
+  }
+  return emptyProviderSnapshot(id, "error", result.error + (result.text ? `: ${result.text.slice(0, 120)}` : ""));
+}
+
+export function snapshotOk(
+  id: ProviderUsageId,
+  windows: ProviderUsageWindow[],
+  error?: string,
+): ProviderUsageSnapshot {
+  return {
+    id,
+    displayName: providerDisplayName(id),
+    status: windows.length > 0 ? "ok" : "error",
+    windows,
+    fetchedAt: Date.now(),
+    ...(error && windows.length === 0 ? { error } : {}),
+    ...(error && windows.length > 0 ? { error } : {}),
+  };
+}
+
+export function windowOf(
+  id: string,
+  label: string,
+  utilization: number | null | undefined,
+  resetsAt: string | null = null,
+  detail?: string,
+): ProviderUsageWindow | null {
+  const util =
+    utilization === null || utilization === undefined || !Number.isFinite(utilization)
+      ? null
+      : utilization;
+  // A window needs either a real meter or a human detail value — never a
+  // fabricated 0% bar for unknown usage.
+  if (util === null && !detail) return null;
+  return { id, label, utilization: util, resetsAt, ...(detail ? { detail } : {}) };
+}
+
+/** Meterless window carrying a human value ("$12.34") instead of a percent. */
+export function detailWindow(id: string, label: string, detail: string, resetsAt: string | null = null): ProviderUsageWindow {
+  return { id, label, utilization: null, resetsAt, detail };
+}
+
+export function num(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+export function isoFromSecOrMs(value: unknown): string | null {
+  const n = num(value);
+  if (n === null) return null;
+  const ms = n > 1e12 ? n : n * 1000;
+  const d = new Date(ms);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+export function isoFromIso(value: unknown): string | null {
+  if (typeof value !== "string" || !value) return null;
+  const t = Date.parse(value);
+  return Number.isNaN(t) ? null : new Date(t).toISOString();
+}
+
+export function percentUsed(used: number | null, limit: number | null): number | null {
+  if (used === null || limit === null || limit <= 0) return null;
+  return (used / limit) * 100;
+}
+
+export function percentFromRemaining(remainingFraction: number | null): number | null {
+  if (remainingFraction === null) return null;
+  return (1 - remainingFraction) * 100;
+}

--- a/src/server/services/provider-usage/index.ts
+++ b/src/server/services/provider-usage/index.ts
@@ -1,0 +1,65 @@
+/**
+ * Multi-provider usage aggregator — CodexBar fork surface for mission-control.
+ * Every catalog id routes through a live adapter (credentials + probe).
+ */
+
+import type {
+  ProviderUsageId,
+  ProviderUsageResponse,
+  ProviderUsageSnapshot,
+} from "~/shared/provider-usage";
+import {
+  DEFAULT_PROVIDER_USAGE_IDS,
+  emptyProviderSnapshot,
+  isProviderUsageId,
+} from "~/shared/provider-usage";
+import { fetchProviderUsage } from "./all-adapters";
+
+async function fetchOne(id: ProviderUsageId): Promise<ProviderUsageSnapshot> {
+  try {
+    return await fetchProviderUsage(id);
+  } catch (err) {
+    return emptyProviderSnapshot(
+      id,
+      "error",
+      err instanceof Error ? err.message : "provider fetch failed",
+    );
+  }
+}
+
+/**
+ * Aggregate usage for the requested provider ids (or mission-control defaults).
+ * Never throws. Unknown ids are skipped.
+ */
+export async function getProviderUsage(
+  requestedIds?: readonly string[] | null,
+): Promise<ProviderUsageResponse> {
+  const ids: ProviderUsageId[] = [];
+  const seen = new Set<string>();
+  const source =
+    requestedIds && requestedIds.length > 0 ? requestedIds : DEFAULT_PROVIDER_USAGE_IDS;
+  for (const raw of source) {
+    if (!isProviderUsageId(raw) || seen.has(raw)) continue;
+    seen.add(raw);
+    ids.push(raw);
+  }
+  if (ids.length === 0) {
+    for (const id of DEFAULT_PROVIDER_USAGE_IDS) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        ids.push(id);
+      }
+    }
+  }
+
+  const providers = await Promise.all(ids.map((id) => fetchOne(id)));
+  return { providers, fetchedAt: Date.now() };
+}
+
+export { fetchProviderUsage } from "./all-adapters";
+export { getCodexUsage, _resetCodexUsageCache, _setCodexCredsReaderForTests } from "./codex-usage";
+export {
+  getCursorUsage,
+  _resetCursorUsageCache,
+  _setCursorSessionReaderForTests,
+} from "./cursor-usage";

--- a/src/shared/__tests__/provider-usage-normalize.test.ts
+++ b/src/shared/__tests__/provider-usage-normalize.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vitest";
+import {
+  claudeLimitsToProviderSnapshot,
+  normalizeClaudeUsagePayload,
+  normalizeCodexUsagePayload,
+  normalizeCrofUsagePayload,
+  normalizeCursorUsagePayload,
+  normalizeDeepSeekUsagePayload,
+  normalizeElevenLabsUsagePayload,
+  normalizeKimiK2UsagePayload,
+  normalizeMoonshotUsagePayload,
+  normalizeOpenRouterUsagePayload,
+  normalizePoeUsagePayload,
+  stubProviderSnapshot,
+} from "../provider-usage-normalize";
+import {
+  DEFAULT_PROVIDER_USAGE_IDS,
+  isProviderUsageId,
+  normalizeProviderUsageIds,
+  PROVIDER_USAGE_CATALOG,
+  PROVIDER_USAGE_IDS,
+} from "../provider-usage";
+
+describe("provider-usage catalog (CodexBar fork)", () => {
+  it("includes the full CodexBar provider id set", () => {
+    expect(PROVIDER_USAGE_IDS.length).toBeGreaterThanOrEqual(50);
+    expect(PROVIDER_USAGE_CATALOG.map((p) => p.id).sort()).toEqual(
+      [...PROVIDER_USAGE_IDS].sort(),
+    );
+    expect(isProviderUsageId("claude")).toBe(true);
+    expect(isProviderUsageId("codex")).toBe(true);
+    expect(isProviderUsageId("cursor")).toBe(true);
+    expect(isProviderUsageId("not-a-provider")).toBe(false);
+  });
+
+  it("defaults enabled providers to the mission-control agent surface", () => {
+    expect(DEFAULT_PROVIDER_USAGE_IDS).toEqual(["claude", "codex", "cursor"]);
+    expect(normalizeProviderUsageIds(["claude", "bogus", "claude", "codex"])).toEqual([
+      "claude",
+      "codex",
+    ]);
+  });
+});
+
+describe("normalizeClaudeUsagePayload", () => {
+  it("maps five_hour/seven_day/seven_day_opus into windows", () => {
+    const snap = normalizeClaudeUsagePayload({
+      five_hour: { utilization: 48, resets_at: "2026-07-10T06:49:00Z" },
+      seven_day: { utilization: 36, resets_at: "2026-07-13T15:59:00Z" },
+      seven_day_opus: { utilization: 12, resets_at: "2026-07-13T15:59:00Z" },
+    });
+    expect(snap.id).toBe("claude");
+    expect(snap.status).toBe("ok");
+    expect(snap.windows).toEqual([
+      { id: "session", label: "session", utilization: 48, resetsAt: "2026-07-10T06:49:00.000Z" },
+      { id: "weekly", label: "week", utilization: 36, resetsAt: "2026-07-13T15:59:00.000Z" },
+      { id: "weeklyOpus", label: "opus", utilization: 12, resetsAt: "2026-07-13T15:59:00.000Z" },
+    ]);
+  });
+
+  it("prefers seven_day_sonnet over seven_day_opus for the model-week slot", () => {
+    const snap = normalizeClaudeUsagePayload({
+      five_hour: { utilization: 5, resets_at: "2026-07-10T06:49:00Z" },
+      seven_day_sonnet: { utilization: 33, resets_at: "2026-07-13T15:59:00Z" },
+      seven_day_opus: { utilization: 12, resets_at: "2026-07-13T15:59:00Z" },
+    });
+    const model = snap.windows.find((w) => w.id === "weeklyOpus");
+    expect(model).toMatchObject({ label: "sonnet", utilization: 33 });
+  });
+
+  it("claudeLimitsToProviderSnapshot preserves status and windows", () => {
+    const snap = claudeLimitsToProviderSnapshot({
+      session: { utilization: 10, resetsAt: "2026-07-10T00:00:00.000Z" },
+      weekly: null,
+      weeklyOpus: null,
+      status: "ok",
+      fetchedAt: 123,
+    });
+    expect(snap.windows).toHaveLength(1);
+    expect(snap.fetchedAt).toBe(123);
+  });
+});
+
+describe("normalizeCodexUsagePayload", () => {
+  it("maps primary/secondary windows with unix reset_at", () => {
+    const snap = normalizeCodexUsagePayload({
+      plan_type: "plus",
+      rate_limit: {
+        primary_window: {
+          used_percent: 42,
+          reset_at: 1_720_000_000,
+          limit_window_seconds: 18_000,
+        },
+        secondary_window: {
+          used_percent: 15,
+          reset_at: 1_720_500_000,
+          limit_window_seconds: 604_800,
+        },
+      },
+    });
+    expect(snap.id).toBe("codex");
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]).toMatchObject({ id: "session", utilization: 42 });
+    expect(snap.windows[1]).toMatchObject({ id: "weekly", utilization: 15 });
+    expect(snap.windows[0]!.resetsAt).toBe(new Date(1_720_000_000 * 1000).toISOString());
+  });
+
+  it("swaps weekly primary into secondary lane (CodexRateWindowNormalizer)", () => {
+    const snap = normalizeCodexUsagePayload({
+      rate_limit: {
+        primary_window: {
+          used_percent: 80,
+          reset_at: 1_720_500_000,
+          limit_window_seconds: 604_800,
+        },
+        secondary_window: {
+          used_percent: 20,
+          reset_at: 1_720_000_000,
+          limit_window_seconds: 18_000,
+        },
+      },
+    });
+    expect(snap.windows[0]).toMatchObject({ id: "session", utilization: 20 });
+    expect(snap.windows[1]).toMatchObject({ id: "weekly", utilization: 80 });
+  });
+
+  it("promotes a lone unknown-length secondary window to the session lane", () => {
+    const snap = normalizeCodexUsagePayload({
+      rate_limit: {
+        secondary_window: { used_percent: 55, reset_at: 1_720_000_000 },
+      },
+    });
+    expect(snap.windows).toHaveLength(1);
+    expect(snap.windows[0]).toMatchObject({ id: "session", utilization: 55 });
+  });
+});
+
+describe("normalizeCursorUsagePayload", () => {
+  it("maps plan totalPercentUsed + auto/api breakdown", () => {
+    const snap = normalizeCursorUsagePayload({
+      billingCycleEnd: "2026-08-01T00:00:00.000Z",
+      individualUsage: {
+        plan: {
+          totalPercentUsed: 63.5,
+          autoPercentUsed: 40,
+          apiPercentUsed: 12,
+        },
+      },
+    });
+    expect(snap.id).toBe("cursor");
+    expect(snap.status).toBe("ok");
+    expect(snap.windows).toEqual([
+      {
+        id: "plan",
+        label: "plan",
+        utilization: 63.5,
+        resetsAt: "2026-08-01T00:00:00.000Z",
+      },
+      {
+        id: "auto",
+        label: "auto",
+        utilization: 40,
+        resetsAt: "2026-08-01T00:00:00.000Z",
+      },
+      {
+        id: "api",
+        label: "api",
+        utilization: 12,
+        resetsAt: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("derives plan percent from cents when totalPercentUsed is absent", () => {
+    const snap = normalizeCursorUsagePayload({
+      individualUsage: {
+        plan: { used: 500, limit: 2000 },
+      },
+    });
+    expect(snap.windows[0]).toMatchObject({ id: "plan", utilization: 25 });
+  });
+
+  it("falls back to avg(auto, api) and clamps to 100 (CursorStatusProbe chain)", () => {
+    const snap = normalizeCursorUsagePayload({
+      individualUsage: {
+        plan: { autoPercentUsed: 130, apiPercentUsed: 50 },
+      },
+    });
+    // auto clamps to 100; headline = avg(100, 50) = 75.
+    expect(snap.windows.find((w) => w.id === "plan")).toMatchObject({ utilization: 75 });
+    expect(snap.windows.find((w) => w.id === "auto")).toMatchObject({ utilization: 100 });
+  });
+
+  it("uses teamUsage.pooled when the personal plan block is absent", () => {
+    const snap = normalizeCursorUsagePayload({
+      teamUsage: { pooled: { used: 30, limit: 120 } },
+    });
+    expect(snap.windows[0]).toMatchObject({ id: "plan", utilization: 25 });
+  });
+});
+
+describe("stubProviderSnapshot", () => {
+  it("keeps legacy unavailable fixture for fixtures that still import it", () => {
+    const snap = stubProviderSnapshot("openrouter");
+    expect(snap.status).toBe("unavailable");
+    expect(snap.windows).toEqual([]);
+    expect(snap.error).toMatch(/not yet ported/i);
+  });
+});
+
+describe("normalizeOpenRouterUsagePayload", () => {
+  it("maps credits total/usage into a balance window", () => {
+    const snap = normalizeOpenRouterUsagePayload({
+      data: { total_credits: 100, total_usage: 25 },
+    });
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]).toMatchObject({ id: "balance", utilization: 25 });
+  });
+});
+
+describe("normalizeDeepSeekUsagePayload", () => {
+  it("prefers USD balance_infos entry", () => {
+    const snap = normalizeDeepSeekUsagePayload({
+      balance_infos: [
+        { currency: "CNY", total_balance: 10, granted_balance: 0, topped_up_balance: 10 },
+        { currency: "USD", total_balance: 42.5, granted_balance: 2.5, topped_up_balance: 40 },
+      ],
+    });
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]?.id).toBe("balance");
+    // Balance-only: meterless window carrying the value, no fake 0% bar.
+    expect(snap.windows[0]?.utilization).toBeNull();
+    expect(snap.windows[0]?.detail).toMatch(/42\.5/);
+    expect(snap.error).toBeUndefined();
+  });
+});
+
+describe("normalizeElevenLabsUsagePayload", () => {
+  it("maps character_count/limit to percent", () => {
+    const snap = normalizeElevenLabsUsagePayload({
+      character_count: 2500,
+      character_limit: 10000,
+      next_character_count_reset_unix: 1_720_000_000,
+    });
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]).toMatchObject({ id: "characters", utilization: 25 });
+    expect(snap.windows[0]!.resetsAt).toBeTruthy();
+  });
+});
+
+describe("normalizeMoonshotUsagePayload", () => {
+  it("maps available_balance", () => {
+    const snap = normalizeMoonshotUsagePayload({
+      data: { available_balance: 12.3, voucher_balance: 0, cash_balance: 12.3 },
+    });
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]?.utilization).toBeNull();
+    expect(snap.windows[0]?.detail).toMatch(/12\.3/);
+  });
+});
+
+describe("normalizeKimiK2UsagePayload", () => {
+  it("computes utilization from consumed + remaining", () => {
+    const snap = normalizeKimiK2UsagePayload({
+      total_credits_consumed: 30,
+      credits_remaining: 70,
+    });
+    expect(snap.windows[0]).toMatchObject({ id: "credits", utilization: 30 });
+  });
+});
+
+describe("normalizePoeUsagePayload", () => {
+  it("maps current_point_balance", () => {
+    const snap = normalizePoeUsagePayload({ current_point_balance: 9001 });
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]?.utilization).toBeNull();
+    expect(snap.windows[0]?.detail).toMatch(/9001/);
+  });
+});
+
+describe("normalizeCrofUsagePayload", () => {
+  it("maps request plan and credits", () => {
+    const snap = normalizeCrofUsagePayload({
+      requests_plan: 100,
+      usable_requests: 40,
+      credits: 5.5,
+    });
+    expect(snap.status).toBe("ok");
+    expect(snap.windows.find((w) => w.id === "requests")?.utilization).toBe(60);
+    expect(snap.windows.some((w) => w.id === "credits")).toBe(true);
+  });
+});
+
+describe("catalog implemented flags", () => {
+  it("marks every catalog provider implemented", () => {
+    expect(PROVIDER_USAGE_CATALOG.every((p) => p.implemented)).toBe(true);
+  });
+});

--- a/src/shared/provider-usage-normalize.ts
+++ b/src/shared/provider-usage-normalize.ts
@@ -1,0 +1,583 @@
+/**
+ * Pure normalize helpers for provider usage payloads.
+ * Free of Electron/UI and credential I/O so unit tests drive them with fixtures.
+ */
+
+import type {
+  ProviderUsageId,
+  ProviderUsageSnapshot,
+  ProviderUsageStatus,
+  ProviderUsageWindow,
+} from "./provider-usage";
+import { providerDisplayName } from "./provider-usage";
+
+function finiteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function isoFromUnknown(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) {
+    const t = Date.parse(value);
+    return Number.isNaN(t) ? null : new Date(t).toISOString();
+  }
+  const n = finiteNumber(value);
+  if (n === null) return null;
+  // Codex uses unix seconds for reset_at.
+  const ms = n > 1e12 ? n : n * 1000;
+  const d = new Date(ms);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+function windowOf(
+  id: string,
+  label: string,
+  utilization: number | null,
+  resetsAt: string | null,
+  detail?: string,
+): ProviderUsageWindow | null {
+  if (utilization === null && !detail) return null;
+  return { id, label, utilization, resetsAt, ...(detail ? { detail } : {}) };
+}
+
+/** Compact human amount for meterless balance windows. */
+export function formatAmount(value: number, unit?: string): string {
+  const s = Number.isInteger(value)
+    ? String(value)
+    : Math.abs(value) >= 100
+      ? value.toFixed(0)
+      : value.toFixed(2);
+  return unit ? `${s} ${unit}` : s;
+}
+
+/**
+ * Claude OAuth / statusline-tap shape:
+ * `{ five_hour, seven_day, seven_day_opus }` each `{ utilization, resets_at }`.
+ */
+export function normalizeClaudeUsagePayload(
+  body: unknown,
+  opts?: { fetchedAt?: number; status?: ProviderUsageStatus; error?: string },
+): ProviderUsageSnapshot {
+  const b = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  const parseBucket = (bucket: unknown): { utilization: number; resetsAt: string | null } | null => {
+    if (!bucket || typeof bucket !== "object") return null;
+    const o = bucket as { utilization?: unknown; resets_at?: unknown; resetsAt?: unknown };
+    const utilization = finiteNumber(o.utilization);
+    if (utilization === null) return null;
+    return {
+      utilization,
+      resetsAt: isoFromUnknown(o.resets_at ?? o.resetsAt),
+    };
+  };
+
+  const session = parseBucket(b.five_hour);
+  const weekly = parseBucket(b.seven_day);
+  // Model-scoped weekly slot — CodexBar prefers seven_day_sonnet over opus.
+  const sonnet = parseBucket(b.seven_day_sonnet);
+  const weeklyOpus = sonnet ?? parseBucket(b.seven_day_opus);
+  const modelLabel = sonnet ? "sonnet" : "opus";
+  const windows: ProviderUsageWindow[] = [];
+  if (session) {
+    windows.push({ id: "session", label: "session", utilization: session.utilization, resetsAt: session.resetsAt });
+  }
+  if (weekly) {
+    windows.push({ id: "weekly", label: "week", utilization: weekly.utilization, resetsAt: weekly.resetsAt });
+  }
+  if (weeklyOpus) {
+    windows.push({
+      id: "weeklyOpus",
+      label: modelLabel,
+      utilization: weeklyOpus.utilization,
+      resetsAt: weeklyOpus.resetsAt,
+    });
+  }
+
+  return {
+    id: "claude",
+    displayName: providerDisplayName("claude"),
+    status: opts?.status ?? (windows.length > 0 ? "ok" : "error"),
+    windows,
+    fetchedAt: opts?.fetchedAt ?? Date.now(),
+    ...(opts?.error ? { error: opts.error } : {}),
+  };
+}
+
+/**
+ * Codex `wham/usage` rate_limit windows:
+ * `rate_limit.primary_window` / `secondary_window` with
+ * `used_percent`, `reset_at` (unix s), `limit_window_seconds`.
+ */
+export function normalizeCodexUsagePayload(
+  body: unknown,
+  opts?: { fetchedAt?: number; status?: ProviderUsageStatus; error?: string },
+): ProviderUsageSnapshot {
+  const b = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  const rateLimit =
+    b.rate_limit && typeof b.rate_limit === "object"
+      ? (b.rate_limit as Record<string, unknown>)
+      : b.rateLimit && typeof b.rateLimit === "object"
+        ? (b.rateLimit as Record<string, unknown>)
+        : {};
+
+  const parseWindow = (
+    raw: unknown,
+  ): { utilization: number; resetsAt: string | null; windowMinutes: number | null } | null => {
+    if (!raw || typeof raw !== "object") return null;
+    const w = raw as Record<string, unknown>;
+    const utilization = finiteNumber(w.used_percent ?? w.usedPercent);
+    if (utilization === null) return null;
+    const seconds = finiteNumber(w.limit_window_seconds ?? w.limitWindowSeconds);
+    return {
+      utilization,
+      resetsAt: isoFromUnknown(w.reset_at ?? w.resetAt),
+      windowMinutes: seconds === null ? null : Math.round(seconds / 60),
+    };
+  };
+
+  let primary = parseWindow(rateLimit.primary_window ?? rateLimit.primaryWindow);
+  let secondary = parseWindow(rateLimit.secondary_window ?? rateLimit.secondaryWindow);
+
+  // Align with CodexRateWindowNormalizer: 300m = session, 10080m = weekly.
+  const role = (w: { windowMinutes: number | null }) => {
+    if (w.windowMinutes === 300) return "session" as const;
+    if (w.windowMinutes === 10080) return "weekly" as const;
+    return "unknown" as const;
+  };
+  if (primary && secondary) {
+    const pr = role(primary);
+    const sr = role(secondary);
+    if (pr === "weekly" && (sr === "session" || sr === "unknown")) {
+      const tmp = primary;
+      primary = secondary;
+      secondary = tmp;
+    }
+  } else if (primary && !secondary && role(primary) === "weekly") {
+    secondary = primary;
+    primary = null;
+  } else if (!primary && secondary && role(secondary) !== "weekly") {
+    // CodexRateWindowNormalizer promotes a lone secondary window to the
+    // primary/session lane unless it is definitely the weekly window.
+    primary = secondary;
+    secondary = null;
+  }
+
+  const windows: ProviderUsageWindow[] = [];
+  if (primary) {
+    windows.push({
+      id: "session",
+      label: "session",
+      utilization: primary.utilization,
+      resetsAt: primary.resetsAt,
+    });
+  }
+  if (secondary) {
+    windows.push({
+      id: "weekly",
+      label: "week",
+      utilization: secondary.utilization,
+      resetsAt: secondary.resetsAt,
+    });
+  }
+
+  return {
+    id: "codex",
+    displayName: providerDisplayName("codex"),
+    status: opts?.status ?? (windows.length > 0 ? "ok" : "error"),
+    windows,
+    fetchedAt: opts?.fetchedAt ?? Date.now(),
+    ...(opts?.error ? { error: opts.error } : {}),
+  };
+}
+
+/**
+ * Cursor `usage-summary` response → plan / auto / api windows.
+ * Mirrors CursorStatusProbe snapshot mapping (plan primary, auto secondary, api tertiary).
+ */
+export function normalizeCursorUsagePayload(
+  body: unknown,
+  opts?: { fetchedAt?: number; status?: ProviderUsageStatus; error?: string },
+): ProviderUsageSnapshot {
+  const b = body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  const rec = (v: unknown): Record<string, unknown> =>
+    v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+  const individual = rec(b.individualUsage);
+  const plan = rec(individual.plan);
+  const clamp = (v: number | null): number | null =>
+    v === null ? null : Math.min(100, Math.max(0, v));
+
+  const resetsAt = isoFromUnknown(b.billingCycleEnd);
+  const planPct = clamp(finiteNumber(plan.totalPercentUsed));
+  const autoPct = clamp(finiteNumber(plan.autoPercentUsed));
+  const apiPct = clamp(finiteNumber(plan.apiPercentUsed));
+
+  const ratioPct = (o: Record<string, unknown>): number | null => {
+    const used = finiteNumber(o.used);
+    const limit = finiteNumber(o.limit);
+    if (used === null || limit === null || limit <= 0) return null;
+    return clamp((used / limit) * 100);
+  };
+
+  // Headline plan percent — CursorStatusProbe precedence: totalPercentUsed →
+  // avg(auto, api) → api alone → auto alone → plan used/limit →
+  // individualUsage.overall (enterprise personal cap) → teamUsage.pooled.
+  let planUtilization = planPct;
+  if (planUtilization === null && autoPct !== null && apiPct !== null) {
+    planUtilization = clamp((autoPct + apiPct) / 2);
+  }
+  if (planUtilization === null) planUtilization = apiPct ?? autoPct;
+  if (planUtilization === null) planUtilization = ratioPct(plan);
+  if (planUtilization === null) planUtilization = ratioPct(rec(individual.overall));
+  if (planUtilization === null) planUtilization = ratioPct(rec(rec(b.teamUsage).pooled));
+
+  const windows: ProviderUsageWindow[] = [];
+  const planWin = windowOf("plan", "plan", planUtilization, resetsAt);
+  if (planWin) windows.push(planWin);
+  const autoWin = windowOf("auto", "auto", autoPct, resetsAt);
+  if (autoWin) windows.push(autoWin);
+  const apiWin = windowOf("api", "api", apiPct, resetsAt);
+  if (apiWin) windows.push(apiWin);
+
+  return {
+    id: "cursor",
+    displayName: providerDisplayName("cursor"),
+    status: opts?.status ?? (windows.length > 0 ? "ok" : "error"),
+    windows,
+    fetchedAt: opts?.fetchedAt ?? Date.now(),
+    ...(opts?.error ? { error: opts.error } : {}),
+  };
+}
+
+/** Map a known ClaudeUsageLimits-shaped object into the multi-provider snapshot. */
+export function claudeLimitsToProviderSnapshot(limits: {
+  session: { utilization: number; resetsAt: string | null } | null;
+  weekly: { utilization: number; resetsAt: string | null } | null;
+  weeklyOpus: { utilization: number; resetsAt: string | null } | null;
+  status: string;
+  fetchedAt: number;
+  error?: string;
+}): ProviderUsageSnapshot {
+  const windows: ProviderUsageWindow[] = [];
+  if (limits.session) {
+    windows.push({
+      id: "session",
+      label: "session",
+      utilization: limits.session.utilization,
+      resetsAt: limits.session.resetsAt,
+    });
+  }
+  if (limits.weekly) {
+    windows.push({
+      id: "weekly",
+      label: "week",
+      utilization: limits.weekly.utilization,
+      resetsAt: limits.weekly.resetsAt,
+    });
+  }
+  if (limits.weeklyOpus) {
+    windows.push({
+      id: "weeklyOpus",
+      label: "opus",
+      utilization: limits.weeklyOpus.utilization,
+      resetsAt: limits.weeklyOpus.resetsAt,
+    });
+  }
+  const status: ProviderUsageStatus =
+    limits.status === "ok" ||
+    limits.status === "unauthenticated" ||
+    limits.status === "rate_limited" ||
+    limits.status === "error"
+      ? limits.status
+      : "error";
+  return {
+    id: "claude",
+    displayName: providerDisplayName("claude"),
+    status,
+    windows,
+    fetchedAt: limits.fetchedAt,
+    ...(limits.error ? { error: limits.error } : {}),
+  };
+}
+
+/** @deprecated Prefer live adapters — kept for fixtures that assert legacy stub shape. */
+export function stubProviderSnapshot(id: ProviderUsageId): ProviderUsageSnapshot {
+  return {
+    id,
+    displayName: providerDisplayName(id),
+    status: "unavailable",
+    windows: [],
+    fetchedAt: Date.now(),
+    error: "Adapter not yet ported from CodexBar (catalog entry only)",
+  };
+}
+
+function asRecord(body: unknown): Record<string, unknown> {
+  return body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+}
+
+function nested(obj: Record<string, unknown>, ...path: string[]): unknown {
+  let cur: unknown = obj;
+  for (const key of path) {
+    if (!cur || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return cur;
+}
+
+function balanceWindow(
+  id: string,
+  label: string,
+  used: number | null,
+  limit: number | null,
+  remaining: number | null,
+  resetsAt: string | null = null,
+  unit?: string,
+): ProviderUsageWindow | null {
+  if (used !== null && limit !== null && limit > 0) {
+    return { id, label, utilization: (used / limit) * 100, resetsAt };
+  }
+  if (remaining !== null && limit !== null && limit > 0) {
+    return { id, label, utilization: ((limit - remaining) / limit) * 100, resetsAt };
+  }
+  // Balance-only: no meter exists — carry the value itself, never a fake 0%.
+  if (remaining !== null) {
+    return { id, label, utilization: null, resetsAt, detail: formatAmount(remaining, unit) };
+  }
+  if (used !== null) {
+    return { id, label, utilization: null, resetsAt, detail: `${formatAmount(used, unit)} used` };
+  }
+  return null;
+}
+
+/** OpenRouter `/api/v1/credits` + `/api/v1/key` combined normalize. */
+export function normalizeOpenRouterUsagePayload(
+  creditsBody: unknown,
+  keyBody?: unknown,
+  opts?: { fetchedAt?: number },
+): ProviderUsageSnapshot {
+  const creditsRoot = asRecord(creditsBody);
+  const data = asRecord(nested(creditsRoot, "data") ?? creditsRoot);
+  const totalCredits = finiteNumber(data.total_credits ?? data.totalCredits);
+  const totalUsage = finiteNumber(data.total_usage ?? data.totalUsage);
+  const remaining =
+    totalCredits !== null && totalUsage !== null ? Math.max(0, totalCredits - totalUsage) : totalCredits;
+
+  const windows: ProviderUsageWindow[] = [];
+  const bal = balanceWindow("balance", "bal", totalUsage, totalCredits, remaining, null);
+  if (bal) windows.push(bal);
+
+  if (keyBody) {
+    const keyRoot = asRecord(keyBody);
+    const keyData = asRecord(nested(keyRoot, "data") ?? keyRoot);
+    const limit = finiteNumber(keyData.limit ?? keyData.limit_remaining);
+    const usage = finiteNumber(keyData.usage ?? keyData.usage_daily);
+    const limitWin = balanceWindow("key", "key", usage, limit, null, null);
+    if (limitWin && (usage !== null || (limit !== null && limit > 0))) windows.push(limitWin);
+
+    for (const [field, wid, label] of [
+      ["usage_daily", "day", "day"],
+      ["usage_weekly", "week", "week"],
+      ["usage_monthly", "month", "month"],
+    ] as const) {
+      const spend = finiteNumber(keyData[field]);
+      if (spend !== null && spend > 0) {
+        // Spend-only lanes without a hard limit — meterless detail windows.
+        windows.push({
+          id: wid,
+          label,
+          utilization: null,
+          resetsAt: null,
+          detail: `${formatAmount(spend)} spent`,
+        });
+      }
+    }
+  }
+
+  return {
+    id: "openrouter",
+    displayName: providerDisplayName("openrouter"),
+    status: windows.length > 0 ? "ok" : "error",
+    windows,
+    fetchedAt: opts?.fetchedAt ?? Date.now(),
+    ...(windows.length === 0 ? { error: "no OpenRouter usage fields" } : {}),
+  };
+}
+
+/** DeepSeek `GET /user/balance` → balance window. */
+export function normalizeDeepSeekUsagePayload(
+  body: unknown,
+  opts?: { fetchedAt?: number },
+): ProviderUsageSnapshot {
+  const root = asRecord(body);
+  const infos = Array.isArray(root.balance_infos)
+    ? root.balance_infos
+    : Array.isArray(root.balanceInfos)
+      ? root.balanceInfos
+      : [];
+  let total: number | null = null;
+  let unit: string | undefined;
+  for (const raw of infos) {
+    if (!raw || typeof raw !== "object") continue;
+    const info = raw as Record<string, unknown>;
+    const currency = String(info.currency ?? "").toUpperCase();
+    const t = finiteNumber(info.total_balance ?? info.totalBalance);
+    if (t === null) continue;
+    if (currency === "USD" || total === null) {
+      total = t;
+      unit = currency || undefined;
+      if (currency === "USD" && t > 0) break;
+    }
+  }
+  const windows: ProviderUsageWindow[] = [];
+  const bal = balanceWindow("balance", "bal", null, null, total, null, unit);
+  if (bal) {
+    windows.push(bal);
+  }
+  return {
+    id: "deepseek",
+    displayName: providerDisplayName("deepseek"),
+    status: windows.length > 0 ? "ok" : "error",
+    windows,
+    fetchedAt: opts?.fetchedAt ?? Date.now(),
+    ...(windows.length === 0 ? { error: "no balance data" } : {}),
+  };
+}
+
+/** ElevenLabs `GET /v1/user/subscription`. */
+export function normalizeElevenLabsUsagePayload(
+  body: unknown,
+  opts?: { fetchedAt?: number },
+): ProviderUsageSnapshot {
+  const root = asRecord(body);
+  const used = finiteNumber(root.character_count ?? root.characterCount);
+  const limit = finiteNumber(root.character_limit ?? root.characterLimit);
+  const resetUnix = finiteNumber(
+    root.next_character_count_reset_unix ?? root.nextCharacterCountResetUnix,
+  );
+  const resetsAt = resetUnix !== null ? isoFromUnknown(resetUnix) : null;
+  const windows: ProviderUsageWindow[] = [];
+  const chars = balanceWindow("characters", "chars", used, limit, null, resetsAt);
+  if (chars) windows.push(chars);
+
+  const voiceUsed = finiteNumber(root.voice_slots_used ?? root.voiceSlotsUsed);
+  const voiceLimit = finiteNumber(root.voice_limit ?? root.voiceLimit);
+  const voices = balanceWindow("voices", "voices", voiceUsed, voiceLimit, null, null);
+  if (voices && voiceUsed !== null && voiceLimit !== null) windows.push(voices);
+
+  return {
+    id: "elevenlabs",
+    displayName: providerDisplayName("elevenlabs"),
+    status: windows.length > 0 ? "ok" : "error",
+    windows,
+    fetchedAt: opts?.fetchedAt ?? Date.now(),
+    ...(windows.length === 0 ? { error: "no subscription fields" } : {}),
+  };
+}
+
+/** Moonshot balance payload. */
+export function normalizeMoonshotUsagePayload(
+  body: unknown,
+  opts?: { fetchedAt?: number },
+): ProviderUsageSnapshot {
+  const root = asRecord(body);
+  const data = asRecord(nested(root, "data") ?? root);
+  const available = finiteNumber(data.available_balance ?? data.availableBalance);
+  const windows: ProviderUsageWindow[] = [];
+  const bal = balanceWindow("balance", "bal", null, null, available, null);
+  if (bal) windows.push(bal);
+  return {
+    id: "moonshot",
+    displayName: providerDisplayName("moonshot"),
+    status: windows.length > 0 ? "ok" : "error",
+    windows,
+    fetchedAt: opts?.fetchedAt ?? Date.now(),
+    ...(windows.length === 0 ? { error: "no balance" } : {}),
+  };
+}
+
+/** Kimi K2 credits payload. */
+export function normalizeKimiK2UsagePayload(
+  body: unknown,
+  opts?: { fetchedAt?: number },
+): ProviderUsageSnapshot {
+  const root = asRecord(body);
+  const consumed = finiteNumber(
+    root.total_credits_consumed ?? root.total_credits_used ?? root.consumed ?? root.used,
+  );
+  const remaining = finiteNumber(
+    root.credits_remaining ??
+      root.creditsRemaining ??
+      root.remaining_credits ??
+      root.remainingCredits ??
+      root.remaining,
+  );
+  const limit =
+    consumed !== null && remaining !== null ? consumed + remaining : finiteNumber(root.total ?? root.limit);
+  const windows: ProviderUsageWindow[] = [];
+  const bal = balanceWindow("credits", "credits", consumed, limit, remaining, null);
+  if (bal) windows.push(bal);
+  return {
+    id: "kimik2",
+    displayName: providerDisplayName("kimik2"),
+    status: windows.length > 0 ? "ok" : "error",
+    windows,
+    fetchedAt: opts?.fetchedAt ?? Date.now(),
+    ...(windows.length === 0 ? { error: "no credit fields" } : {}),
+  };
+}
+
+/** Poe current_balance payload. */
+export function normalizePoeUsagePayload(
+  body: unknown,
+  opts?: { fetchedAt?: number },
+): ProviderUsageSnapshot {
+  const root = asRecord(body);
+  const balance = finiteNumber(
+    root.current_point_balance ?? root.currentPointBalance ?? root.balance ?? root.points,
+  );
+  const windows: ProviderUsageWindow[] = [];
+  const bal = balanceWindow("balance", "pts", null, null, balance, null, "pts");
+  if (bal) windows.push(bal);
+  return {
+    id: "poe",
+    displayName: providerDisplayName("poe"),
+    status: windows.length > 0 ? "ok" : "error",
+    windows,
+    fetchedAt: opts?.fetchedAt ?? Date.now(),
+    ...(windows.length === 0 ? { error: "no balance" } : {}),
+  };
+}
+
+/** Crof usage_api payload. */
+export function normalizeCrofUsagePayload(
+  body: unknown,
+  opts?: { fetchedAt?: number },
+): ProviderUsageSnapshot {
+  const root = asRecord(body);
+  const windows: ProviderUsageWindow[] = [];
+  const requestsPlan = finiteNumber(root.requests_plan ?? root.requestsPlan);
+  const usable = finiteNumber(root.usable_requests ?? root.usableRequests);
+  if (requestsPlan !== null && requestsPlan > 0 && usable !== null) {
+    const used = Math.max(0, requestsPlan - usable);
+    windows.push({
+      id: "requests",
+      label: "req",
+      utilization: (used / requestsPlan) * 100,
+      resetsAt: null,
+    });
+  }
+  const credits = finiteNumber(root.credits);
+  const creditWin = balanceWindow("credits", "credits", null, null, credits, null);
+  if (creditWin) windows.push(creditWin);
+  return {
+    id: "crof",
+    displayName: providerDisplayName("crof"),
+    status: windows.length > 0 ? "ok" : "error",
+    windows,
+    fetchedAt: opts?.fetchedAt ?? Date.now(),
+    ...(windows.length === 0 ? { error: "no crof usage fields" } : {}),
+  };
+}

--- a/src/shared/provider-usage.ts
+++ b/src/shared/provider-usage.ts
@@ -1,0 +1,221 @@
+/**
+ * Multi-provider usage limits — CodexBar capability forked into mission-control
+ * TypeScript (Windows + macOS). Catalog IDs match CodexBar's UsageProvider.
+ *
+ * Every catalog id has a live adapter that resolves credentials and probes
+ * the provider API/local source. Missing credentials → unauthenticated.
+ */
+
+/** A single usage window (session, weekly, plan, auto, balance, …). */
+export type ProviderUsageWindow = {
+  /** Stable window id within the provider (e.g. session, weekly, plan). */
+  id: string;
+  /** Short UI label. */
+  label: string;
+  /**
+   * Percent of the limit consumed, 0–100 (may exceed 100 from APIs).
+   * `null` for meterless windows (e.g. prepaid balances) — the UI renders
+   * `detail` instead of a bar; never fabricate 0% for unknown usage.
+   */
+  utilization: number | null;
+  /** ISO-8601 reset time, or null if unknown. */
+  resetsAt: string | null;
+  /** Human value for meterless windows ("$12.34", "1,200 pts"). */
+  detail?: string;
+};
+
+export type ProviderUsageStatus =
+  | "ok"
+  | "unauthenticated"
+  | "rate_limited"
+  | "error"
+  | "unavailable";
+
+/** CodexBar UsageProvider raw values (full catalog). */
+export const PROVIDER_USAGE_IDS = [
+  "codex",
+  "openai",
+  "azureopenai",
+  "claude",
+  "cursor",
+  "opencode",
+  "opencodego",
+  "alibaba",
+  "alibabatokenplan",
+  "factory",
+  "gemini",
+  "antigravity",
+  "copilot",
+  "devin",
+  "zai",
+  "minimax",
+  "manus",
+  "kimi",
+  "kilo",
+  "kiro",
+  "vertexai",
+  "augment",
+  "jetbrains",
+  "kimik2",
+  "moonshot",
+  "amp",
+  "t3chat",
+  "ollama",
+  "synthetic",
+  "warp",
+  "openrouter",
+  "elevenlabs",
+  "windsurf",
+  "zed",
+  "perplexity",
+  "mimo",
+  "doubao",
+  "sakana",
+  "abacus",
+  "mistral",
+  "deepseek",
+  "codebuff",
+  "crof",
+  "venice",
+  "commandcode",
+  "qoder",
+  "stepfun",
+  "bedrock",
+  "grok",
+  "groq",
+  "llmproxy",
+  "litellm",
+  "deepgram",
+  "poe",
+  "chutes",
+  "crossmodel",
+  "clawrouter",
+  "wayfinder",
+] as const;
+
+export type ProviderUsageId = (typeof PROVIDER_USAGE_IDS)[number];
+
+export type ProviderUsageMeta = {
+  id: ProviderUsageId;
+  displayName: string;
+  /** Whether this provider has a live TS adapter (vs catalog-only stub). */
+  implemented: boolean;
+  /** Default-on for mission-control agent surface. */
+  defaultEnabled: boolean;
+};
+
+/** Full forked catalog — display names align with CodexBar ProviderDefaults. */
+export const PROVIDER_USAGE_CATALOG: readonly ProviderUsageMeta[] = [
+  { id: "claude", displayName: "Claude", implemented: true, defaultEnabled: true },
+  { id: "codex", displayName: "Codex", implemented: true, defaultEnabled: true },
+  { id: "cursor", displayName: "Cursor", implemented: true, defaultEnabled: true },
+  { id: "openai", displayName: "OpenAI", implemented: true, defaultEnabled: false },
+  { id: "azureopenai", displayName: "Azure OpenAI", implemented: true, defaultEnabled: false },
+  { id: "opencode", displayName: "OpenCode", implemented: true, defaultEnabled: false },
+  { id: "opencodego", displayName: "OpenCode Go", implemented: true, defaultEnabled: false },
+  { id: "alibaba", displayName: "Alibaba Coding Plan", implemented: true, defaultEnabled: false },
+  { id: "alibabatokenplan", displayName: "Alibaba Token Plan", implemented: true, defaultEnabled: false },
+  { id: "factory", displayName: "Factory", implemented: true, defaultEnabled: false },
+  { id: "gemini", displayName: "Gemini", implemented: true, defaultEnabled: false },
+  { id: "antigravity", displayName: "Antigravity", implemented: true, defaultEnabled: false },
+  { id: "copilot", displayName: "Copilot", implemented: true, defaultEnabled: false },
+  { id: "devin", displayName: "Devin", implemented: true, defaultEnabled: false },
+  { id: "zai", displayName: "Z.ai", implemented: true, defaultEnabled: false },
+  { id: "minimax", displayName: "MiniMax", implemented: true, defaultEnabled: false },
+  { id: "manus", displayName: "Manus", implemented: true, defaultEnabled: false },
+  { id: "kimi", displayName: "Kimi", implemented: true, defaultEnabled: false },
+  { id: "kilo", displayName: "Kilo", implemented: true, defaultEnabled: false },
+  { id: "kiro", displayName: "Kiro", implemented: true, defaultEnabled: false },
+  { id: "vertexai", displayName: "Vertex AI", implemented: true, defaultEnabled: false },
+  { id: "augment", displayName: "Augment", implemented: true, defaultEnabled: false },
+  { id: "jetbrains", displayName: "JetBrains", implemented: true, defaultEnabled: false },
+  { id: "kimik2", displayName: "Kimi K2", implemented: true, defaultEnabled: false },
+  { id: "moonshot", displayName: "Moonshot", implemented: true, defaultEnabled: false },
+  { id: "amp", displayName: "Amp", implemented: true, defaultEnabled: false },
+  { id: "t3chat", displayName: "T3 Chat", implemented: true, defaultEnabled: false },
+  { id: "ollama", displayName: "Ollama", implemented: true, defaultEnabled: false },
+  { id: "synthetic", displayName: "Synthetic", implemented: true, defaultEnabled: false },
+  { id: "warp", displayName: "Warp", implemented: true, defaultEnabled: false },
+  { id: "openrouter", displayName: "OpenRouter", implemented: true, defaultEnabled: false },
+  { id: "elevenlabs", displayName: "ElevenLabs", implemented: true, defaultEnabled: false },
+  { id: "windsurf", displayName: "Windsurf", implemented: true, defaultEnabled: false },
+  { id: "zed", displayName: "Zed", implemented: true, defaultEnabled: false },
+  { id: "perplexity", displayName: "Perplexity", implemented: true, defaultEnabled: false },
+  { id: "mimo", displayName: "MiMo", implemented: true, defaultEnabled: false },
+  { id: "doubao", displayName: "Doubao", implemented: true, defaultEnabled: false },
+  { id: "sakana", displayName: "Sakana", implemented: true, defaultEnabled: false },
+  { id: "abacus", displayName: "Abacus", implemented: true, defaultEnabled: false },
+  { id: "mistral", displayName: "Mistral", implemented: true, defaultEnabled: false },
+  { id: "deepseek", displayName: "DeepSeek", implemented: true, defaultEnabled: false },
+  { id: "codebuff", displayName: "Codebuff", implemented: true, defaultEnabled: false },
+  { id: "crof", displayName: "Crof", implemented: true, defaultEnabled: false },
+  { id: "venice", displayName: "Venice", implemented: true, defaultEnabled: false },
+  { id: "commandcode", displayName: "Command Code", implemented: true, defaultEnabled: false },
+  { id: "qoder", displayName: "Qoder", implemented: true, defaultEnabled: false },
+  { id: "stepfun", displayName: "StepFun", implemented: true, defaultEnabled: false },
+  { id: "bedrock", displayName: "Bedrock", implemented: true, defaultEnabled: false },
+  { id: "grok", displayName: "Grok", implemented: true, defaultEnabled: false },
+  { id: "groq", displayName: "Groq", implemented: true, defaultEnabled: false },
+  { id: "llmproxy", displayName: "LLM Proxy", implemented: true, defaultEnabled: false },
+  { id: "litellm", displayName: "LiteLLM", implemented: true, defaultEnabled: false },
+  { id: "deepgram", displayName: "Deepgram", implemented: true, defaultEnabled: false },
+  { id: "poe", displayName: "Poe", implemented: true, defaultEnabled: false },
+  { id: "chutes", displayName: "Chutes", implemented: true, defaultEnabled: false },
+  { id: "crossmodel", displayName: "CrossModel", implemented: true, defaultEnabled: false },
+  { id: "clawrouter", displayName: "ClawRouter", implemented: true, defaultEnabled: false },
+  { id: "wayfinder", displayName: "Wayfinder", implemented: true, defaultEnabled: false },
+] as const;
+
+export const DEFAULT_PROVIDER_USAGE_IDS: ProviderUsageId[] = PROVIDER_USAGE_CATALOG.filter(
+  (p) => p.defaultEnabled,
+).map((p) => p.id);
+
+export type ProviderUsageSnapshot = {
+  id: ProviderUsageId;
+  displayName: string;
+  status: ProviderUsageStatus;
+  windows: ProviderUsageWindow[];
+  fetchedAt: number;
+  error?: string;
+};
+
+/** Aggregated multi-provider payload returned by GET /api/provider-usage. */
+export type ProviderUsageResponse = {
+  providers: ProviderUsageSnapshot[];
+  fetchedAt: number;
+};
+
+export function isProviderUsageId(value: unknown): value is ProviderUsageId {
+  return typeof value === "string" && (PROVIDER_USAGE_IDS as readonly string[]).includes(value);
+}
+
+export function providerDisplayName(id: ProviderUsageId): string {
+  return PROVIDER_USAGE_CATALOG.find((p) => p.id === id)?.displayName ?? id;
+}
+
+export function normalizeProviderUsageIds(raw: unknown): ProviderUsageId[] {
+  if (!Array.isArray(raw)) return [...DEFAULT_PROVIDER_USAGE_IDS];
+  const out: ProviderUsageId[] = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    if (!isProviderUsageId(item) || seen.has(item)) continue;
+    seen.add(item);
+    out.push(item);
+  }
+  return out.length > 0 ? out : [...DEFAULT_PROVIDER_USAGE_IDS];
+}
+
+export function emptyProviderSnapshot(
+  id: ProviderUsageId,
+  status: ProviderUsageStatus,
+  error?: string,
+): ProviderUsageSnapshot {
+  return {
+    id,
+    displayName: providerDisplayName(id),
+    status,
+    windows: [],
+    fetchedAt: Date.now(),
+    ...(error ? { error } : {}),
+  };
+}


### PR DESCRIPTION
Forks CodexBar's multi-provider usage/limits capability into Mission Control (TypeScript/Electron, Windows + macOS). Every adapter was fact-checked against the CodexBar Swift sources; behavior is faithful where portable and honest where not.

## Backend
- **Full catalog, no stubs**: all 58 CodexBar `UsageProvider` ids route through live adapters. Missing credentials → `unauthenticated` (with the exact env var / config entry / auth file named); unportable protocols (gRPC-web protobuf, AWS SigV4, console `sec_token` scrapes, private GraphQL, CLI JSON-RPC) → `error` naming the gap. Never `unavailable`-because-unimplemented, never fake-healthy 0% gauges.
- **Honest data model**: windows are either real meters (`utilization` 0–100 + reset) or meterless values (`utilization: null` + `detail: "$12.34"`) for prepaid balances/spend.
- **Credential resolution**: env → `~/.codexbar/config.json` → CLI auth files → cookies; bare cookie tokens are wrapped with each provider's real cookie name (e.g. Perplexity `__Secure-next-auth.session-token`, Kimi `kimi-auth`). Windows + macOS paths probed. No secrets logged; tests use injected readers/fixtures.
- **Core trio corrected to CodexBar behavior**: Claude (`claude-code` UA, 401 vs 403 split, `seven_day_sonnet ?? seven_day_opus` model slot, file-before-keychain), Codex (`chatgpt_base_url` from `config.toml` with the `/backend-api` vs `/api/codex/usage` rule, CodexRateWindowNormalizer lone-window promotion), Cursor (full plan-percent precedence chain incl. enterprise/team ratios, clamping, JWT-expiry check).
- **Real-data adapters** built from verbatim Swift specs: OpenCodeGo (local `opencode.db` cost sums vs $12/$30/$60 windows), Windsurf (`state.vscdb` `cachedPlanInfo`, remaining→used inversion), Kilo (tRPC credit blocks, micro-USD), Copilot (editor headers, zero-entitlement suppression), JetBrains (quotaInfo JSON-in-XML), Zed (`userID token` auth, edit-predictions window), Perplexity (credit-grants waterfall), MiniMax (inverted `model_remains`), Zai, Kimi, Synthetic, Chutes, Amp, Codebuff, CrossModel, LLMProxy, LiteLLM, ClawRouter, Factory, CommandCode, Qoder, StepFun, Abacus, Augment, Devin, Manus, Mistral, T3Chat, MiMo, Sakana, Doubao, and the API-key set.

## UI (opt-in, quiet by default)
- Top bar: single ghost chip — utilization ring + worst window (`codex 91%`), status-colored. CardFrame popover: per-provider bars/percents/resets (or detail text), auth help for unauthenticated providers, refresh, Settings shortcut. Escape/click-outside/focus handled; disabled ⇒ no chrome at all.
- Settings → Usage: searchable chip-grid over the catalog with live status dots, "Needs sign-in" hints, Claude session/weekly toggles.

## API
- `GET /api/provider-usage?providers=a,b,c` → `{ providers: [{id, status, windows[]}], fetchedAt }`. Legacy `GET /api/claude-usage-limits` unchanged.

## Verification
- Typecheck + ESLint clean; 27 provider unit tests + settings/API suites green (fixtures drive the shipped normalize/service/API paths).
- Live smoke on Windows with real local credentials: Claude ok (session/weekly), Codex ok (session/weekly), Cursor ok (plan/auto/api), OpenRouter honest `unauthenticated`.
- `docs/provider-usage.md` documents the adapter tiers and data model.