### PR TITLE
SECURITY AUDIT: MEDIUM: unvalidated hook transcript_path enables arbitrary file read into project memory

### DIFF
--- a/.agents/skills/recall/SKILL.md
+++ b/.agents/skills/recall/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: recall
+description: "Save durable project knowledge to Mission Control's Recall (project memory) so future sessions start already knowing it, AND navigate this project's indexed code graph. Use when you discover or decide something worth remembering about THIS project — an architecture fact, a decision and its rationale, a convention, a stack detail, a glossary term, a known issue, or a useful discovery (\"X lives in Y\", \"Z is generated\"). Also use when you need to LOCATE or READ code — where a symbol is defined (and its verbatim source), what calls it, or what a change would impact — via the graph_search / graph_node / get_neighbors / impact_of / shortest_path MCP tools instead of grepping. Requires a Mission Control agent session (MC_API_URL, MC_API_TOKEN, MC_TASK_ID are injected automatically). Not for transient to-dos, run-specific notes, or projects running outside Mission Control."
+user-invocable: true
+---
+
+Mission Control agent sessions receive env vars automatically:
+
+- `MC_API_URL` — loopback API base (e.g. `http://127.0.0.1:54321`)
+- `MC_API_TOKEN` — bearer token for that API
+- `MC_TASK_ID` — the active task/session id
+
+Mission Control maintains **Recall**, a curated, per-project memory that it assembles into a **Session Brief** and hands to every new session. When you learn something durable about this project, write it back so the next session doesn't rediscover it.
+
+Skip this entirely when the MC env vars are missing (plain shell outside Mission Control).
+
+## Navigating the code (Recall code graph)
+
+Mission Control also indexes this project into a **code graph** — every function, class, method, type, interface, and file, plus the calls/imports between them. It's exposed as MCP tools on the `recall` server. **Prefer these over `grep`/`glob` when you need to locate code or trace relationships** — the graph is pre-indexed, ranked by how central a symbol is, and complete (it won't miss a dynamically-shaped call site the way a text search can):
+
+- `graph_search(query, include_source?)` — find **where a symbol is defined** by name or path (functions, classes, methods, types, React components, files). Your first move when you'd otherwise `grep` for a definition. Returns the most-connected matches first; pass `include_source: true` to get the top matches' verbatim source inline.
+- `graph_node(node)` — **read a symbol's definition source** (verbatim, line-numbered) without opening the file. Prefer this over `Read` when you need the body of one function/class/component.
+- `get_neighbors(node, direction)` — a symbol's **direct callers/callees and importers**. Answers "what calls X" / "what does X depend on" without grepping for call sites. `direction`: `in`, `out`, or `both`.
+- `impact_of(node)` — **what transitively breaks if I change this** (reverse-reachable dependents, several hops out). Run it before an edit instead of grepping for usages.
+- `shortest_path(from, to)` — **how two areas connect** through imports/calls — a question `grep` can't answer.
+
+If a graph tool reports the project isn't indexed yet, fall back to `grep` for that lookup; don't block on it. The graph covers JavaScript/TypeScript (`.ts` / `.tsx` / `.js` / `.jsx` / `.mts` / `.cts` / `.mjs` / `.cjs`) and Python (`.py`).
+
+## When to save a memory
+
+Save a memory when you establish a **durable fact about the project** — not about the current task:
+
+- **decision** — a choice that was made and why ("Use JWT instead of session cookies — stateless across the worker fleet")
+- **architecture** — where things live / how data flows ("Auth flow lives in `useAuth`")
+- **convention** — a project-specific pattern or do/don't ("All API errors go through `handleDomainError`")
+- **stack** — a language/framework/build/runtime/infra fact
+- **glossary** — a domain term and its meaning
+- **known-issue** — a current limitation, gotcha, or flaky area
+- **discovery** — a useful finding ("Migrations run on boot from `ensureSchema`")
+- **overview** / **preference** — what the project is / how the user likes to work here
+
+Do **not** save: the task you were asked to do, TODOs, transient state, or anything only true for this one run. Prefer a few high-signal facts over many. Recall dedupes by title, so re-saving a known fact is harmless.
+
+## How to save
+
+First resolve the project id from the task, then POST the memory:
+
+```bash
+# 1. Get the project id for this session.
+PROJECT_ID=$(curl -s "$MC_API_URL/api/tasks/$MC_TASK_ID" \
+  -H "authorization: Bearer $MC_API_TOKEN" \
+  | sed -n 's/.*"projectId":"\([^"]*\)".*/\1/p')
+
+# 2. Save a memory.
+curl -s -X POST "$MC_API_URL/api/projects/$PROJECT_ID/memory" \
+  -H "authorization: Bearer $MC_API_TOKEN" \
+  -H "content-type: application/json" \
+  -d '{
+    "type": "decision",
+    "title": "Use JWT instead of session cookies",
+    "body": "Chosen for statelessness across the worker fleet.",
+    "source": "agent",
+    "confidence": "confirmed"
+  }'
+```
+
+### Fields
+
+- `type` (required) — one of `overview`, `stack`, `architecture`, `decision`, `convention`, `glossary`, `known-issue`, `preference`, `discovery`.
+- `title` (required) — a one-line headline. This is what gets injected into future briefs, so make it self-contained (≤ 200 chars).
+- `body` (optional) — a short detail: the why / where / how.
+- `source` — always send `"agent"` so the memory is tagged as agent-written.
+- `confidence` — `"confirmed"` when you verified it in the code, `"inferred"` when you're reasonably sure, `"ambiguous"` when unsure.
+- `tags` (optional) — a string array for filtering.
+
+A `403` means the user has disabled agent memory writes in Settings → Recall — respect that and stop trying.
+
+## Etiquette
+
+- Save at most a handful of memories per session — the highest-signal facts only.
+- Keep each memory atomic (one fact per entry).
+- Don't echo the whole brief back; only write things that are genuinely new or now more certain.

--- a/src/server/services/__tests__/recall-auto-distill.test.ts
+++ b/src/server/services/__tests__/recall-auto-distill.test.ts
@@ -138,7 +138,10 @@ describe("recall auto-distill on session:finished", () => {
 
   it("feeds the session transcript to the distiller when one was reported", async () => {
     const { task } = makeProjectWithSession();
-    const transcriptFile = path.join(tmpRoot, `transcript-${task.id}.jsonl`);
+    // Paths must live under ~/.claude/projects/ (setTranscriptPath containment).
+    const claudeProjects = path.join(os.homedir(), ".claude", "projects");
+    fs.mkdirSync(claudeProjects, { recursive: true });
+    const transcriptFile = path.join(claudeProjects, `mc-autodistill-${task.id}.jsonl`);
     fs.writeFileSync(
       transcriptFile,
       [
@@ -155,24 +158,32 @@ describe("recall auto-distill on session:finished", () => {
       ].join("\n") + "\n",
       "utf8",
     );
-    setTranscriptPath(task.id, transcriptFile);
-    distillSession.mockResolvedValue([
-      { type: "architecture", title: "Rate limiting is token-bucket middleware", body: "" },
-    ]);
+    try {
+      setTranscriptPath(task.id, transcriptFile);
+      distillSession.mockResolvedValue([
+        { type: "architecture", title: "Rate limiting is token-bucket middleware", body: "" },
+      ]);
 
-    const learned = waitForLearned();
-    updateStatus(task.id, { status: "finished" });
-    await learned;
+      const learned = waitForLearned();
+      updateStatus(task.id, { status: "finished" });
+      await learned;
 
-    expect(distillSession).toHaveBeenCalledTimes(1);
-    const arg = distillSession.mock.calls[0][0] as { transcript: string | null };
-    expect(arg.transcript).toContain("ASSISTANT: I'll add a token-bucket limiter");
-    expect(arg.transcript).toContain("TOOL(Edit): src/mw/rate-limit.ts");
+      expect(distillSession).toHaveBeenCalledTimes(1);
+      const arg = distillSession.mock.calls[0][0] as { transcript: string | null };
+      expect(arg.transcript).toContain("ASSISTANT: I'll add a token-bucket limiter");
+      expect(arg.transcript).toContain("TOOL(Edit): src/mw/rate-limit.ts");
+    } finally {
+      fs.rmSync(transcriptFile, { force: true });
+    }
   });
 
   it("falls back to prompts-only when the transcript path is unreadable", async () => {
     const { task } = makeProjectWithSession();
-    setTranscriptPath(task.id, path.join(tmpRoot, "does-not-exist.jsonl"));
+    // Allowed location, but the file itself does not exist.
+    setTranscriptPath(
+      task.id,
+      path.join(os.homedir(), ".claude", "projects", "mc-autodistill-missing.jsonl"),
+    );
     distillSession.mockResolvedValue([{ type: "stack", title: "Electron app", body: "" }]);
 
     const learned = waitForLearned();

--- a/src/server/services/__tests__/recall-bounded-maps.test.ts
+++ b/src/server/services/__tests__/recall-bounded-maps.test.ts
@@ -1,10 +1,17 @@
 import { afterEach, describe, expect, it } from "vitest";
+import * as os from "node:os";
+import * as path from "node:path";
 import { sweepStaleCooldowns } from "../_cooldowns";
 import {
   __resetTranscriptPaths,
   getTranscriptPath,
   setTranscriptPath,
 } from "../session-transcripts";
+
+// setTranscriptPath only accepts paths under ~/.claude/projects/ (containment).
+function allowedPath(name: string): string {
+  return path.join(os.homedir(), ".claude", "projects", name);
+}
 
 describe("sweepStaleCooldowns", () => {
   it("drops entries older than 10× the window and keeps recent ones", () => {
@@ -26,21 +33,26 @@ describe("session transcript path map", () => {
 
   it("evicts the oldest-inserted task past the cap", () => {
     for (let i = 0; i < 501; i++) {
-      setTranscriptPath(`task-${i}`, `/tmp/transcript-${i}.jsonl`);
+      setTranscriptPath(`task-${i}`, allowedPath(`transcript-${i}.jsonl`));
     }
     expect(getTranscriptPath("task-0")).toBeUndefined();
-    expect(getTranscriptPath("task-1")).toBe("/tmp/transcript-1.jsonl");
-    expect(getTranscriptPath("task-500")).toBe("/tmp/transcript-500.jsonl");
+    expect(getTranscriptPath("task-1")).toBe(allowedPath("transcript-1.jsonl"));
+    expect(getTranscriptPath("task-500")).toBe(allowedPath("transcript-500.jsonl"));
   });
 
   it("refreshes recency when a task's path is re-reported", () => {
     for (let i = 0; i < 500; i++) {
-      setTranscriptPath(`task-${i}`, `/tmp/t-${i}.jsonl`);
+      setTranscriptPath(`task-${i}`, allowedPath(`t-${i}.jsonl`));
     }
     // task-0 reports again → becomes most recent, so task-1 is evicted instead.
-    setTranscriptPath("task-0", "/tmp/t-0-again.jsonl");
-    setTranscriptPath("task-new", "/tmp/t-new.jsonl");
-    expect(getTranscriptPath("task-0")).toBe("/tmp/t-0-again.jsonl");
+    setTranscriptPath("task-0", allowedPath("t-0-again.jsonl"));
+    setTranscriptPath("task-new", allowedPath("t-new.jsonl"));
+    expect(getTranscriptPath("task-0")).toBe(allowedPath("t-0-again.jsonl"));
     expect(getTranscriptPath("task-1")).toBeUndefined();
+  });
+
+  it("rejects paths outside the Claude transcript directory", () => {
+    setTranscriptPath("task-evil", "/tmp/not-a-claude-transcript.jsonl");
+    expect(getTranscriptPath("task-evil")).toBeUndefined();
   });
 });

--- a/src/server/services/git.ts
+++ b/src/server/services/git.ts
@@ -393,6 +393,28 @@ export async function fetchRemote(
 export type PullMode = "ff-only" | "rebase" | "merge";
 
 /**
+ * Rebase/merge pulls create a commit, which git refuses to do when no
+ * committer identity is configured ("empty ident name … not allowed") — common
+ * on fresh machines, sandboxes, and CI runners. Inject a throwaway identity for
+ * *only* the fields git can't already resolve, so a configured user.name/email
+ * is always preferred and left untouched.
+ */
+async function fallbackIdentityArgs(cwd: string): Promise<string[]> {
+  const [name, email] = await Promise.all([
+    runGit(cwd, ["config", "user.name"]),
+    runGit(cwd, ["config", "user.email"]),
+  ]);
+  const args: string[] = [];
+  if (!(name.code === 0 && name.stdout.trim())) {
+    args.push("-c", "user.name=Mission Control");
+  }
+  if (!(email.code === 0 && email.stdout.trim())) {
+    args.push("-c", "user.email=mission-control@localhost");
+  }
+  return args;
+}
+
+/**
  * Pull the current branch from its upstream (or origin/<branch>).
  * Default is fast-forward only; rebase/merge are explicit so a header click
  * never invents a merge commit unless the user asked for it.
@@ -412,14 +434,19 @@ export async function pull(
   const modeArgs =
     mode === "rebase" ? ["--rebase"] : mode === "merge" ? ["--no-rebase"] : ["--ff-only"];
 
-  let result = await runGit(cwd, ["pull", ...modeArgs], { timeoutMs: PUSH_TIMEOUT_MS });
+  // ff-only never commits; rebase/merge can, so give git a fallback identity.
+  const identityArgs = mode === "ff-only" ? [] : await fallbackIdentityArgs(cwd);
+
+  let result = await runGit(cwd, [...identityArgs, "pull", ...modeArgs], {
+    timeoutMs: PUSH_TIMEOUT_MS,
+  });
   if (result.code !== 0) {
     const noUpstream =
       /no tracking information|There is no tracking information|no upstream/i.test(
         result.stderr || "",
       ) || /set the upstream/i.test(result.stderr || "");
     if (noUpstream) {
-      result = await runGit(cwd, ["pull", ...modeArgs, "origin", branch], {
+      result = await runGit(cwd, [...identityArgs, "pull", ...modeArgs, "origin", branch], {
         timeoutMs: PUSH_TIMEOUT_MS,
       });
     }

--- a/src/server/services/session-transcripts.ts
+++ b/src/server/services/session-transcripts.ts
@@ -6,6 +6,10 @@
 // generic updateStatus/session:finished signature to avoid threading a
 // Claude-only field through shared plumbing.
 
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+
 // taskId -> latest known transcript path. The path is stable for a session, so
 // we overwrite (not clear on read): the same session finishes many times and
 // each distill should still find it. Bounded: nothing else evicts entries in
@@ -14,8 +18,49 @@
 const MAX_TRACKED_TASKS = 500;
 const transcriptPaths = new Map<string, string>();
 
+// Claude Code writes its per-session JSONL logs under `~/.claude/projects/`
+// (see token-usage.ts). The `transcript_path` we stash here is later read from
+// disk and fed to the auto-distill LLM, whose output is stored as project
+// memory (readable via `GET /api/projects/:id/memory`). Because the value
+// arrives verbatim in an agent hook payload, an untrusted-but-token-holding
+// caller could otherwise point it at any file (`~/.ssh/*.jsonl`, other repos'
+// transcripts) and exfiltrate the content into memory. Pin it to the real
+// Claude transcript base so only genuine session logs are ever read.
+function claudeTranscriptBase(): string {
+  return path.join(os.homedir(), ".claude", "projects");
+}
+
+export function isAllowedTranscriptPath(transcriptPath: string): boolean {
+  const trimmed = transcriptPath.trim();
+  if (!trimmed || trimmed.includes("\0")) return false;
+  const base = claudeTranscriptBase();
+  const abs = path.resolve(trimmed);
+  const withinLexical =
+    abs === base || abs.startsWith(base + path.sep);
+  if (!withinLexical) return false;
+  // Symlink laundering: if the file exists, its realpath must still live under
+  // the real base (a symlink `~/.claude/projects/x.jsonl -> /etc/shadow` would
+  // otherwise pass the lexical check).
+  try {
+    if (fs.existsSync(abs)) {
+      const realBase = fs.realpathSync(base);
+      const realAbs = fs.realpathSync(abs);
+      if (realAbs !== realBase && !realAbs.startsWith(realBase + path.sep)) {
+        return false;
+      }
+    }
+  } catch {
+    return false;
+  }
+  return true;
+}
+
 export function setTranscriptPath(taskId: string, transcriptPath: string): void {
   if (!taskId || !transcriptPath) return;
+  // Only accept paths inside the real Claude transcript directory — the value
+  // is attacker-influenced (it comes straight from a hook payload) and is later
+  // read from disk and distilled into project memory.
+  if (!isAllowedTranscriptPath(transcriptPath)) return;
   // Re-insert so the Map's insertion order doubles as recency order.
   transcriptPaths.delete(taskId);
   transcriptPaths.set(taskId, transcriptPath);


### PR DESCRIPTION
## Summary

`POST /api/hooks/:id` (`src/server/controllers/hooks.controller.ts`) stashes `payload.transcript_path` verbatim (only `.trim()`) via `setTranscriptPath`. That path is later read from disk by the auto-distill pass — `recall-auto-distill.ts` → `readTranscriptForDistill` → `fs.readFileSync` — fed to the distiller LLM, and the result is stored as **project memory**, which is readable through `GET /api/projects/:id/memory`.

No containment check was applied to the path.

## Impact (malicious / token-holding agent)

An agent legitimately holds the API bearer token (delivered via `mcEnv`). Using it, it can:

1. `POST /api/hooks/anything?taskId=<its own task>` with body `{"transcript_path":"/home/you/.ssh/known_hosts", ...}` (or any JSONL-shaped log — other transcripts, app logs, etc.).
2. `POST` a Stop-mapped event to flip the task to `finished`, which emits `session:finished` and triggers the distill → read → store-as-memory pipeline.
3. Read the exfiltrated content back via `GET /api/projects/:id/memory`.

`renderRecord` skips non-JSON lines, so impact is bounded to JSONL/message-shaped files rather than arbitrary binaries — but it is a genuine path-unvalidated read of files **outside any registered project**, laundered into user-visible memory.

## Fix

Legitimate Claude Code transcripts always live under `~/.claude/projects/` (this is exactly where `src/server/services/token-usage.ts` reads them). `setTranscriptPath` now validates the path against that base with realpath-based containment (rejecting symlink escapes and NUL bytes). Anything outside is dropped fail-soft — distill simply falls back to prompts-only, which is already the behavior for non-Claude harnesses that never supply `transcript_path`.

The check is centralized in `session-transcripts.ts` (`isAllowedTranscriptPath`, exported for unit testing) so every caller is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)