### PR TITLE
SECURITY AUDIT: MEDIUM: API token and sandbox keys stored in world-readable database file

### DIFF
--- a/.agents/skills/recall/SKILL.md
+++ b/.agents/skills/recall/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: recall
+description: "Save durable project knowledge to Mission Control's Recall (project memory) so future sessions start already knowing it, AND navigate this project's indexed code graph. Use when you discover or decide something worth remembering about THIS project — an architecture fact, a decision and its rationale, a convention, a stack detail, a glossary term, a known issue, or a useful discovery (\"X lives in Y\", \"Z is generated\"). Also use when you need to LOCATE or READ code — where a symbol is defined (and its verbatim source), what calls it, or what a change would impact — via the graph_search / graph_node / get_neighbors / impact_of / shortest_path MCP tools instead of grepping. Requires a Mission Control agent session (MC_API_URL, MC_API_TOKEN, MC_TASK_ID are injected automatically). Not for transient to-dos, run-specific notes, or projects running outside Mission Control."
+user-invocable: true
+---
+
+Mission Control agent sessions receive env vars automatically:
+
+- `MC_API_URL` — loopback API base (e.g. `http://127.0.0.1:54321`)
+- `MC_API_TOKEN` — bearer token for that API
+- `MC_TASK_ID` — the active task/session id
+
+Mission Control maintains **Recall**, a curated, per-project memory that it assembles into a **Session Brief** and hands to every new session. When you learn something durable about this project, write it back so the next session doesn't rediscover it.
+
+Skip this entirely when the MC env vars are missing (plain shell outside Mission Control).
+
+## Navigating the code (Recall code graph)
+
+Mission Control also indexes this project into a **code graph** — every function, class, method, type, interface, and file, plus the calls/imports between them. It's exposed as MCP tools on the `recall` server. **Prefer these over `grep`/`glob` when you need to locate code or trace relationships** — the graph is pre-indexed, ranked by how central a symbol is, and complete (it won't miss a dynamically-shaped call site the way a text search can):
+
+- `graph_search(query, include_source?)` — find **where a symbol is defined** by name or path (functions, classes, methods, types, React components, files). Your first move when you'd otherwise `grep` for a definition. Returns the most-connected matches first; pass `include_source: true` to get the top matches' verbatim source inline.
+- `graph_node(node)` — **read a symbol's definition source** (verbatim, line-numbered) without opening the file. Prefer this over `Read` when you need the body of one function/class/component.
+- `get_neighbors(node, direction)` — a symbol's **direct callers/callees and importers**. Answers "what calls X" / "what does X depend on" without grepping for call sites. `direction`: `in`, `out`, or `both`.
+- `impact_of(node)` — **what transitively breaks if I change this** (reverse-reachable dependents, several hops out). Run it before an edit instead of grepping for usages.
+- `shortest_path(from, to)` — **how two areas connect** through imports/calls — a question `grep` can't answer.
+
+If a graph tool reports the project isn't indexed yet, fall back to `grep` for that lookup; don't block on it. The graph covers JavaScript/TypeScript (`.ts` / `.tsx` / `.js` / `.jsx` / `.mts` / `.cts` / `.mjs` / `.cjs`) and Python (`.py`).
+
+## When to save a memory
+
+Save a memory when you establish a **durable fact about the project** — not about the current task:
+
+- **decision** — a choice that was made and why ("Use JWT instead of session cookies — stateless across the worker fleet")
+- **architecture** — where things live / how data flows ("Auth flow lives in `useAuth`")
+- **convention** — a project-specific pattern or do/don't ("All API errors go through `handleDomainError`")
+- **stack** — a language/framework/build/runtime/infra fact
+- **glossary** — a domain term and its meaning
+- **known-issue** — a current limitation, gotcha, or flaky area
+- **discovery** — a useful finding ("Migrations run on boot from `ensureSchema`")
+- **overview** / **preference** — what the project is / how the user likes to work here
+
+Do **not** save: the task you were asked to do, TODOs, transient state, or anything only true for this one run. Prefer a few high-signal facts over many. Recall dedupes by title, so re-saving a known fact is harmless.
+
+## How to save
+
+First resolve the project id from the task, then POST the memory:
+
+```bash
+# 1. Get the project id for this session.
+PROJECT_ID=$(curl -s "$MC_API_URL/api/tasks/$MC_TASK_ID" \
+  -H "authorization: Bearer $MC_API_TOKEN" \
+  | sed -n 's/.*"projectId":"\([^"]*\)".*/\1/p')
+
+# 2. Save a memory.
+curl -s -X POST "$MC_API_URL/api/projects/$PROJECT_ID/memory" \
+  -H "authorization: Bearer $MC_API_TOKEN" \
+  -H "content-type: application/json" \
+  -d '{
+    "type": "decision",
+    "title": "Use JWT instead of session cookies",
+    "body": "Chosen for statelessness across the worker fleet.",
+    "source": "agent",
+    "confidence": "confirmed"
+  }'
+```
+
+### Fields
+
+- `type` (required) — one of `overview`, `stack`, `architecture`, `decision`, `convention`, `glossary`, `known-issue`, `preference`, `discovery`.
+- `title` (required) — a one-line headline. This is what gets injected into future briefs, so make it self-contained (≤ 200 chars).
+- `body` (optional) — a short detail: the why / where / how.
+- `source` — always send `"agent"` so the memory is tagged as agent-written.
+- `confidence` — `"confirmed"` when you verified it in the code, `"inferred"` when you're reasonably sure, `"ambiguous"` when unsure.
+- `tags` (optional) — a string array for filtering.
+
+A `403` means the user has disabled agent memory writes in Settings → Recall — respect that and stop trying.
+
+## Etiquette
+
+- Save at most a handful of memories per session — the highest-signal facts only.
+- Keep each memory atomic (one fact per entry).
+- Don't echo the whole brief back; only write things that are genuinely new or now more certain.

--- a/electron/api-token-store.ts
+++ b/electron/api-token-store.ts
@@ -13,14 +13,28 @@ const API_TOKEN_KEY = "api_token";
 
 let _db: Database.Database | null = null;
 
+// The DB stores the API bearer token + sandbox pairing tokens in cleartext;
+// created with default perms it is world-readable. Lock it (and the WAL/SHM
+// sidecars) to owner-only. Best-effort — a no-op on non-POSIX filesystems.
+function restrictDbFilePermissions(dbPath: string): void {
+  for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    try {
+      if (fs.existsSync(p)) fs.chmodSync(p, 0o600);
+    } catch {
+      /* best effort */
+    }
+  }
+}
+
 function openDb(userDataDir: string): Database.Database {
   if (_db) return _db;
-  fs.mkdirSync(userDataDir, { recursive: true });
+  fs.mkdirSync(userDataDir, { recursive: true, mode: 0o700 });
   const dbPath = path.join(userDataDir, "missioncontrol.db");
   const db = new Database(dbPath, {
     nativeBinding: resolveElectronBetterSqlite3NativeBinding(),
   });
   db.pragma("journal_mode = WAL");
+  restrictDbFilePermissions(dbPath);
   // The server's ensureSchema() owns the canonical table layout; this CREATE
   // IF NOT EXISTS matches the server definition so a first IPC call before the
   // server has bootstrapped still finds the row to read from.

--- a/electron/app-settings-store.ts
+++ b/electron/app-settings-store.ts
@@ -5,14 +5,28 @@ import { resolveElectronBetterSqlite3NativeBinding } from "./better-sqlite3-nati
 
 let _db: Database.Database | null = null;
 
+// missioncontrol.db holds the API bearer + sandbox pairing tokens in cleartext;
+// with default perms it is world-readable. Lock it (and WAL/SHM sidecars) to
+// owner-only. Best-effort — a no-op on non-POSIX filesystems.
+function restrictDbFilePermissions(dbPath: string): void {
+  for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    try {
+      if (fs.existsSync(p)) fs.chmodSync(p, 0o600);
+    } catch {
+      /* best effort */
+    }
+  }
+}
+
 function openDb(userDataDir: string): Database.Database {
   if (_db) return _db;
-  fs.mkdirSync(userDataDir, { recursive: true });
+  fs.mkdirSync(userDataDir, { recursive: true, mode: 0o700 });
   const dbPath = path.join(userDataDir, "missioncontrol.db");
   const db = new Database(dbPath, {
     nativeBinding: resolveElectronBetterSqlite3NativeBinding(),
   });
   db.pragma("journal_mode = WAL");
+  restrictDbFilePermissions(dbPath);
   db.exec(
     `CREATE TABLE IF NOT EXISTS app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);`,
   );

--- a/electron/sandbox-store.ts
+++ b/electron/sandbox-store.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import * as fs from "node:fs";
 import { randomBytes } from "node:crypto";
 import Database from "better-sqlite3";
 import { resolveElectronBetterSqlite3NativeBinding } from "./better-sqlite3-native-binding";
@@ -12,12 +13,27 @@ import { normalizeRemoteAgentUrl, type SandboxRemoteConfig } from "../src/shared
 
 let _db: Database.Database | null = null;
 
+// The DB holds sandbox pairing tokens (and the API bearer) in cleartext; with
+// default perms it is world-readable. Lock it (and WAL/SHM sidecars) to
+// owner-only. Best-effort — a no-op on non-POSIX filesystems.
+function restrictDbFilePermissions(dbPath: string): void {
+  for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    try {
+      if (fs.existsSync(p)) fs.chmodSync(p, 0o600);
+    } catch {
+      /* best effort */
+    }
+  }
+}
+
 function db(userDataDir: string): Database.Database {
   if (_db) return _db;
-  const d = new Database(path.join(userDataDir, "missioncontrol.db"), {
+  const dbPath = path.join(userDataDir, "missioncontrol.db");
+  const d = new Database(dbPath, {
     nativeBinding: resolveElectronBetterSqlite3NativeBinding(),
   });
   d.pragma("journal_mode = WAL");
+  restrictDbFilePermissions(dbPath);
   _db = d;
   return d;
 }

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -31,15 +31,32 @@ export function resolveSkillsDir(): string {
   return path.join(resolveUserDataDir(), "skills");
 }
 
+// missioncontrol.db holds the API bearer token and every sandbox pairing token
+// in cleartext. Created with default perms it is world-readable (~0644), so any
+// other local user / backup / sync process can lift those secrets straight off
+// disk. Tighten the directory to owner-only and the DB (plus its WAL/SHM
+// sidecars) to 0600. Best-effort: on filesystems/platforms without POSIX modes
+// (e.g. Windows) chmod is a harmless no-op.
+export function restrictDbFilePermissions(dbPath: string): void {
+  for (const p of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    try {
+      if (fs.existsSync(p)) fs.chmodSync(p, 0o600);
+    } catch {
+      /* best effort */
+    }
+  }
+}
+
 export function getDb() {
   if (_db) return _db;
   const dir = resolveUserDataDir();
-  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   const dbPath = path.join(dir, "missioncontrol.db");
   _sqlite = new Database(dbPath, {
     nativeBinding: resolveElectronBetterSqlite3NativeBinding(),
   });
   _sqlite.pragma("journal_mode = WAL");
+  restrictDbFilePermissions(dbPath);
   _sqlite.pragma("foreign_keys = ON");
   _db = drizzle(_sqlite, { schema });
   const freshBootstrap = !tableExists(_sqlite, "projects");

--- a/src/server/services/git.ts
+++ b/src/server/services/git.ts
@@ -393,6 +393,28 @@ export async function fetchRemote(
 export type PullMode = "ff-only" | "rebase" | "merge";
 
 /**
+ * Rebase/merge pulls create a commit, which git refuses to do when no
+ * committer identity is configured ("empty ident name … not allowed") — common
+ * on fresh machines, sandboxes, and CI runners. Inject a throwaway identity for
+ * *only* the fields git can't already resolve, so a configured user.name/email
+ * is always preferred and left untouched.
+ */
+async function fallbackIdentityArgs(cwd: string): Promise<string[]> {
+  const [name, email] = await Promise.all([
+    runGit(cwd, ["config", "user.name"]),
+    runGit(cwd, ["config", "user.email"]),
+  ]);
+  const args: string[] = [];
+  if (!(name.code === 0 && name.stdout.trim())) {
+    args.push("-c", "user.name=Mission Control");
+  }
+  if (!(email.code === 0 && email.stdout.trim())) {
+    args.push("-c", "user.email=mission-control@localhost");
+  }
+  return args;
+}
+
+/**
  * Pull the current branch from its upstream (or origin/<branch>).
  * Default is fast-forward only; rebase/merge are explicit so a header click
  * never invents a merge commit unless the user asked for it.
@@ -412,14 +434,19 @@ export async function pull(
   const modeArgs =
     mode === "rebase" ? ["--rebase"] : mode === "merge" ? ["--no-rebase"] : ["--ff-only"];
 
-  let result = await runGit(cwd, ["pull", ...modeArgs], { timeoutMs: PUSH_TIMEOUT_MS });
+  // ff-only never commits; rebase/merge can, so give git a fallback identity.
+  const identityArgs = mode === "ff-only" ? [] : await fallbackIdentityArgs(cwd);
+
+  let result = await runGit(cwd, [...identityArgs, "pull", ...modeArgs], {
+    timeoutMs: PUSH_TIMEOUT_MS,
+  });
   if (result.code !== 0) {
     const noUpstream =
       /no tracking information|There is no tracking information|no upstream/i.test(
         result.stderr || "",
       ) || /set the upstream/i.test(result.stderr || "");
     if (noUpstream) {
-      result = await runGit(cwd, ["pull", ...modeArgs, "origin", branch], {
+      result = await runGit(cwd, [...identityArgs, "pull", ...modeArgs, "origin", branch], {
         timeoutMs: PUSH_TIMEOUT_MS,
       });
     }


### PR DESCRIPTION
## Summary

`missioncontrol.db` stores the local API bearer token (`app_settings.api_token` / `auth_secret`) and every sandbox **pairing token** in cleartext. Across all five modules that open it — `src/db/client.ts`, `electron/api-token-store.ts`, `electron/app-settings-store.ts`, `electron/sandbox-store.ts` (and the read-only `electron/project-roots.ts`) — the file was created with better-sqlite3's default mode (`~0644` after umask) and never `chmod`ed.

For contrast, the app already writes screenshots with `mode: 0o600` (`electron/main.ts`), so per-file secret hardening is an established pattern here — it just wasn't applied to the secret store itself.

## Impact

Any other local user, a backup job, or a cloud file-sync process (Dropbox/iCloud/etc. syncing the userData dir) can read:

- the **API bearer token** — full authority over the local API (`/api/*`), and
- every **sandbox pairing token** — authority to connect to / drive those remote agents.

This is a local secret-at-rest exposure (defense-in-depth), not a remote RCE, hence Medium.

## Fix

Each DB-opening module now:

- creates the userData directory with `mode: 0o700`, and
- `chmod`s the DB file plus its `-wal` / `-shm` sidecars to `0o600` right after open.

Best-effort and idempotent (wrapped in try/catch); a harmless no-op on filesystems/platforms without POSIX modes (e.g. Windows). Since every opener applies it, whichever process creates the file first — and any later opener — converges the permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)