### PR TITLE
feat(ci): auto-tag main merges; GitHub release without academy finalize

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: release
-description: Cut a Mission Control desktop release — bump package.json (must match the git tag), commit, create an annotated v-tag, push to trigger release.yml CI, and verify academy artifacts align with bundle version. Use when the user says "cut a release", "release mission control", "tag a release", "bump version", "publish a new version", or "/release". Accepts bump type major|minor|patch (default patch for hotfixes). Read references/mission-control-release.md for the full CI pipeline, version alignment rules, and post-release checks.
+description: Cut a Mission Control desktop release — bump package.json (must match the git tag), commit, create an annotated v-tag, push to trigger release.yml CI. Prefer letting auto-tag-release.yml patch-bump on merges to main; use this skill for major/minor, hotfixes, or when automation was skipped with [skip release]. Read references/mission-control-release.md for the full CI pipeline, academy approval gate, and version alignment rules.
 ---
 
 # Mission Control release
 
-Phased workflow for this Electron desktop app. **Read [`references/mission-control-release.md`](references/mission-control-release.md)** for CI jobs, academy publishing, and the v0.47.1 version-mismatch incident.
+Phased workflow for this Electron desktop app. **Read [`references/mission-control-release.md`](references/mission-control-release.md)** for CI jobs, academy publishing, auto-tag automation, and the v0.47.1 version-mismatch incident.
+
+**Default path:** merges to `main` are automatically patch-bumped and tagged by `.github/workflows/auto-tag-release.yml` after Hosted CI is green. Prefer that unless the user asked for a major/minor bump or a manual hotfix.
 
 **Bump type from args:** `major` | `minor` | `patch`. Default **`patch`** for this repo (desktop app ships frequently).
 
@@ -18,8 +20,9 @@ Phased workflow for this Electron desktop app. **Read [`references/mission-contr
 1. **Bump `package.json` before creating the git tag.** The tag version (without `v`) and `package.json` `version` must be identical on the commit you tag.
 2. **Use `pnpm version X.Y.Z --no-git-tag-version`** — never `git tag` first and bump later.
 3. **Never reuse or force-move a remote tag.** If a bad tag shipped, bump to the next patch and release again.
-4. **Pushing the tag triggers `release.yml`** — CI builds electron-builder artifacts and publishes to agentsystem.dev. There is no separate manual upload step on the happy path.
-5. **Verify after CI:** academy `latestVersion`, artifact filenames, and `CFBundleShortVersionString` must all match.
+4. **Pushing the tag triggers `release.yml`** — CI builds signed installers, uploads academy **draft** assets, and attaches installers to the **GitHub Release**. It does **not** finalize / promote the Electron updater.
+5. **In-app Update / electron-updater only advance after approval on agentsystem.dev.** GitHub Releases are for manual download only.
+6. **Verify after CI + after academy approval:** GitHub assets exist immediately; academy `latestVersion` only matches after you approve.
 
 ### Version alignment check (run before tagging)
 
@@ -46,6 +49,7 @@ node -p "require('./package.json').version"
 - Dirty tree → STOP.
 - Not on `main` → confirm with user.
 - Manifest: `package.json` only (not `publish/package.json`).
+- If the next merge would auto-tag and the user only wanted a delay → suggest `[skip release]` on the merge commit instead.
 
 ---
 
@@ -111,7 +115,7 @@ git push --follow-tags
 
 When the user explicitly requests push in the same turn, push immediately after local tag creation.
 
-Monitor: GitHub Actions → `Release` workflow for the new tag. Wait for `finalize` to succeed, then run post-release checks from [`references/mission-control-release.md`](references/mission-control-release.md).
+Monitor: GitHub Actions → `Release` workflow for the new tag. Wait for `publish-github` to succeed (GitHub Release assets). Remind the user that **existing users are not prompted until they approve the release on agentsystem.dev**.
 
 ---
 
@@ -122,4 +126,4 @@ Monitor: GitHub Actions → `Release` workflow for the new tag. Wait for `finali
 - **NEVER force-push or delete a published tag** without explicit user request and understanding of academy/CI impact.
 - **NEVER use lightweight tags** — always `git tag -a`.
 - **NEVER release from a dirty working tree.**
-- **NEVER skip post-release verification** — confirm API version, artifact names, and bundle version match.
+- **NEVER tell the user the updater is live just because GitHub Release assets exist** — academy approval is the updater gate.

--- a/.agents/skills/release/references/mission-control-release.md
+++ b/.agents/skills/release/references/mission-control-release.md
@@ -8,7 +8,7 @@ How desktop releases are built, published, and verified for this repo.
 |--------|----------|
 | `package.json` `version` | electron-builder artifact names, `Info.plist` / `CFBundleShortVersionString`, Vite `__MC_VERSION__` baked into the app |
 | Git tag `vX.Y.Z` | GitHub Actions `RELEASE_VERSION`, academy API release row, auto-update metadata |
-| Academy API `releases[].version` | In-app update check (`isNewerSemver` vs installed `CURRENT_MC_VERSION`) |
+| Academy API finalized `releases[].version` | In-app update check (`isNewerSemver` vs installed `CURRENT_MC_VERSION`) |
 
 **Critical:** `package.json` version and the git tag (without `v`) must be identical **before** you push the tag. If they diverge, users get a permanent “update available” loop: the API advertises `v0.47.1` while installed binaries report `0.47.0`.
 
@@ -18,35 +18,66 @@ How desktop releases are built, published, and verified for this repo.
 - CI registered the release as `v0.47.1` on academy but built `MissionControl-0.47.0-*.dmg` with bundle version `0.47.0`.
 - Fixed in `v0.47.2` by bumping `package.json` first, then tagging.
 
-## Release flow (happy path)
+## Happy path (automated)
 
 ```
-main (feature commits merged)
-  → bump package.json (pnpm version X.Y.Z --no-git-tag-version)
-  → commit: chore(release): vX.Y.Z
-  → annotated tag: git tag -a vX.Y.Z -m "<notes>"
-  → push: git push --follow-tags
-  → GitHub Actions release.yml (triggered by tag push)
-  → academy hosts DMG/EXE/AppImage + mac auto-update manifest
+merge to main (feature commits)
+  → ci.yml green on that push
+  → auto-tag-release.yml patch-bumps package.json, commits chore(release): vX.Y.Z, pushes annotated tag
+  → release.yml (triggered by tag)
+      → prepare + per-platform publish → academy draft/versioned assets
+      → attach installers to GitHub Release (manual download)
+  → you approve on agentsystem.dev
+      → finalize + activate auto-update feed
+      → Electron updater / in-app Update UI advance
 ```
 
-## GitHub Actions (`release.yml`)
+Skip automation for a main push: include `[skip release]` in the merge commit message.
 
-Triggered on `push: tags: v*` or manual `workflow_dispatch` with an existing tag.
+Manual major/minor (or hotfix without waiting for a merge): use the `/release` skill — it still bumps, tags, and relies on the same `release.yml` + academy approval gate.
+
+## GitHub Actions
+
+### `auto-tag-release.yml`
+
+Triggered on `push` to `main` (skips `chore(release): v*` and `[skip release]`).
+
+| Step | Purpose |
+|------|---------|
+| Wait for Hosted CI | Same gate as release — `scripts/wait-for-hosted-ci.mjs` |
+| Patch bump | `npm version patch --no-git-tag-version` |
+| Commit + annotated tag | `chore(release): vX.Y.Z` then `git tag -a` |
+| Push + dispatch | Commit to `main`, push tag, then `gh workflow run release.yml -f tag=vX.Y.Z` |
+
+**Why dispatch:** pushes authenticated with `GITHUB_TOKEN` do not trigger other workflows (GitHub recursion guard). Auto-tag therefore starts `release.yml` via `workflow_dispatch` after pushing the tag.
+
+Permissions: `contents: write`, `actions: write`. Branch protection must allow `github-actions[bot]` to push release commits (or use a fine-grained PAT in the workflow).
+
+### `release.yml`
+
+Triggered on `push: tags: v*` (manual tags / `--follow-tags`) or `workflow_dispatch` with an existing tag (auto-tag path).
 
 | Job | Purpose |
 |-----|---------|
 | `resolve` | Resolve tag ref + read annotated tag body as release notes |
-| `release-gate` | Wait for `ci.yml` to pass on the tagged commit on `main` |
-| `prepare` | `scripts/publish-release.mjs prepare` — create-or-get academy release row |
-| `build` (matrix) | mac-arm64, mac-x64, win-x64, linux-x64 — electron-builder + upload |
-| `finalize` | Compose `latest-mac.yml`, verify all platforms, mark release finalized |
+| `release-gate` | Wait for `ci.yml` on the tagged commit, or its parent when the tip is `chore(release): v*` (bot bump has no CI run) |
+| `prepare` | `scripts/publish-release.mjs prepare` — create-or-get academy release row (draft) |
+| `build` (matrix) | mac-arm64, mac-x64, win-x64, linux-x64 — electron-builder + academy `publish` |
+| `publish-github` | Attach `.dmg` / `.exe` / `.AppImage` to the GitHub Release |
+
+**Not done by CI:** `publish-release.mjs finalize` and publishing `latest-mac.yml` / auto-update feeds. Those stay on agentsystem.dev approval so existing users are not prompted until you promote.
 
 Secrets required in GitHub: `MISSION_CONTROL_RELEASE_TOKEN`, `ACADEMY_BASE_URL`, mac signing (`MAC_CERTS`, `APPLE_*`).
 
 Re-run a single failed matrix job from Actions UI; asset upsert is idempotent per platform.
 
-## Local commands
+### `ci.yml` packaging
+
+`package-linux` (unsigned AppImage artifact) runs on **pull_request** only — for PR smoke downloads. Main releases come from `release.yml`.
+
+## Local / manual `/release` commands
+
+Still valid for major/minor or when automation is skipped:
 
 ```bash
 # Preflight
@@ -55,7 +86,7 @@ git rev-parse --abbrev-ref HEAD # should be main
 git describe --tags --abbrev=0  # last tag
 
 # Bump (pnpm project)
-pnpm version 0.48.0 --no-git-tag-version
+pnpm version 0.49.0 --no-git-tag-version
 
 # Verify alignment BEFORE tagging
 node -e "const v=require('./package.json').version; console.log('package.json:', v)"
@@ -63,29 +94,41 @@ node -e "const v=require('./package.json').version; console.log('package.json:',
 
 # Commit + annotated tag
 git add package.json
-git commit -m "chore(release): v0.48.0"
-git tag -a v0.48.0 -m "## v0.48.0\n\n- ..."
+git commit -m "chore(release): v0.49.0"
+git tag -a v0.49.0 -m "## v0.49.0\n\n- ..."
 
-# Publish (triggers CI)
+# Publish (triggers release.yml)
 git push --follow-tags
 ```
 
 ## Post-release verification
 
-After CI `finalize` succeeds:
+After `publish-github` succeeds:
 
 ```bash
-# 1. Academy API latest matches tag
+# 1. GitHub Release has installers (manual download)
+gh release view vX.Y.Z --json assets --jq '.assets[].name'
+
+# 2. Academy latest finalized still the previous approved version until you approve
+curl -sS -H 'Accept: application/json' \
+  'https://agentsystem.dev/api/mission-control/releases?limit=1' \
+  | jq '.releases[0].version'
+```
+
+After **approving on agentsystem.dev**:
+
+```bash
+# Latest finalized matches the new tag
 curl -sS -H 'Accept: application/json' \
   'https://agentsystem.dev/api/mission-control/releases?limit=1' \
   | jq '.releases[0].version'
 
-# 2. Asset filenames include the new version (not an older one)
+# Asset filenames include the new version
 curl -sS -H 'Accept: application/json' \
   'https://agentsystem.dev/api/mission-control/releases?limit=1' \
   | jq '.releases[0].assets[].fileName'
 
-# 3. Installed app matches (after downloading DMG)
+# Installed app matches (after downloading DMG)
 /usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' \
   '/Applications/MissionControl.app/Contents/Info.plist'
 ```
@@ -94,17 +137,18 @@ Installed version in **Settings → About** comes from `__MC_VERSION__` (build-t
 
 ## In-app update behavior
 
-- **Academy check:** `src/queries/mission-control-version.ts` fetches `/api/mission-control/releases?limit=1`, compares semver to `CURRENT_MC_VERSION`.
-- **Electron auto-updater:** `app-update.yml` points at `https://agentsystem.dev/downloads/mission-control/auto-update` (mac `latest-mac.yml` composed at finalize).
+- **Academy check:** `src/queries/mission-control-version.ts` fetches `/api/mission-control/releases?limit=1`, compares semver to `CURRENT_MC_VERSION`. Only **finalized/approved** releases appear.
+- **Electron auto-updater:** `package.json` `publish.url` points at `https://agentsystem.dev/downloads/mission-control/auto-update` (mac `latest-mac.yml` activated on academy approval).
 - Update button shows when `isNewerSemver(remote, installed)` is true.
+- **GitHub Releases** never advance the updater — they are for manual install only.
 
 ## When a tag already exists with wrong metadata
 
 Do **not** force-move an existing remote tag. Instead:
 
 1. Bump `package.json` to the next patch (e.g. `0.47.1` broken → ship `0.47.2`).
-2. Commit, tag, push.
-3. Let CI publish corrected artifacts.
+2. Commit, tag, push (or merge another change to main and let auto-tag run).
+3. Let CI publish corrected artifacts; approve on academy when ready.
 
 Deleting/re-tagging `v0.47.1` on a shared remote breaks anyone who already pulled it and poisons academy caches.
 

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,0 +1,125 @@
+name: Auto tag release
+
+# After a green Hosted CI run on main, patch-bump package.json, commit, and
+# push an annotated v* tag. Because pushes that use GITHUB_TOKEN do not trigger
+# other workflows, this job then starts release.yml via workflow_dispatch.
+# Academy finalize / approval remains the gate for the Electron updater.
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: auto-tag-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  actions: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  bump-and-tag:
+    name: Patch bump + tag
+    if: >-
+      github.event.head_commit != null &&
+      !startsWith(github.event.head_commit.message, 'chore(release): v') &&
+      !contains(github.event.head_commit.message, '[skip release]')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.15.0
+          package-manager-cache: false
+
+      - name: Wait for Hosted CI on this push
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: node scripts/wait-for-hosted-ci.mjs
+
+      - name: Patch bump, commit, tag, push, dispatch release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          WAITED_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Stay current if another commit landed while we waited for CI.
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
+
+          # Skip if HEAD itself is already a release commit (race / re-run).
+          head_msg="$(git log -1 --pretty=%s)"
+          if [[ "$head_msg" == chore\(release\):\ v* ]] || [[ "$head_msg" == *"[skip release]"* ]]; then
+            echo "HEAD already a release/skip commit ($head_msg); nothing to do."
+            exit 0
+          fi
+
+          head_sha="$(git rev-parse HEAD)"
+          if [[ "$head_sha" != "$WAITED_SHA" ]]; then
+            echo "main moved to $head_sha while waiting (was $WAITED_SHA); re-checking Hosted CI."
+            RELEASE_SHA="$head_sha" node scripts/wait-for-hosted-ci.mjs
+          fi
+
+          prev_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          old_version="$(node -p "require('./package.json').version")"
+
+          # npm version only edits package.json (no install needed).
+          npm version patch --no-git-tag-version
+          new_version="$(node -p "require('./package.json').version")"
+          tag="v${new_version}"
+
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists locally — aborting" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "Tag $tag already exists on origin — aborting" >&2
+            exit 1
+          fi
+
+          notes_file="$(mktemp)"
+          {
+            echo "## ${tag}"
+            echo
+            if [[ -n "$prev_tag" ]]; then
+              echo "Changes since ${prev_tag}:"
+              echo
+              git log --pretty=format:'- %s (%h)' "${prev_tag}..HEAD"
+              echo
+            else
+              echo "Initial automated release from ${old_version}."
+            fi
+          } > "$notes_file"
+
+          git add package.json
+          git commit -m "chore(release): ${tag}"
+          git tag -a "$tag" -F "$notes_file"
+
+          # Push commit + tag. GITHUB_TOKEN pushes do not re-trigger workflows,
+          # so release.yml is started explicitly via workflow_dispatch below.
+          git push origin HEAD:main
+          git push origin "$tag"
+
+          gh workflow run release.yml \
+            --ref main \
+            -f "tag=${tag}"
+
+          echo "Created and pushed ${tag} (package.json ${old_version} → ${new_version}); dispatched Release workflow."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,54 @@ jobs:
           cache: true
       - run: pnpm install --frozen-lockfile
       - run: pnpm scan:secrets
+
+  # Unsigned Linux AppImage for PR / main smoke downloads. Signed multi-platform
+  # installers ship via release.yml → academy + GitHub Releases.
+  package-linux:
+    name: Package Linux (unsigned)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.15.0
+          package-manager-cache: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.1.2
+          cache: true
+
+      # node-gyp 9.x imports distutils; pin 3.11 like release.yml.
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Populate bundled Whisper resources
+        run: pnpm setup:whisper
+
+      - name: Build web + electron tsc
+        run: |
+          pnpm build
+          pnpm native:electron
+
+      - name: Package unsigned Linux AppImage
+        env:
+          # Skip code-signing discovery on CI (no certs for PR builds).
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: |
+          pnpm exec electron-builder --linux --x64 --publish never \
+            -c.directories.output=dist-electron-out
+
+      - name: Upload Linux AppImage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: MissionControl-linux-x64
+          path: dist-electron-out/*.AppImage
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,11 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm scan:secrets
 
-  # Unsigned Linux AppImage for PR / main smoke downloads. Signed multi-platform
-  # installers ship via release.yml → academy + GitHub Releases.
+  # Unsigned Linux AppImage for PR smoke downloads only. Merges to main are
+  # auto-tagged and built by release.yml (signed mac/win/linux → GitHub Release).
   package-linux:
     name: Package Linux (unsigned)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,6 +333,16 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # Installer binaries for GitHub Release attachment in finalize (academy
+      # publish below is unchanged and remains the canonical CDN).
+      - name: Upload installer for GitHub Release
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: installer-${{ matrix.platform }}
+          path: artifacts/*.${{ matrix.artifact_ext }}
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Publish assets to academy
         env:
           MISSION_CONTROL_RELEASE_TOKEN: ${{ secrets.MISSION_CONTROL_RELEASE_TOKEN }}
@@ -350,7 +360,7 @@ jobs:
     if: ${{ !cancelled() && needs.release-gate.result == 'success' && needs.prepare.result == 'success' && needs.build.result != 'skipped' }}
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: write
       actions: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -367,6 +377,12 @@ jobs:
           pattern: release-manifest-*
           path: release-manifests
 
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: installer-*
+          path: release-installers
+          merge-multiple: true
+
       - name: Compose + publish mac update manifest
         env:
           MISSION_CONTROL_RELEASE_TOKEN: ${{ secrets.MISSION_CONTROL_RELEASE_TOKEN }}
@@ -382,3 +398,32 @@ jobs:
           ACADEMY_BASE_URL: ${{ secrets.ACADEMY_BASE_URL }}
           RELEASE_VERSION: ${{ needs.resolve.outputs.ref }}
         run: node scripts/publish-release.mjs finalize
+
+      - name: Attach installers to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ needs.resolve.outputs.ref }}
+          RELEASE_NOTES: ${{ needs.resolve.outputs.notes }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find release-installers -type f \( -name '*.dmg' -o -name '*.exe' -o -name '*.AppImage' \) | sort)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No installer files found under release-installers/" >&2
+            ls -laR release-installers || true
+            exit 1
+          fi
+          echo "Attaching ${#files[@]} installer(s) to GitHub Release $RELEASE_VERSION:"
+          printf '  %s\n' "${files[@]}"
+
+          notes_file="$(mktemp)"
+          printf '%s\n' "$RELEASE_NOTES" > "$notes_file"
+
+          if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_VERSION" "${files[@]}" --clobber
+          else
+            gh release create "$RELEASE_VERSION" "${files[@]}" \
+              --title "$RELEASE_VERSION" \
+              --notes-file "$notes_file" \
+              --verify-tag
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,8 @@ on:
         required: true
 
 concurrency:
-  group: release-${{ github.ref }}
+  # workflow_dispatch uses inputs.tag; tag-push uses github.ref_name.
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -98,115 +99,26 @@ jobs:
             echo "Release tag $RELEASE_REF points at $release_sha, which is not reachable from origin/main ($main_sha)." >&2
             exit 1
           fi
+          echo "sha=$release_sha"
+
+          # Bot chore(release) commits pushed with GITHUB_TOKEN do not re-trigger
+          # ci.yml. Gate on the parent (last human/feature commit) instead.
+          subject="$(git log -1 --pretty=%s "$release_sha")"
+          fallback_sha=""
+          if [[ "$subject" == chore\(release\):\ v* ]]; then
+            fallback_sha="$(git rev-parse "${release_sha}^")"
+            echo "Release commit is automated bump; CI fallback SHA=$fallback_sha"
+          fi
           echo "sha=$release_sha" >> "$GITHUB_OUTPUT"
+          echo "fallback_sha=$fallback_sha" >> "$GITHUB_OUTPUT"
 
       - name: Wait for Hosted CI to pass
-        shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           RELEASE_SHA: ${{ steps.tag.outputs.sha }}
-          CI_GATE_MAX_ATTEMPTS: "120"
-          CI_GATE_POLL_SECONDS: "30"
-        run: |
-          node <<'NODE'
-          const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
-          const token = process.env.GITHUB_TOKEN;
-          const releaseSha = process.env.RELEASE_SHA;
-          const workflowFile = "ci.yml";
-          const maxAttempts = Number(process.env.CI_GATE_MAX_ATTEMPTS);
-          const pollSeconds = Number(process.env.CI_GATE_POLL_SECONDS);
-
-          async function main() {
-            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-              const run = await findHostedCiRun();
-              if (!run) {
-                await waitForNextAttempt(
-                  `No Hosted CI push run on main found yet for ${releaseSha}`,
-                  attempt,
-                );
-                continue;
-              }
-
-              const conclusion = run.conclusion ?? "pending";
-              console.log(
-                `Hosted CI run ${run.html_url} is ${run.status}/${conclusion} for ${releaseSha}.`,
-              );
-
-              if (run.status === "completed") {
-                if (run.conclusion === "success") {
-                  console.log("Hosted CI passed; release may continue.");
-                  return;
-                }
-
-                throw new Error(
-                  `Hosted CI must pass before release. Run ${run.html_url} completed with conclusion ${run.conclusion}.`,
-                );
-              }
-
-              await waitForNextAttempt("Hosted CI is still running", attempt);
-            }
-
-            throw new Error(
-              `Timed out waiting for Hosted CI to pass for ${releaseSha} after ${maxAttempts} attempts.`,
-            );
-          }
-
-          async function findHostedCiRun() {
-            const params = new URLSearchParams({
-              branch: "main",
-              event: "push",
-              head_sha: releaseSha,
-              per_page: "10",
-            });
-            const path = `/repos/${owner}/${repo}/actions/workflows/${encodeURIComponent(
-              workflowFile,
-            )}/runs?${params}`;
-            const data = await githubApi(path);
-            const runs = data.workflow_runs ?? [];
-            return runs.find(
-              (run) =>
-                run.head_sha === releaseSha &&
-                run.head_branch === "main" &&
-                run.event === "push",
-            );
-          }
-
-          async function waitForNextAttempt(reason, attempt) {
-            if (attempt >= maxAttempts) {
-              return;
-            }
-            console.log(
-              `${reason}; checking again in ${pollSeconds}s (${attempt}/${maxAttempts}).`,
-            );
-            await new Promise((resolve) => setTimeout(resolve, pollSeconds * 1000));
-          }
-
-          async function githubApi(path) {
-            const response = await fetch(`https://api.github.com${path}`, {
-              headers: {
-                Accept: "application/vnd.github+json",
-                Authorization: `Bearer ${token}`,
-                "User-Agent": "mission-control-release-gate",
-                "X-GitHub-Api-Version": "2022-11-28",
-              },
-            });
-
-            if (!response.ok) {
-              const body = await response.text();
-              throw new Error(
-                `GitHub API request failed (${response.status} ${response.statusText}): ${body}`,
-              );
-            }
-
-            return response.json();
-          }
-
-          main().catch((error) => {
-            console.error(error.stack ?? error.message);
-            process.exit(1);
-          });
-          NODE
+          FALLBACK_SHA: ${{ steps.tag.outputs.fallback_sha }}
+        run: node scripts/wait-for-hosted-ci.mjs
 
   prepare:
     name: Prepare release record
@@ -258,10 +170,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     # Cap each platform build so a hung job (notably mac-x64) can't block the
-    # rest. fail-fast: false above keeps siblings running; finalize tolerates
-    # missing platforms by leaving the release as a draft. To rebuild a single
-    # failed platform, re-run that matrix job from the Actions UI — asset
-    # upsert is idempotent on (releaseId, platform).
+    # rest. fail-fast: false above keeps siblings running; academy stays draft
+    # until you approve on agentsystem.dev. To rebuild a single failed
+    # platform, re-run that matrix job from the Actions UI — asset upsert is
+    # idempotent on (releaseId, platform).
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -325,16 +237,9 @@ jobs:
         run: |
           node scripts/stage-release-artifacts.mjs
 
-      - name: Upload release manifest
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: release-manifest-${{ matrix.platform }}
-          path: artifacts/manifest.json
-          if-no-files-found: error
-          retention-days: 1
-
-      # Installer binaries for GitHub Release attachment in finalize (academy
-      # publish below is unchanged and remains the canonical CDN).
+      # Installer binaries for GitHub Release attachment in publish-github.
+      # Academy publish below uploads draft/versioned assets only — finalize /
+      # auto-update feeds are gated by approval on agentsystem.dev.
       - name: Upload installer for GitHub Release
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -350,54 +255,23 @@ jobs:
           RELEASE_VERSION: ${{ needs.resolve.outputs.ref }}
         run: node scripts/publish-release.mjs publish
 
-  finalize:
-    name: Finalize release
+  publish-github:
+    name: Publish GitHub Release
     needs: [resolve, release-gate, prepare, build]
-    # Run regardless of per-matrix outcome — partial successes still leave the
-    # asset rows uploaded; finalize will refuse if any expected platform is
-    # missing, which is what we want (release stays a draft, can be completed
-    # by re-running the failed platform job).
+    # Attach installers even when some matrix legs fail — operators can
+    # download what succeeded. Academy finalize stays offline until approval
+    # on agentsystem.dev (this job must NOT call finalize or publish latest-*).
     if: ${{ !cancelled() && needs.release-gate.result == 'success' && needs.prepare.result == 'success' && needs.build.result != 'skipped' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: write
       actions: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ needs.resolve.outputs.ref }}
-          fetch-depth: 0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24.15.0
-          package-manager-cache: false
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: release-manifest-*
-          path: release-manifests
-
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: installer-*
           path: release-installers
           merge-multiple: true
-
-      - name: Compose + publish mac update manifest
-        env:
-          MISSION_CONTROL_RELEASE_TOKEN: ${{ secrets.MISSION_CONTROL_RELEASE_TOKEN }}
-          ACADEMY_BASE_URL: ${{ secrets.ACADEMY_BASE_URL }}
-          RELEASE_VERSION: ${{ needs.resolve.outputs.ref }}
-        run: |
-          node scripts/compose-mac-update-manifest.mjs
-          ARTIFACTS_DIR=artifacts-mac-metadata node scripts/publish-release.mjs publish
-
-      - name: Finalize
-        env:
-          MISSION_CONTROL_RELEASE_TOKEN: ${{ secrets.MISSION_CONTROL_RELEASE_TOKEN }}
-          ACADEMY_BASE_URL: ${{ secrets.ACADEMY_BASE_URL }}
-          RELEASE_VERSION: ${{ needs.resolve.outputs.ref }}
-        run: node scripts/publish-release.mjs finalize
 
       - name: Attach installers to GitHub Release
         env:
@@ -417,7 +291,13 @@ jobs:
           printf '  %s\n' "${files[@]}"
 
           notes_file="$(mktemp)"
-          printf '%s\n' "$RELEASE_NOTES" > "$notes_file"
+          {
+            printf '%s\n' "$RELEASE_NOTES"
+            echo
+            echo "---"
+            echo "Installers on this GitHub Release are for manual download."
+            echo "In-app updates stay on the previously approved agentsystem.dev release until this version is approved there."
+          } > "$notes_file"
 
           if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
             gh release upload "$RELEASE_VERSION" "${files[@]}" --clobber

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ mission-control/
 
 ## Download
 
-- **Stable builds:** [agentsystem.dev](https://agentsystem.dev) (signed macOS / Windows / Linux installers from the release pipeline)
-- **GitHub Releases:** [AgentSystemLabs/mission-control/releases](https://github.com/AgentSystemLabs/mission-control/releases) — same versioned installers attached when a `v*` tag ships
-- **CI Artifacts:** every PR and `main` push builds an unsigned Linux AppImage (`MissionControl-linux-x64`) — open the workflow run → **Artifacts**
+- **GitHub Releases:** [AgentSystemLabs/mission-control/releases](https://github.com/AgentSystemLabs/mission-control/releases) — signed macOS / Windows / Linux installers attached automatically when a `v*` tag ships (manual install / dogfooding)
+- **Stable + in-app updates:** [agentsystem.dev](https://agentsystem.dev) — same installers after a release is **approved** there; the Electron updater and in-app Update UI only advance on approval
+- **PR CI Artifacts:** pull requests build an unsigned Linux AppImage (`MissionControl-linux-x64`) — open the workflow run → **Artifacts**
 
 After download: macOS open the `.dmg` and drag the app to Applications; Windows run the Setup `.exe`; Linux make the `.AppImage` executable (`chmod +x`) and run it (FUSE 2 may be required on some distros).
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ mission-control/
 └── README.md
 ```
 
+## Download
+
+- **Stable builds:** [agentsystem.dev](https://agentsystem.dev) (signed macOS / Windows / Linux installers from the release pipeline)
+- **GitHub Releases:** [AgentSystemLabs/mission-control/releases](https://github.com/AgentSystemLabs/mission-control/releases) — same versioned installers attached when a `v*` tag ships
+- **CI Artifacts:** every PR and `main` push builds an unsigned Linux AppImage (`MissionControl-linux-x64`) — open the workflow run → **Artifacts**
+
+After download: macOS open the `.dmg` and drag the app to Applications; Windows run the Setup `.exe`; Linux make the `.AppImage` executable (`chmod +x`) and run it (FUSE 2 may be required on some distros).
+
 ## Getting started
 
 ```bash

--- a/scripts/publish-release.mjs
+++ b/scripts/publish-release.mjs
@@ -8,8 +8,9 @@ import { makeFail } from "./lib/cli.mjs";
 //   publish   Read ./artifacts/manifest.json (built by the current job),
 //             register each asset on the release, and upload it to R2.
 //   finalize  Verify all expected platforms are uploaded and mark the
-//             release finalized. Tolerated to fail (caller decides) — useful
-//             for the "publish what we have, finalize when complete" mode.
+//             release finalized. Not called from release.yml CI — promotion
+//             is gated by approval on agentsystem.dev (keeps the Electron
+//             updater off unapproved builds).
 //
 // Why split: previously this script demanded all 4 platform manifests up front
 // and called one combined create-with-assets endpoint. That coupled every

--- a/scripts/wait-for-hosted-ci.mjs
+++ b/scripts/wait-for-hosted-ci.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Poll until ci.yml completes successfully for a given main-branch push SHA.
+// Used by release.yml (release-gate) and auto-tag-release.yml.
+//
+// Env:
+//   GITHUB_TOKEN          required
+//   GITHUB_REPOSITORY     owner/repo
+//   RELEASE_SHA           commit SHA that should have a green Hosted CI push run
+//   FALLBACK_SHA          optional — if no CI run ever appears for RELEASE_SHA
+//                         (common for bot chore(release) commits pushed with
+//                         GITHUB_TOKEN, which do not re-trigger workflows),
+//                         wait for this SHA instead after FALLBACK_AFTER_ATTEMPTS
+//   FALLBACK_AFTER_ATTEMPTS  default 3
+//   CI_GATE_MAX_ATTEMPTS  default 120
+//   CI_GATE_POLL_SECONDS  default 30
+
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+const releaseSha = process.env.RELEASE_SHA;
+const fallbackSha = process.env.FALLBACK_SHA || "";
+const workflowFile = process.env.CI_WORKFLOW_FILE || "ci.yml";
+const maxAttempts = Number(process.env.CI_GATE_MAX_ATTEMPTS || "120");
+const pollSeconds = Number(process.env.CI_GATE_POLL_SECONDS || "30");
+const fallbackAfterAttempts = Number(process.env.FALLBACK_AFTER_ATTEMPTS || "3");
+
+if (!token) {
+  console.error("GITHUB_TOKEN is required");
+  process.exit(1);
+}
+if (!repository) {
+  console.error("GITHUB_REPOSITORY is required");
+  process.exit(1);
+}
+if (!releaseSha) {
+  console.error("RELEASE_SHA is required");
+  process.exit(1);
+}
+
+const [owner, repo] = repository.split("/");
+
+async function main() {
+  let activeSha = releaseSha;
+  let switchedToFallback = false;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    if (
+      !switchedToFallback &&
+      fallbackSha &&
+      fallbackSha !== releaseSha &&
+      attempt > fallbackAfterAttempts
+    ) {
+      const primaryRun = await findHostedCiRun(releaseSha);
+      if (!primaryRun) {
+        console.log(
+          `No Hosted CI run for ${releaseSha} after ${fallbackAfterAttempts} attempts; falling back to ${fallbackSha}.`,
+        );
+        activeSha = fallbackSha;
+        switchedToFallback = true;
+      }
+    }
+
+    const run = await findHostedCiRun(activeSha);
+    if (!run) {
+      await waitForNextAttempt(
+        `No Hosted CI push run on main found yet for ${activeSha}`,
+        attempt,
+      );
+      continue;
+    }
+
+    const conclusion = run.conclusion ?? "pending";
+    console.log(
+      `Hosted CI run ${run.html_url} is ${run.status}/${conclusion} for ${activeSha}.`,
+    );
+
+    if (run.status === "completed") {
+      if (run.conclusion === "success") {
+        console.log("Hosted CI passed.");
+        return;
+      }
+
+      throw new Error(
+        `Hosted CI must pass before continuing. Run ${run.html_url} completed with conclusion ${run.conclusion}.`,
+      );
+    }
+
+    await waitForNextAttempt("Hosted CI is still running", attempt);
+  }
+
+  throw new Error(
+    `Timed out waiting for Hosted CI to pass for ${activeSha} after ${maxAttempts} attempts.`,
+  );
+}
+
+async function findHostedCiRun(sha) {
+  const params = new URLSearchParams({
+    branch: "main",
+    event: "push",
+    head_sha: sha,
+    per_page: "10",
+  });
+  const path = `/repos/${owner}/${repo}/actions/workflows/${encodeURIComponent(
+    workflowFile,
+  )}/runs?${params}`;
+  const data = await githubApi(path);
+  const runs = data.workflow_runs ?? [];
+  return runs.find(
+    (run) =>
+      run.head_sha === sha &&
+      run.head_branch === "main" &&
+      run.event === "push",
+  );
+}
+
+async function waitForNextAttempt(reason, attempt) {
+  if (attempt >= maxAttempts) {
+    return;
+  }
+  console.log(
+    `${reason}; checking again in ${pollSeconds}s (${attempt}/${maxAttempts}).`,
+  );
+  await new Promise((resolve) => setTimeout(resolve, pollSeconds * 1000));
+}
+
+async function githubApi(path) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "mission-control-wait-for-hosted-ci",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `GitHub API request failed (${response.status} ${response.statusText}): ${body}`,
+    );
+  }
+
+  return response.json();
+}
+
+main().catch((error) => {
+  console.error(error.stack ?? error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- **Auto-tag on main:** after Hosted CI is green, `auto-tag-release.yml` patch-bumps `package.json`, commits `chore(release): vX.Y.Z`, pushes an annotated tag, and dispatches `release.yml` (GITHUB_TOKEN pushes cannot chain-trigger workflows).
- **Multi-platform release build unchanged** (mac/win/linux signed) → academy **draft** asset upload + **GitHub Release** attach for manual downloads.
- **Removed CI finalize / `latest-*` feed publish** so the Electron updater and in-app Update UI only advance after **approval on agentsystem.dev**.
- PR-only unsigned Linux AppImage in `ci.yml` (not on main — full release covers that).
- Docs/README updated for the new operator flow.

Closes #43

## Operator flow
1. Merge to `main`
2. Wait for Auto tag + Release Actions
3. Dogfood from GitHub Releases if desired
4. Approve on agentsystem.dev → users get Update prompt

## Caveats
- Branch protection must allow `github-actions[bot]` to push the `chore(release)` commit (or swap in a PAT).
- Confirm academy’s approve UI still runs finalize + activates the auto-update feed (CI no longer does that).
- Skip a release: include `[skip release]` in the merge commit message.

## Test plan
- [ ] Merge a small change to main (or run auto-tag on a test after merge) and confirm bump commit + tag appear
- [ ] Confirm Release workflow builds all platforms and attaches installers to the GitHub Release
- [ ] Confirm `/api/mission-control/releases?limit=1` still shows the previous finalized version until approval
- [ ] Approve on agentsystem.dev and confirm in-app Update / auto-update feed advance
- [ ] Open a PR and confirm unsigned Linux AppImage artifact uploads; main push does not run `package-linux`