### PR TITLE
fix(ci): create GitHub Release without local --verify-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,11 +299,13 @@ jobs:
             echo "In-app updates stay on the previously approved agentsystem.dev release until this version is approved there."
           } > "$notes_file"
 
+          # Do not use --verify-tag: this job has no git checkout, and gh would
+          # fail with "not a git repository". The tag already exists on origin
+          # (auto-tag / manual push); create the release against that remote tag.
           if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
             gh release upload "$RELEASE_VERSION" "${files[@]}" --clobber
           else
             gh release create "$RELEASE_VERSION" "${files[@]}" \
               --title "$RELEASE_VERSION" \
-              --notes-file "$notes_file" \
-              --verify-tag
+              --notes-file "$notes_file"
           fi


### PR DESCRIPTION
## Summary
- `publish-github` failed on v0.48.5 because `gh release create --verify-tag` requires a local `.git`, and that job only downloads artifacts.
- Drop `--verify-tag`; the tag already exists on origin from auto-tag / manual push.

## Test plan
- [ ] Re-run failed `publish-github` job (or `workflow_dispatch` release for `v0.48.5`) and confirm GitHub Release gets the 4 installers
- [ ] Confirm no academy finalize ran


Made with [Cursor](https://cursor.com)