### PR TITLE
feat(screenshots): pulse the receiving grid cell on attach

### DIFF
--- a/src/components/views/ScreenshotHistory.tsx
+++ b/src/components/views/ScreenshotHistory.tsx
@@ -148,7 +148,8 @@ function ScreenshotHistoryCard({
         const taskId = sessionHostAtPoint(e.clientX, e.clientY)?.getAttribute("data-task-id");
         // Dropped on empty space: no-op, the screenshot stays in history.
         if (!taskId) return;
-        void attachImageToSession(taskId, shot.path);
+        // No landing pulse: the drop gesture itself pointed at the cell.
+        void attachImageToSession(taskId, shot.path, { flash: false });
         playScreenshotDrop();
         // No removal — history persists after attaching.
         return;

--- a/src/components/views/ScreenshotThumbnail.tsx
+++ b/src/components/views/ScreenshotThumbnail.tsx
@@ -161,7 +161,8 @@ function ScreenshotStackCard({
         const taskId = sessionHostAtPoint(e.clientX, e.clientY)?.getAttribute("data-task-id");
         // Dropped on empty space: keep the thumbnail for another try.
         if (!taskId) return;
-        void attachImageToSession(taskId, shot.path);
+        // No landing pulse: the drop gesture itself pointed at the cell.
+        void attachImageToSession(taskId, shot.path, { flash: false });
         playScreenshotDrop();
         dismiss();
         return;

--- a/src/components/views/SessionGrid.tsx
+++ b/src/components/views/SessionGrid.tsx
@@ -377,6 +377,11 @@ type GridCellProps = {
   /** True when this session is pinned — tints the cell frame so pinned panes
    *  stand out from the rest of the grid. */
   isPinned: boolean;
+  /** Nonce of a pending "image attached" pulse on this cell (null = none).
+   *  Keys the overlay element so back-to-back attaches restart the animation. */
+  flashNonce: number | null;
+  /** Drop the pulse overlay once its animation finishes. */
+  onFlashDone: (taskId: string) => void;
 };
 
 /** One grid cell (its terminal), memoized so a per-grid state change — moving
@@ -402,6 +407,8 @@ const GridCell = memo(function GridCell({
   onTogglePin,
   pinBusy,
   isPinned,
+  flashNonce,
+  onFlashDone,
 }: GridCellProps) {
   return (
     <CardFrame
@@ -471,6 +478,14 @@ const GridCell = memo(function GridCell({
           />
         )}
       </div>
+      {flashNonce !== null && (
+        <div
+          key={flashNonce}
+          className="mc-cell-attach-flash"
+          aria-hidden
+          onAnimationEnd={() => onFlashDone(session.taskId)}
+        />
+      )}
     </CardFrame>
   );
 });
@@ -672,6 +687,23 @@ export function SessionGrid({
   const [expandedTaskId, setExpandedTaskId] = useState<string | null>(null);
   // Task whose cell is momentarily spotlighted after a notification "Open".
   const [focusedTaskId, setFocusedTaskId] = useState<string | null>(null);
+  // Cell pulsing the "image landed here" flash after a screenshot attach. The
+  // nonce keys the overlay so a repeat attach to the same cell replays it; the
+  // overlay clears itself on animationend.
+  const [attachFlash, setAttachFlash] = useState<{ taskId: string; nonce: number } | null>(null);
+  const handleFlashDone = useCallback((taskId: string) => {
+    setAttachFlash((prev) => (prev?.taskId === taskId ? null : prev));
+  }, []);
+  // A focus request already pending when the grid mounts was posted from a
+  // gridless surface (focus mode, single-panel view). It still gets consumed —
+  // scroll + caret as usual — but its attach flash is stale by the time the
+  // grid appears, so only requests raised after this nonce may pulse.
+  const preMountFlashNonceRef = useRef(gridFocusRequest?.nonce ?? 0);
+  // Live mirror of `expandedTaskId` for the spotlight effect: reading the state
+  // there would add it to the effect's deps, and the dep-change cleanup would
+  // kill the in-flight focus poll on every expand/collapse.
+  const expandedTaskIdRef = useRef<string | null>(null);
+  expandedTaskIdRef.current = expandedTaskId;
   // Keyboard-navigation mode (Cmd/Ctrl+G): the selected cell, or null when off.
   const [navTaskId, setNavTaskId] = useState<string | null>(null);
   const [pendingArchive, setPendingArchive] = useState<OpenTerminal | null>(null);
@@ -917,6 +949,19 @@ export function SessionGrid({
     setNavTaskId(null);
     setExpandedTaskId((prev) => (prev && prev !== taskId ? null : prev));
     setFocusedTaskId(taskId);
+    // An attach-flagged request also pulses the cell: the static spotlight ring
+    // is invisible when the target is already the focused cell — exactly the
+    // click-to-attach case, which targets the active session. Skip the pulse
+    // where it can't inform: the receiving cell is expanded (it fills the grid,
+    // there's nothing to pick it out from), or the request predates this grid
+    // (attached from focus mode / single view — stale by the time cells exist).
+    if (
+      gridFocusRequest.flash &&
+      gridFocusRequest.nonce > preMountFlashNonceRef.current &&
+      expandedTaskIdRef.current !== taskId
+    ) {
+      setAttachFlash({ taskId, nonce: gridFocusRequest.nonce });
+    }
 
     // A brand-new session's pane can mount a few frames late (progressive mount)
     // and then rebuild once as it persists (awaitingCreate → persisted), which
@@ -2128,6 +2173,10 @@ export function SessionGrid({
                   onTogglePin={onTogglePinned ? handleTogglePin : undefined}
                   pinBusy={pinningTaskIds?.has(session.taskId) ?? false}
                   isPinned={pinnedTaskIds?.has(session.taskId) ?? false}
+                  flashNonce={
+                    attachFlash?.taskId === session.taskId ? attachFlash.nonce : null
+                  }
+                  onFlashDone={handleFlashDone}
                 />
               );
             })}

--- a/src/lib/terminal-store.tsx
+++ b/src/lib/terminal-store.tsx
@@ -115,8 +115,15 @@ type Ctx = {
   /** Run an arbitrary command in the active PTY for this task. */
   runIn: (taskId: string, command: string) => Promise<void>;
   /** Paste an image path into a session's terminal (no submit) and make it
-   *  active + focused — the drop target of the native screenshot flow. */
-  attachImageToSession: (taskId: string, imagePath: string) => Promise<void>;
+   *  active + focused — the drop target of the native screenshot flow. The
+   *  receiving grid cell also pulses so the landing spot is visible; pass
+   *  `flash: false` from surfaces where the user aimed at the cell themselves
+   *  (drag-and-drop) and the cue would be noise. */
+  attachImageToSession: (
+    taskId: string,
+    imagePath: string,
+    opts?: { flash?: boolean },
+  ) => Promise<void>;
   /** Persistent, per-project screenshot history (oldest first), backed by the
    *  PNGs on disk and restored across app restarts. The on-demand history strip
    *  filters this by project and renders it newest-first. */
@@ -143,10 +150,14 @@ type Ctx = {
   toggleGridView: () => void;
   /** Latest request to spotlight a session cell in the grid (e.g. from a
    *  notification's "Open"). The nonce makes repeated requests for the same
-   *  task retrigger the grid's focus effect. */
-  gridFocusRequest: { taskId: string; nonce: number } | null;
-  /** Ask the grid to scroll to, highlight, and focus a session's cell. */
-  focusGridSession: (taskId: string) => void;
+   *  task retrigger the grid's focus effect. `flash` asks the grid to also
+   *  play the attach pulse on the cell. */
+  gridFocusRequest: { taskId: string; nonce: number; flash?: boolean } | null;
+  /** Ask the grid to scroll to, highlight, and focus a session's cell.
+   *  `flash` additionally pulses the cell — the "your image landed here" cue
+   *  after a screenshot attach, which the static spotlight ring can't convey
+   *  when the target is already the focused cell. */
+  focusGridSession: (taskId: string, opts?: { flash?: boolean }) => void;
   /** Claim a spotlight request for handling. True exactly once per nonce: the
    *  request state lingers after the grid's focus effect runs, and the grid
    *  remounts across project switches, so without this a stale request would
@@ -633,12 +644,12 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
   }, [screenshots, pendingScreenshotIds]);
 
   const [gridFocusRequest, setGridFocusRequest] = useState<
-    { taskId: string; nonce: number } | null
+    { taskId: string; nonce: number; flash?: boolean } | null
   >(null);
   const gridFocusNonceRef = useRef(0);
-  const focusGridSession = useCallback((taskId: string) => {
+  const focusGridSession = useCallback((taskId: string, opts?: { flash?: boolean }) => {
     gridFocusNonceRef.current += 1;
-    setGridFocusRequest({ taskId, nonce: gridFocusNonceRef.current });
+    setGridFocusRequest({ taskId, nonce: gridFocusNonceRef.current, flash: opts?.flash });
   }, []);
   // Highest nonce the grid has handled. Kept here (not in the grid) so it
   // survives the grid unmounting/remounting across project switches — a ref,
@@ -1155,7 +1166,7 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
   );
 
   const attachImageToSession = useCallback(
-    async (taskId: string, imagePath: string) => {
+    async (taskId: string, imagePath: string, opts?: { flash?: boolean }) => {
       const target = sessionsRef.current.find((p) => p.taskId === taskId);
       if (!target?.ptyId) return;
       const electron = getElectron();
@@ -1178,7 +1189,11 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
         }
       }
       setActiveSession(target.project, taskId);
-      focusGridSession(taskId);
+      // Flash the receiving cell: with many sessions open (and click-to-attach
+      // targeting the *active* one, which already wears the focus ring) the
+      // plain spotlight gives no visible cue about where the image landed.
+      // Drag-drop callers opt out — the user aimed at the cell themselves.
+      focusGridSession(taskId, { flash: opts?.flash !== false });
     },
     [setActiveSession, focusGridSession]
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -1680,6 +1680,56 @@ select,
   }
 }
 
+/* ── Attach-landing pulse ─────────────────────────────────────────────────
+   Overlay flashed on the grid cell that just received a screenshot, so the
+   landing pane is unmissable in a busy grid. Opacity-only (accent wash + inset
+   ring) pulsing twice; the base state is invisible and the element unmounts on
+   animationend, so nothing lingers. */
+.mc-cell-attach-flash {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  pointer-events: none;
+  opacity: 0;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  box-shadow:
+    inset 0 0 0 2px var(--accent),
+    inset 0 0 32px color-mix(in srgb, var(--accent) 30%, transparent);
+  animation: mc-cell-attach-flash 1s ease-out;
+}
+@keyframes mc-cell-attach-flash {
+  0% {
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  45% {
+    opacity: 0.25;
+  }
+  65% {
+    opacity: 0.85;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+@keyframes mc-cell-attach-flash-fade {
+  0% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+/* Reduced motion: one gentle fade instead of the double pulse — still an
+   animation so animationend fires and the overlay unmounts. */
+@media (prefers-reduced-motion: reduce) {
+  .mc-cell-attach-flash {
+    animation: mc-cell-attach-flash-fade 0.8s ease-out;
+  }
+}
+
 @keyframes launch-overlay-fade {
   0%,
   91% {


### PR DESCRIPTION
## Problem

Clicking a screenshot thumbnail's attach button pastes the image into the **active** session — but with many sessions open, nothing visibly changes. The grid's spotlight ring is identical to the focus ring the active cell already wears, so it's easy to lose track of where the image went.

## Change

Attaching a screenshot now plays a one-shot accent pulse on the receiving grid cell: an accent wash + inset ring that pulses twice over ~1s, then fades. Opacity-only, follows the active accent via `var(--accent)` / `color-mix` across themes.

- Routed through the existing grid spotlight request as an opt-in `flash` flag on `focusGridSession` — scroll/focus behavior is unchanged.
- The overlay is keyed by the request nonce, so back-to-back attaches to the same cell replay the animation; it unmounts on `animationend`.
- `prefers-reduced-motion`: a single gentle fade instead of the double pulse.

## When it deliberately does NOT pulse

- **Receiving cell is expanded** — it fills the grid; nothing to pick it out from.
- **Attach happened while the grid was unmounted** (focus mode / single-panel view) — the grid captures the pending request nonce at mount and only pulses requests raised after it, so nothing replays stale on remount.
- **Drag-and-drop attaches** (floating stack + history strip) — the drop gesture itself pointed at the cell; those call sites pass `flash: false`.

## Verification

- `npx tsc --noEmit` (both tsconfigs via full typecheck) ✅
- `npx eslint` on touched files ✅
- `vitest run src/lib/__tests__/terminal-store.test.ts` (20 tests) ✅