### PR TITLE
feat(terminal): show the drop-to-attach zone for external file drags

### DIFF
--- a/src/components/views/ScreenshotHistory.tsx
+++ b/src/components/views/ScreenshotHistory.tsx
@@ -13,6 +13,7 @@ import {
   type Shape as AnnotationShape,
   type CropBox,
 } from "~/components/views/ScreenshotAnnotator";
+import { SessionDropzoneHighlight } from "~/components/views/SessionDropzone";
 import { useTerminals, type ScreenshotEntry } from "~/lib/terminal-store";
 import { playScreenshotDrop } from "~/lib/screenshot-sound";
 
@@ -283,43 +284,7 @@ function ScreenshotHistoryCard({
       </div>
 
       {/* Dropzone highlight over the session currently under the cursor. */}
-      {dragging && dropTarget && (
-        <div
-          aria-hidden
-          style={{
-            position: "fixed",
-            left: dropTarget.rect.x,
-            top: dropTarget.rect.y,
-            width: dropTarget.rect.w,
-            height: dropTarget.rect.h,
-            border: "2px solid var(--accent)",
-            background: "color-mix(in srgb, var(--accent) 14%, transparent)",
-            borderRadius: 10,
-            boxShadow: "0 0 0 4px color-mix(in srgb, var(--accent) 22%, transparent)",
-            pointerEvents: "none",
-            boxSizing: "border-box",
-            zIndex: 9999,
-          }}
-        >
-          <div
-            style={{
-              position: "absolute",
-              left: "50%",
-              top: 8,
-              transform: "translateX(-50%)",
-              padding: "3px 10px",
-              borderRadius: 999,
-              fontSize: 11,
-              fontFamily: "var(--mono)",
-              color: "#fff",
-              background: "var(--accent)",
-              whiteSpace: "nowrap",
-            }}
-          >
-            Drop to attach
-          </div>
-        </div>
-      )}
+      {dragging && dropTarget && <SessionDropzoneHighlight rect={dropTarget.rect} />}
 
       {dragging && dragPoint && (
         <div

--- a/src/components/views/ScreenshotThumbnail.tsx
+++ b/src/components/views/ScreenshotThumbnail.tsx
@@ -13,6 +13,7 @@ import {
   type Shape as AnnotationShape,
   type CropBox,
 } from "~/components/views/ScreenshotAnnotator";
+import { SessionDropzoneHighlight } from "~/components/views/SessionDropzone";
 import { useTerminals, type PendingScreenshot } from "~/lib/terminal-store";
 import { playScreenshotDrop } from "~/lib/screenshot-sound";
 
@@ -364,43 +365,7 @@ function ScreenshotStackCard({
       </div>
 
       {/* Dropzone highlight over the session currently under the cursor. */}
-      {dragging && dropTarget && (
-        <div
-          aria-hidden
-          style={{
-            position: "fixed",
-            left: dropTarget.rect.x,
-            top: dropTarget.rect.y,
-            width: dropTarget.rect.w,
-            height: dropTarget.rect.h,
-            border: "2px solid var(--accent)",
-            background: "color-mix(in srgb, var(--accent) 14%, transparent)",
-            borderRadius: 10,
-            boxShadow: "0 0 0 4px color-mix(in srgb, var(--accent) 22%, transparent)",
-            pointerEvents: "none",
-            boxSizing: "border-box",
-            zIndex: 9999,
-          }}
-        >
-          <div
-            style={{
-              position: "absolute",
-              left: "50%",
-              top: 8,
-              transform: "translateX(-50%)",
-              padding: "3px 10px",
-              borderRadius: 999,
-              fontSize: 11,
-              fontFamily: "var(--mono)",
-              color: "#fff",
-              background: "var(--accent)",
-              whiteSpace: "nowrap",
-            }}
-          >
-            Drop to attach
-          </div>
-        </div>
-      )}
+      {dragging && dropTarget && <SessionDropzoneHighlight rect={dropTarget.rect} />}
 
       {dragging && dragPoint && (
         <div

--- a/src/components/views/SessionDropzone.tsx
+++ b/src/components/views/SessionDropzone.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from "react";
+import { getElectron } from "~/lib/electron";
+import { playScreenshotDrop } from "~/lib/screenshot-sound";
+import {
+  TERMINAL_DROP_MAX_FILES,
+  resolveTerminalDropPath,
+} from "~/lib/terminal-pane-helpers";
+import { useTerminalActions } from "~/lib/terminal-store";
+
+export type DropzoneRect = { x: number; y: number; w: number; h: number };
+
+/**
+ * Accent highlight + "Drop to attach" pill over the session host under a drag.
+ * Shared by the screenshot cards' pointer-drags (stack + history strip) and the
+ * native file drag from outside the app, so every drag-to-attach flow reads
+ * identically.
+ */
+export function SessionDropzoneHighlight({ rect }: { rect: DropzoneRect }) {
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: "fixed",
+        left: rect.x,
+        top: rect.y,
+        width: rect.w,
+        height: rect.h,
+        border: "2px solid var(--accent)",
+        background: "color-mix(in srgb, var(--accent) 14%, transparent)",
+        borderRadius: 10,
+        boxShadow: "0 0 0 4px color-mix(in srgb, var(--accent) 22%, transparent)",
+        pointerEvents: "none",
+        boxSizing: "border-box",
+        zIndex: 9999,
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          left: "50%",
+          top: 8,
+          transform: "translateX(-50%)",
+          padding: "3px 10px",
+          borderRadius: 999,
+          fontSize: 11,
+          fontFamily: "var(--mono)",
+          color: "#fff",
+          background: "var(--accent)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        Drop to attach
+      </div>
+    </div>
+  );
+}
+
+/** The `[data-task-id]` session host the drag event is over, if any. */
+function sessionHostFromDragEvent(e: DragEvent): HTMLElement | null {
+  const el = e.target as HTMLElement | null;
+  return (el?.closest?.("[data-task-id]") as HTMLElement | null) ?? null;
+}
+
+function isFileDrag(e: DragEvent): boolean {
+  return !!e.dataTransfer?.types.includes("Files");
+}
+
+/**
+ * Native-drag counterpart of the screenshot cards' drop flow: while a file
+ * dragged from outside the app (Finder, a browser, …) hovers a session host —
+ * grid cell, single-view terminal panel, or the focus-view terminal — show the
+ * same dropzone highlight the screenshot drags show, and accept the drop
+ * anywhere on that host.
+ *
+ * The terminal panes already accept drops over their xterm surface
+ * (wireTerminalFileDrop, plain path-paste); those drops arrive here already
+ * defaultPrevented and are left alone. Drops on the rest of the host (header,
+ * chrome) attach via attachImageToSession — the same path screenshot drops
+ * take, so images land as clipboard pastes and the session activates. Mounted
+ * once in the Shell; listeners are window-level and idle until a file drag
+ * actually hovers a session.
+ */
+export function SessionFileDropZone() {
+  const { attachImageToSession } = useTerminalActions();
+  const [target, setTarget] = useState<{ taskId: string; rect: DropzoneRect } | null>(null);
+
+  useEffect(() => {
+    const onDragOver = (e: DragEvent) => {
+      if (!isFileDrag(e)) return;
+      const host = sessionHostFromDragEvent(e);
+      const taskId = host?.getAttribute("data-task-id");
+      if (!host || !taskId) {
+        setTarget(null);
+        return;
+      }
+      // Make the whole host a valid drop target — the pane's own wiring only
+      // preventDefaults over its xterm surface.
+      e.preventDefault();
+      e.dataTransfer!.dropEffect = "copy";
+      const r = host.getBoundingClientRect();
+      // dragover fires continuously; only re-render when the target changes.
+      setTarget((prev) =>
+        prev &&
+        prev.taskId === taskId &&
+        prev.rect.x === r.left &&
+        prev.rect.y === r.top &&
+        prev.rect.w === r.width &&
+        prev.rect.h === r.height
+          ? prev
+          : { taskId, rect: { x: r.left, y: r.top, w: r.width, h: r.height } },
+      );
+    };
+
+    const onDrop = (e: DragEvent) => {
+      setTarget(null);
+      if (!isFileDrag(e)) return;
+      // Landed on an xterm surface: wireTerminalFileDrop already pasted it.
+      if (e.defaultPrevented) return;
+      const taskId = sessionHostFromDragEvent(e)?.getAttribute("data-task-id");
+      if (!taskId) return;
+      e.preventDefault();
+      const electron = getElectron();
+      if (!electron) return;
+      const files = Array.from(e.dataTransfer?.files ?? []).slice(0, TERMINAL_DROP_MAX_FILES);
+      if (!files.length) return;
+      void (async () => {
+        let attached = false;
+        // Sequential: image attaches paste through the clipboard, so parallel
+        // attaches would race each other's clipboard contents.
+        for (const file of files) {
+          const path = await resolveTerminalDropPath(electron, file);
+          if (!path) continue;
+          await attachImageToSession(taskId, path);
+          attached = true;
+        }
+        if (attached) playScreenshotDrop();
+      })();
+    };
+
+    // relatedTarget is null when the drag leaves the window; in-window
+    // dragleaves between elements carry the element being entered.
+    const onDragLeave = (e: DragEvent) => {
+      if (!e.relatedTarget) setTarget(null);
+    };
+    const onDragEnd = () => setTarget(null);
+
+    window.addEventListener("dragover", onDragOver);
+    window.addEventListener("drop", onDrop);
+    window.addEventListener("dragleave", onDragLeave);
+    window.addEventListener("dragend", onDragEnd);
+    return () => {
+      window.removeEventListener("dragover", onDragOver);
+      window.removeEventListener("drop", onDrop);
+      window.removeEventListener("dragleave", onDragLeave);
+      window.removeEventListener("dragend", onDragEnd);
+    };
+  }, [attachImageToSession]);
+
+  if (!target) return null;
+  return <SessionDropzoneHighlight rect={target.rect} />;
+}

--- a/src/lib/terminal-pane-helpers.ts
+++ b/src/lib/terminal-pane-helpers.ts
@@ -25,7 +25,7 @@ type TerminalLike = {
 const TERMINAL_IMAGE_MIME = /^image\/(?:png|jpe?g|webp|gif|bmp)$/i;
 const TERMINAL_IMAGE_EXT = /\.(?:png|jpe?g|webp|gif|bmp)$/i;
 const TERMINAL_IMAGE_MAX_BYTES = 20 * 1024 * 1024;
-const TERMINAL_DROP_MAX_FILES = 10;
+export const TERMINAL_DROP_MAX_FILES = 10;
 
 const ANSI_ESCAPE_REGEX =
   /(?:\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b[PX^_].*?(?:\x1b\\)|\x1b[@-_])/g;
@@ -152,7 +152,12 @@ function isTerminalImageFile(file: File): boolean {
   return TERMINAL_IMAGE_MIME.test(file.type) || TERMINAL_IMAGE_EXT.test(file.name);
 }
 
-async function resolveTerminalDropPath(electron: Electron, file: File): Promise<string | null> {
+/** Absolute path for a dropped File: the native path when the OS provides one,
+ *  else (browser-originated image drags) the payload saved to a temp PNG. */
+export async function resolveTerminalDropPath(
+  electron: Electron,
+  file: File,
+): Promise<string | null> {
   const nativePath = electron.getPathForFile(file);
   if (nativePath) return nativePath;
   if (!isTerminalImageFile(file)) return null;

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -25,6 +25,7 @@ import {
   useUserTerminals,
 } from "~/lib/user-terminal-store";
 import { TerminalPanel } from "~/components/views/TerminalPanel";
+import { SessionFileDropZone } from "~/components/views/SessionDropzone";
 import { UserTerminalPanel } from "~/components/views/UserTerminalPanel";
 import { ProjectPicker } from "~/components/views/ProjectPicker";
 import { ProjectBar } from "~/components/views/ProjectBar";
@@ -593,6 +594,7 @@ function Shell() {
         }}
       >
         <Outlet />
+        <SessionFileDropZone />
       </div>
     );
   }
@@ -726,6 +728,7 @@ function Shell() {
           }}
         />
         <VoiceController />
+        <SessionFileDropZone />
       </div>
       <ConfirmDialog
         open={!!closeIntentTarget}


### PR DESCRIPTION
## Problem

Dragging a file from outside the app (Finder, a browser) gave no visual feedback — no dropzone highlight, unlike the screenshot cards' drag-to-attach flow. Drops also only worked over the xterm surface itself; dropping on the rest of a session cell did nothing.

## Change

**`SessionFileDropZone`** (new, mounted once in the Shell + the focus-mode branch): window-level native-drag listeners that track the `[data-task-id]` session host under a `Files` drag — grid cell, single-view terminal panel, or focus-view terminal — and show the same "Drop to attach" highlight the screenshot drags use.

- **Shared highlight**: the dropzone overlay JSX was duplicated verbatim in `ScreenshotThumbnail` and `ScreenshotHistory`; it's extracted into `SessionDropzoneHighlight`, now rendered by all three flows.
- **Whole-cell drops**: the window-level `dragover` preventDefaults over the session host, so drops land anywhere on the cell. The pane's existing `wireTerminalFileDrop` still handles drops over its xterm surface (those arrive `defaultPrevented` at the window and are left alone — no double paste); drops on the rest of the cell attach via `attachImageToSession`, the same path screenshot drops take (clipboard image paste, session activates + focuses).
- Multi-file drops attach sequentially (clipboard-paste attaches would race in parallel), capped at the existing `TERMINAL_DROP_MAX_FILES` (10). `resolveTerminalDropPath` + `TERMINAL_DROP_MAX_FILES` exported from `terminal-pane-helpers` for reuse.
- Highlight clears on drop, on the drag leaving the window (`relatedTarget === null`), and on `dragend`.

## Note if #86 lands too

#86 adds a "landed here" pulse to `attachImageToSession` (default on) with a `flash: false` opt-out for drag-drop surfaces. Once both merge, the external-drop call here should pass `{ flash: false }` for consistency — one-line follow-up; the branches don't conflict textually.

## Verification

- `npx tsc --noEmit` + `npx tsc -p electron/tsconfig.json --noEmit` ✅
- `npx eslint` on touched files ✅
- `vitest run` terminal-pane-helpers + terminal-store suites (30 tests) ✅