### PR TITLE
fix(theme): legible on-fill button ink + cohesive New session pill (flat theme)

### DIFF
--- a/src/lib/accent-colors.ts
+++ b/src/lib/accent-colors.ts
@@ -19,27 +19,37 @@ export type AccentColor = {
   name: string;
   value: string;
   rgb: string;
+  /** Ink for text/icons sitting ON the solid accent fill (e.g. the Ship /
+   *  primary buttons in the flat theme). Bright accents take dark ink; the
+   *  darker, saturated accents (blue/indigo/purple/red) take light ink, where
+   *  near-black reads as muddy even though its raw contrast ratio passes. */
+  onAccent: string;
 };
+
+// On-accent ink options. Dark is the near-black used across the flat theme;
+// light is plain white for accents where dark ink reads unclear.
+const ON_ACCENT_DARK = "#050607";
+const ON_ACCENT_LIGHT = "#ffffff";
 
 export const DEFAULT_ACCENT_COLOR: AccentColorId = "deep-orange";
 
 export const ACCENT_COLORS: AccentColor[] = [
-  { id: "deep-orange", name: "Deep orange", value: "#ff5a1f", rgb: "255, 90, 31" },
+  { id: "deep-orange", name: "Deep orange", value: "#ff5a1f", rgb: "255, 90, 31", onAccent: ON_ACCENT_DARK },
   // Warm terracotta-amber sampled from the ember reference (the focused pane's
   // border + cursor). Ember defaults to this; any theme can use it.
-  { id: "terracotta", name: "Terracotta", value: "#d0854e", rgb: "208, 133, 78" },
-  { id: "blue", name: "Blue", value: "#3b82f6", rgb: "59, 130, 246" },
-  { id: "green", name: "Green", value: "#22c55e", rgb: "34, 197, 94" },
-  { id: "teal", name: "Teal", value: "#14b8a6", rgb: "20, 184, 166" },
-  { id: "cyan", name: "Cyan", value: "#06b6d4", rgb: "6, 182, 212" },
-  { id: "purple", name: "Purple", value: "#a855f7", rgb: "168, 85, 247" },
-  { id: "magenta", name: "Magenta", value: "#d946ef", rgb: "217, 70, 239" },
-  { id: "pink", name: "Pink", value: "#f472b6", rgb: "244, 114, 182" },
-  { id: "red", name: "Red", value: "#ef4444", rgb: "239, 68, 68" },
-  { id: "amber", name: "Amber", value: "#f59e0b", rgb: "245, 158, 11" },
-  { id: "lime", name: "Lime", value: "#84cc16", rgb: "132, 204, 22" },
-  { id: "indigo", name: "Indigo", value: "#6366f1", rgb: "99, 102, 241" },
-  { id: "slate", name: "Slate", value: "#94a3b8", rgb: "148, 163, 184" },
+  { id: "terracotta", name: "Terracotta", value: "#d0854e", rgb: "208, 133, 78", onAccent: ON_ACCENT_DARK },
+  { id: "blue", name: "Blue", value: "#3b82f6", rgb: "59, 130, 246", onAccent: ON_ACCENT_LIGHT },
+  { id: "green", name: "Green", value: "#22c55e", rgb: "34, 197, 94", onAccent: ON_ACCENT_DARK },
+  { id: "teal", name: "Teal", value: "#14b8a6", rgb: "20, 184, 166", onAccent: ON_ACCENT_DARK },
+  { id: "cyan", name: "Cyan", value: "#06b6d4", rgb: "6, 182, 212", onAccent: ON_ACCENT_DARK },
+  { id: "purple", name: "Purple", value: "#a855f7", rgb: "168, 85, 247", onAccent: ON_ACCENT_LIGHT },
+  { id: "magenta", name: "Magenta", value: "#d946ef", rgb: "217, 70, 239", onAccent: ON_ACCENT_DARK },
+  { id: "pink", name: "Pink", value: "#f472b6", rgb: "244, 114, 182", onAccent: ON_ACCENT_DARK },
+  { id: "red", name: "Red", value: "#ef4444", rgb: "239, 68, 68", onAccent: ON_ACCENT_LIGHT },
+  { id: "amber", name: "Amber", value: "#f59e0b", rgb: "245, 158, 11", onAccent: ON_ACCENT_DARK },
+  { id: "lime", name: "Lime", value: "#84cc16", rgb: "132, 204, 22", onAccent: ON_ACCENT_DARK },
+  { id: "indigo", name: "Indigo", value: "#6366f1", rgb: "99, 102, 241", onAccent: ON_ACCENT_LIGHT },
+  { id: "slate", name: "Slate", value: "#94a3b8", rgb: "148, 163, 184", onAccent: ON_ACCENT_DARK },
 ];
 
 export function getAccentColor(id: string | null | undefined): AccentColor {
@@ -59,6 +69,7 @@ export function applyAccentColor(id: string | null | undefined) {
   const color = getAccentColor(id);
   const root = document.documentElement;
   root.style.setProperty("--accent", color.value);
+  root.style.setProperty("--mc-on-accent", color.onAccent);
   root.style.setProperty("--accent-dim", `rgba(${color.rgb}, 0.18)`);
   root.style.setProperty("--accent-faint", `rgba(${color.rgb}, 0.1)`);
   root.style.setProperty("--accent-border", `rgba(${color.rgb}, 0.38)`);

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -132,13 +132,16 @@ var tt=localStorage.getItem(${JSON.stringify(SURFACE_TINT_CACHE_KEY)});
 if(tt==="subtle"||tt==="vivid"||tt==="intense"){d.setAttribute("data-tint",tt);}
 if(localStorage.getItem(${JSON.stringify(LAUNCH_INTRO_CACHE_KEY)})==="1"){d.setAttribute("data-launch-intro","true");}
 var t=${JSON.stringify(
-  Object.fromEntries(ACCENT_COLORS.map((c) => [c.id, { v: c.value, r: c.rgb }])),
+  Object.fromEntries(
+    ACCENT_COLORS.map((c) => [c.id, { v: c.value, r: c.rgb, k: c.onAccent }]),
+  ),
 )};
 var a=localStorage.getItem(${JSON.stringify(ACCENT_CACHE_KEY)});
 var c=a&&t[a]?t[a]:t[${JSON.stringify(DEFAULT_ACCENT_COLOR)}];
 if(c&&a&&a!==${JSON.stringify(DEFAULT_ACCENT_COLOR)}){
   var s=d.style;
   s.setProperty("--accent",c.v);
+  s.setProperty("--mc-on-accent",c.k);
   s.setProperty("--accent-dim","rgba("+c.r+", 0.18)");
   s.setProperty("--accent-faint","rgba("+c.r+", 0.1)");
   s.setProperty("--accent-border","rgba("+c.r+", 0.38)");

--- a/src/styles.css
+++ b/src/styles.css
@@ -2790,7 +2790,10 @@ body[data-card-glow] .cursor-glow {
 [data-minimal="true"] .mc-btn-primary {
   background: var(--accent);
   border-color: color-mix(in srgb, var(--accent) 90%, black);
-  color: var(--mm-on-accent);
+  /* Per-accent on-fill ink (set alongside --accent in accent-colors.ts): light
+     ink for the darker/saturated accents where near-black reads muddy, dark ink
+     for bright ones. Falls back to --mm-on-accent (dark) for the default. */
+  color: var(--mc-on-accent, var(--mm-on-accent));
   box-shadow:
     0 1px 0 oklch(1 0 0 / 0.14) inset,
     0 1px 2px oklch(0 0 0 / 0.30);
@@ -2903,17 +2906,20 @@ body[data-card-glow] .cursor-glow {
     var(--mm-ring);
 }
 
-/* New session button: outline style in minimal theme only.
-   Transparent fill, accent border + accent text/icon. */
+/* New session button: soft-outline style in minimal theme only.
+   A faint accent fill + a firm accent border give the cluster a defined
+   pill body, so the label and its attached +/gear segments read as one
+   button rather than three loose accent glyphs. Still clearly lighter than
+   a solid primary, preserving the minimal-theme aesthetic. */
 [data-minimal="true"] .mc-btn-primary.mc-btn-new-session {
-  background: transparent;
-  border-color: color-mix(in srgb, var(--accent) 48%, transparent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 62%, transparent);
   color: var(--accent-ink);
   box-shadow: none;
 }
 [data-minimal="true"] .mc-btn-primary.mc-btn-new-session:hover {
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
-  border-color: color-mix(in srgb, var(--accent) 64%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 78%, transparent);
   box-shadow: none;
 }
 [data-minimal="true"] .mc-btn-primary.mc-btn-new-session:focus-visible {
@@ -2927,15 +2933,15 @@ body[data-card-glow] .cursor-glow {
    still form the seamless middle seams. */
 [data-minimal="true"] .mc-btn-ghost.mc-btn-new-session-config,
 [data-minimal="true"] .mc-btn-ghost.mc-btn-new-session-row {
-  background: transparent;
-  border-color: color-mix(in srgb, var(--accent) 48%, transparent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 62%, transparent);
   color: var(--accent-ink);
   box-shadow: none;
 }
 [data-minimal="true"] .mc-btn-ghost.mc-btn-new-session-config:hover,
 [data-minimal="true"] .mc-btn-ghost.mc-btn-new-session-row:hover {
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
-  border-color: color-mix(in srgb, var(--accent) 64%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 78%, transparent);
 }
 
 [data-minimal="true"] .mc-btn-primary.mc-btn-attached-left,


### PR DESCRIPTION
## What

Two related flat-theme button polish fixes surfaced while reviewing toolbar button colors.

### 1. Per-accent on-fill ink (the main fix)
Solid accent/primary buttons (e.g. **Ship**) used a single hard-coded near-black ink (`--mm-on-accent = #050607`) for **every** accent. On the darker, saturated accents that reads muddy/unclear even though the raw WCAG ratio passes — most visibly the Ship button on a **blue** accent.

On-fill ink is now chosen **per accent**:
- **Light ink** → blue, indigo, purple, red (near-black reads muddy; convention + perceptual contrast want light)
- **Dark ink** → deep-orange, terracotta, green, teal, cyan, magenta, pink, amber, lime, slate (bright accents where dark is genuinely crisper — e.g. terracotta is 7.2:1 dark vs 2.9:1 white)

### 2. New session pill cohesion
The flat-theme New session button is a soft-outline pill whose border was too faint (`accent 48%`), so the label + its attached `+`/gear segments read as three loose accent glyphs. A faint accent resting fill + firmer border fuse them into one button.

## How (scoping)
- Ink emitted as a dedicated `--mc-on-accent` var, set in both the React path (`applyAccentColor`) and the cold-start pre-hydration script (no flash).
- Only the **flat** primary-button rule reads it, with `--mm-on-accent` as fallback → painted theme and `--action-commit-text` untouched.

## Files
- `src/lib/accent-colors.ts` — `onAccent` field per accent + emit `--mc-on-accent`
- `src/routes/__root.tsx` — pre-hydration script emits `--mc-on-accent`
- `src/styles.css` — flat primary reads `--mc-on-accent`; strengthened New session pill

## Checks
`tsc --noEmit` clean · eslint clean · no tests pinned the accent table. Scoped to the flat/minimal theme; painted + light themes unaffected.