### PR TITLE
feat(settings): appearance settings — terminal & interface typography on a shared card layout

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, webUtils } from "electron";
+import { contextBridge, ipcRenderer, webFrame, webUtils } from "electron";
 import { IPC } from "./ipc-channels";
 
 /** Subscribe to a main→renderer IPC channel; returns an unsubscribe fn. */
@@ -349,6 +349,13 @@ const electronAPI = {
     ipcRenderer.invoke(IPC.appReload),
   setWindowBackgroundColor: (color: string): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke(IPC.appSetBackgroundColor, color),
+  setZoomFactor: (factor: number): Promise<{ ok: true } | { ok: false; error: string }> => {
+    // webFrame is renderer-local — no IPC round-trip needed. Clamp to the
+    // interface-scale range so a bad value can't blow the window up.
+    const clamped = Math.min(1.5, Math.max(0.5, factor));
+    webFrame.setZoomFactor(clamped);
+    return Promise.resolve({ ok: true });
+  },
   notifications: {
     getPermission: (): Promise<"granted" | "unsupported"> =>
       ipcRenderer.invoke(IPC.notificationsGetPermission),

--- a/src/components/views/GeneralSettingsPage.tsx
+++ b/src/components/views/GeneralSettingsPage.tsx
@@ -23,6 +23,13 @@ import {
   writeCachedLaunchIntroEnabled,
 } from "~/lib/launch-intro";
 import { DEFAULT_TERMINAL_ZOOM_LEVEL } from "~/shared/terminal-zoom";
+import {
+  DEFAULT_INTERFACE_FONT_SCALE,
+  DEFAULT_TERMINAL_FONT_WEIGHT,
+  DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+  DEFAULT_TERMINAL_LETTER_SPACING,
+  DEFAULT_TERMINAL_LINE_HEIGHT,
+} from "~/shared/terminal-appearance";
 import { DEFAULT_SURFACE_TINT } from "~/shared/surface-tint";
 import {
   readOsNotificationPermission,
@@ -105,6 +112,15 @@ export function GeneralSettingsPage() {
     selectedWorktreeByProject: settings?.selectedWorktreeByProject ?? null,
     commitCli: settings?.commitCli ?? null,
     terminalZoomLevel: settings?.terminalZoomLevel ?? DEFAULT_TERMINAL_ZOOM_LEVEL,
+    terminalFontFamily: settings?.terminalFontFamily ?? null,
+    terminalFontWeight: settings?.terminalFontWeight ?? DEFAULT_TERMINAL_FONT_WEIGHT,
+    terminalFontWeightBold:
+      settings?.terminalFontWeightBold ?? DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+    terminalLineHeight: settings?.terminalLineHeight ?? DEFAULT_TERMINAL_LINE_HEIGHT,
+    terminalLetterSpacing:
+      settings?.terminalLetterSpacing ?? DEFAULT_TERMINAL_LETTER_SPACING,
+    interfaceFontFamily: settings?.interfaceFontFamily ?? null,
+    interfaceFontScale: settings?.interfaceFontScale ?? DEFAULT_INTERFACE_FONT_SCALE,
     sessionHeaderButtons:
       settings?.sessionHeaderButtons ?? DEFAULT_SESSION_HEADER_BUTTON_VISIBILITY,
     defaultAgent: settings?.defaultAgent ?? "claude-code",

--- a/src/components/views/SettingsParts.tsx
+++ b/src/components/views/SettingsParts.tsx
@@ -73,6 +73,48 @@ export function Field({ label, children }: { label: string; children: React.Reac
   );
 }
 
+/**
+ * A single setting presented on the app's surface card (same chrome as
+ * {@link ToggleRow}): a title, an optional description, then its control
+ * stacked below. Use for controls too wide to sit inline beside the label
+ * (selects, value pickers, sliders). Keeps settings pages visually consistent.
+ */
+export function SettingCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        background: "var(--surface-0)",
+        border: "1px solid var(--border)",
+        borderRadius: 7,
+        padding: "14px 16px",
+      }}
+    >
+      <div style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{title}</div>
+      {description && (
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--text-dim)",
+            lineHeight: 1.45,
+            marginTop: 3,
+          }}
+        >
+          {description}
+        </div>
+      )}
+      <div style={{ marginTop: 12 }}>{children}</div>
+    </div>
+  );
+}
+
 /** Row of discrete numeric options styled like a segmented picker (selected = accent + underline). */
 export function ValueRow<T extends number>({
   values,
@@ -100,6 +142,7 @@ export function ValueRow<T extends number>({
             key={candidate}
             type="button"
             role="radio"
+            className="term-value"
             aria-checked={selected}
             onClick={() => onSelect(candidate)}
             style={{

--- a/src/components/views/SettingsParts.tsx
+++ b/src/components/views/SettingsParts.tsx
@@ -73,6 +73,57 @@ export function Field({ label, children }: { label: string; children: React.Reac
   );
 }
 
+/** Row of discrete numeric options styled like a segmented picker (selected = accent + underline). */
+export function ValueRow<T extends number>({
+  values,
+  value,
+  onSelect,
+  format = (v) => String(v),
+  ariaLabel,
+}: {
+  values: readonly T[];
+  value: T;
+  onSelect: (next: T) => void;
+  format?: (v: T) => string;
+  ariaLabel: string;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      style={{ display: "flex", alignItems: "baseline", gap: 4, flexWrap: "wrap" }}
+    >
+      {values.map((candidate) => {
+        const selected = candidate === value;
+        return (
+          <button
+            key={candidate}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onSelect(candidate)}
+            style={{
+              background: "transparent",
+              border: "none",
+              borderBottom: selected
+                ? "2px solid var(--accent)"
+                : "2px solid transparent",
+              color: selected ? "var(--text)" : "var(--text-dim)",
+              fontFamily: "var(--mono)",
+              fontSize: 12,
+              fontWeight: selected ? 600 : 400,
+              padding: "3px 6px 2px",
+              cursor: "pointer",
+            }}
+          >
+            {format(candidate)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export function CodeBlock({
   value,
   onCopy,

--- a/src/components/views/TerminalPane.tsx
+++ b/src/components/views/TerminalPane.tsx
@@ -50,6 +50,7 @@ import {
   terminalNeedsTransparency,
   watchTerminalColorScheme,
 } from "~/lib/terminal-options";
+import { getCurrentTerminalAppearanceOptions } from "~/lib/terminal-appearance";
 import {
   useTerminalZoom,
   useTerminalPaneZoomShortcuts,
@@ -884,11 +885,23 @@ export function TerminalPane({
         // so xterm computes the new background alpha under the right rule.
         term.options.allowTransparency = terminalNeedsTransparency(colorScheme);
         term.options.theme = createTerminalTheme({ cursorColor, colorScheme });
-        // A theme with a bundled face (ember → JetBrains Mono) swaps the
-        // terminal font live; the glyph box changes, so refit to reflow.
+        // A theme with a bundled face (ember → JetBrains Mono) or an
+        // appearance-settings change swaps typography live; any of these
+        // alters the glyph box, so refit to reflow.
         const font = getCurrentTerminalFont();
-        if (term.options.fontFamily !== font) {
+        const appearance = getCurrentTerminalAppearanceOptions();
+        const typographyChanged =
+          term.options.fontFamily !== font ||
+          term.options.fontWeight !== appearance.fontWeight ||
+          term.options.fontWeightBold !== appearance.fontWeightBold ||
+          term.options.lineHeight !== appearance.lineHeight ||
+          term.options.letterSpacing !== appearance.letterSpacing;
+        if (typographyChanged) {
           term.options.fontFamily = font;
+          term.options.fontWeight = appearance.fontWeight;
+          term.options.fontWeightBold = appearance.fontWeightBold;
+          term.options.lineHeight = appearance.lineHeight;
+          term.options.letterSpacing = appearance.letterSpacing;
           fitTerminalSurface(term, fit);
         }
       });

--- a/src/components/views/TerminalSettingsPage.tsx
+++ b/src/components/views/TerminalSettingsPage.tsx
@@ -1,9 +1,15 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { Field, SettingsSection } from "~/components/views/SettingsParts";
+import { Field, SettingsSection, ValueRow } from "~/components/views/SettingsParts";
 import { api, type AppSettings } from "~/lib/api";
 import { queryKeys, useSettings } from "~/queries";
 import { DEFAULT_ACCENT_COLOR } from "~/lib/accent-colors";
-import { TERMINAL_FONT_SIZE } from "~/lib/terminal-options";
+import { TERMINAL_FONT_FAMILY } from "~/lib/terminal-options";
+import { terminalFontStack } from "~/lib/terminal-appearance";
+import {
+  BUNDLED_TERMINAL_FONTS,
+  SYSTEM_MONO_FONT_CANDIDATES,
+  useDetectedFonts,
+} from "~/lib/font-detection";
 import {
   DEFAULT_TERMINAL_ZOOM_LEVEL,
   TERMINAL_ZOOM_LABELS,
@@ -13,20 +19,147 @@ import {
   terminalFontSizeForLevel,
   type TerminalZoomLevel,
 } from "~/shared/terminal-zoom";
+import {
+  DEFAULT_INTERFACE_FONT_SCALE,
+  DEFAULT_TERMINAL_FONT_WEIGHT,
+  DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+  DEFAULT_TERMINAL_LETTER_SPACING,
+  DEFAULT_TERMINAL_LINE_HEIGHT,
+  TERMINAL_FONT_WEIGHTS,
+  TERMINAL_LETTER_SPACINGS,
+  TERMINAL_LINE_HEIGHTS,
+} from "~/shared/terminal-appearance";
 import { emptyVoiceCommandAliases } from "~/shared/voice-command-aliases";
 import { DEFAULT_SESSION_HEADER_BUTTON_VISIBILITY } from "~/shared/session-header-buttons";
 import { DEFAULT_SURFACE_TINT } from "~/shared/surface-tint";
 import { DEFAULT_SHIP_PROMPT } from "~/shared/ship-defaults";
+
+type AppearancePatch = Partial<
+  Pick<
+    AppSettings,
+    | "terminalZoomLevel"
+    | "terminalFontFamily"
+    | "terminalFontWeight"
+    | "terminalFontWeightBold"
+    | "terminalLineHeight"
+    | "terminalLetterSpacing"
+  >
+>;
+
+function TerminalPreview({
+  fontFamily,
+  fontSize,
+  fontWeight,
+  fontWeightBold,
+  lineHeight,
+  letterSpacing,
+}: {
+  fontFamily: string;
+  fontSize: number;
+  fontWeight: number;
+  fontWeightBold: number;
+  lineHeight: number;
+  letterSpacing: number;
+}) {
+  const bold = { fontWeight: fontWeightBold };
+  const dim = { color: "var(--text-dim)" };
+  const prompt = <span style={{ color: "var(--accent)" }}>$</span>;
+  return (
+    <div
+      aria-hidden
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: 7,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          padding: "6px 12px",
+          borderBottom: "1px solid var(--border)",
+          fontFamily: "var(--mono)",
+          fontSize: 10.5,
+          color: "var(--text-dim)",
+          textAlign: "center",
+        }}
+      >
+        Terminal preview
+      </div>
+      <pre
+        style={{
+          margin: 0,
+          padding: "12px 14px",
+          background: "var(--terminal-bg, #050607)",
+          color: "var(--text)",
+          fontFamily,
+          fontSize,
+          fontWeight,
+          lineHeight,
+          letterSpacing,
+          overflowX: "auto",
+        }}
+      >
+        {prompt} <span style={bold}>font-check</span> --sample{"\n"}
+        AaBbCc 1234567890 il1I O0 [] {"{}"} () {"<>"} !@#$%^&*{"\n"}
+        agjpqy AGJPQY _-+=|/:;,.?~{"\n"}
+        {"\n"}
+        {prompt} <span style={bold}>cargo test</span>
+        {"\n"}
+        test result: <span style={{ color: "var(--ok, #099250)", ...bold }}>ok</span>. 847
+        passed; 0 failed; finished in 0.8s{"\n"}
+        <span style={dim}>12:34:56</span>{" "}
+        <span style={{ color: "#2e90fa", ...bold }}>INFO</span>{" "}
+        <span style={dim}>worker</span> started build pipeline{"\n"}
+        <span style={dim}>12:34:57</span>{" "}
+        <span style={{ color: "#c07213", ...bold }}>WARN</span>{" "}
+        <span style={dim}>worker</span> retrying in 250ms{"\n"}
+        <span style={dim}>12:34:58</span>{" "}
+        <span style={{ color: "#2e90fa", ...bold }}>INFO</span>{" "}
+        <span style={dim}>worker</span> build complete{"\n"}
+        {prompt} <span style={bold}>git push</span>
+        {"\n"}
+        Everything up-to-date{"\n"}
+        {prompt}{" "}
+        <span
+          style={{
+            display: "inline-block",
+            width: "0.6em",
+            height: "1em",
+            verticalAlign: "text-bottom",
+            background: "var(--accent)",
+          }}
+        />
+      </pre>
+    </div>
+  );
+}
 
 export function TerminalSettingsPage() {
   const queryClient = useQueryClient();
   const { data: settings } = useSettings();
   const level = settings?.terminalZoomLevel ?? DEFAULT_TERMINAL_ZOOM_LEVEL;
   const fontSize = terminalFontSizeForLevel(level);
+  const fontFamily = settings?.terminalFontFamily ?? null;
+  const fontWeight = settings?.terminalFontWeight ?? DEFAULT_TERMINAL_FONT_WEIGHT;
+  const fontWeightBold =
+    settings?.terminalFontWeightBold ?? DEFAULT_TERMINAL_FONT_WEIGHT_BOLD;
+  const lineHeight = settings?.terminalLineHeight ?? DEFAULT_TERMINAL_LINE_HEIGHT;
+  const letterSpacing =
+    settings?.terminalLetterSpacing ?? DEFAULT_TERMINAL_LETTER_SPACING;
 
-  const optimisticSettings = (
-    patch: Partial<Pick<AppSettings, "terminalZoomLevel">>,
-  ): AppSettings => ({
+  const detectedFonts = useDetectedFonts(SYSTEM_MONO_FONT_CANDIDATES);
+  const systemFonts = detectedFonts.filter(
+    (family) => !(BUNDLED_TERMINAL_FONTS as readonly string[]).includes(family),
+  );
+  // A stored family that's no longer installed still needs to appear selected.
+  const strayFamily =
+    fontFamily &&
+    !(BUNDLED_TERMINAL_FONTS as readonly string[]).includes(fontFamily) &&
+    !systemFonts.includes(fontFamily)
+      ? fontFamily
+      : null;
+
+  const optimisticSettings = (patch: AppearancePatch): AppSettings => ({
     agentSystemBannerDisabled: settings?.agentSystemBannerDisabled ?? false,
     accentColor: settings?.accentColor ?? DEFAULT_ACCENT_COLOR,
     themeStyle: settings?.themeStyle ?? "painted",
@@ -49,6 +182,13 @@ export function TerminalSettingsPage() {
     selectedWorktreeByProject: settings?.selectedWorktreeByProject ?? null,
     commitCli: settings?.commitCli ?? null,
     terminalZoomLevel: level,
+    terminalFontFamily: fontFamily,
+    terminalFontWeight: fontWeight,
+    terminalFontWeightBold: fontWeightBold,
+    terminalLineHeight: lineHeight,
+    terminalLetterSpacing: letterSpacing,
+    interfaceFontFamily: settings?.interfaceFontFamily ?? null,
+    interfaceFontScale: settings?.interfaceFontScale ?? DEFAULT_INTERFACE_FONT_SCALE,
     sessionHeaderButtons:
       settings?.sessionHeaderButtons ?? DEFAULT_SESSION_HEADER_BUTTON_VISIBILITY,
     defaultAgent: settings?.defaultAgent ?? "claude-code",
@@ -80,12 +220,12 @@ export function TerminalSettingsPage() {
     ...patch,
   });
 
-  const setLevel = async (next: TerminalZoomLevel) => {
+  const save = async (patch: AppearancePatch) => {
     const previous = queryClient.getQueryData<AppSettings>(queryKeys.settings);
-    const optimistic = optimisticSettings({ terminalZoomLevel: next });
+    const optimistic = optimisticSettings(patch);
     queryClient.setQueryData(queryKeys.settings, optimistic);
     try {
-      const updated = await api.updateSettings({ terminalZoomLevel: next });
+      const updated = await api.updateSettings(patch);
       queryClient.setQueryData(queryKeys.settings, { ...optimistic, ...updated });
     } catch (error) {
       if (previous) queryClient.setQueryData(queryKeys.settings, previous);
@@ -93,12 +233,82 @@ export function TerminalSettingsPage() {
     }
   };
 
+  const previewFontFamily = fontFamily
+    ? terminalFontStack(fontFamily)
+    : `var(--mc-terminal-font, ${TERMINAL_FONT_FAMILY})`;
+
   return (
     <SettingsSection
       title="Terminal"
-      subtitle="Default text size for new terminals and sessions without a per-pane override."
+      subtitle="Typography for every terminal pane. Changes apply live to open sessions."
       headingLevel="h1"
     >
+      <Field label="Font family">
+        <div style={{ display: "flex", flexDirection: "column", gap: 6, maxWidth: 420 }}>
+          <select
+            value={fontFamily ?? ""}
+            aria-label="Terminal font family"
+            onChange={(event) => {
+              const value = event.target.value;
+              void save({ terminalFontFamily: value === "" ? null : value });
+            }}
+            style={{
+              width: "100%",
+              padding: "9px 10px",
+              borderRadius: 7,
+              border: "1px solid var(--border)",
+              background: "var(--surface-0)",
+              color: "var(--text)",
+              fontFamily: "var(--mono)",
+              fontSize: 12,
+            }}
+          >
+            <option value="">Theme default</option>
+            <optgroup label="Bundled">
+              {BUNDLED_TERMINAL_FONTS.map((family) => (
+                <option key={family} value={family}>
+                  {family}
+                </option>
+              ))}
+            </optgroup>
+            {(systemFonts.length > 0 || strayFamily) && (
+              <optgroup label="Installed on this Mac">
+                {strayFamily && (
+                  <option value={strayFamily}>{strayFamily} (not found)</option>
+                )}
+                {systemFonts.map((family) => (
+                  <option key={family} value={family}>
+                    {family}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+          </select>
+          <div style={{ fontSize: 11.5, color: "var(--text-dim)", lineHeight: 1.5 }}>
+            Bundled faces plus monospace fonts detected on your system. Theme default
+            follows the active theme’s bundled face.
+          </div>
+        </div>
+      </Field>
+
+      <Field label="Font weight">
+        <ValueRow
+          values={TERMINAL_FONT_WEIGHTS}
+          value={fontWeight}
+          onSelect={(next) => void save({ terminalFontWeight: next })}
+          ariaLabel="Weight for regular terminal text"
+        />
+      </Field>
+
+      <Field label="Bold font weight">
+        <ValueRow
+          values={TERMINAL_FONT_WEIGHTS}
+          value={fontWeightBold}
+          onSelect={(next) => void save({ terminalFontWeightBold: next })}
+          ariaLabel="Weight for bold terminal text"
+        />
+      </Field>
+
       <Field label="Default zoom">
         <div style={{ display: "flex", flexDirection: "column", gap: 10, maxWidth: 420 }}>
           <div
@@ -134,7 +344,7 @@ export function TerminalSettingsPage() {
             onChange={(event) => {
               const index = Number(event.currentTarget.value);
               const next = TERMINAL_ZOOM_LEVELS[index];
-              if (next !== undefined) void setLevel(next);
+              if (next !== undefined) void save({ terminalZoomLevel: next as TerminalZoomLevel });
             }}
             aria-label="Default terminal zoom level"
             aria-valuemin={TERMINAL_ZOOM_MIN}
@@ -159,24 +369,42 @@ export function TerminalSettingsPage() {
               <span key={step}>{step > 0 ? `+${step}` : step}</span>
             ))}
           </div>
-          <div
-            style={{
-              marginTop: 4,
-              padding: "10px 12px",
-              borderRadius: 7,
-              border: "1px solid var(--border)",
-              background: "var(--terminal-bg)",
-              fontFamily: "var(--mono)",
-              fontSize,
-              color: "var(--text)",
-              lineHeight: 1.4,
-            }}
-            aria-hidden
-          >
-            $ mission-control — preview at {fontSize}px (base {TERMINAL_FONT_SIZE}px)
+        </div>
+      </Field>
+
+      <Field label="Line height">
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <ValueRow
+            values={TERMINAL_LINE_HEIGHTS}
+            value={lineHeight}
+            onSelect={(next) => void save({ terminalLineHeight: next })}
+            format={(v) => v.toFixed(1)}
+            ariaLabel="Spacing between terminal lines"
+          />
+          <div style={{ fontSize: 11.5, color: "var(--text-dim)", lineHeight: 1.5 }}>
+            1.0 keeps box drawing and ANSI art flush; higher values add breathing room.
           </div>
         </div>
       </Field>
+
+      <Field label="Letter spacing">
+        <ValueRow
+          values={TERMINAL_LETTER_SPACINGS}
+          value={letterSpacing}
+          onSelect={(next) => void save({ terminalLetterSpacing: next })}
+          format={(v) => (Number.isInteger(v) ? String(v) : v.toFixed(1))}
+          ariaLabel="Extra pixels between terminal characters"
+        />
+      </Field>
+
+      <TerminalPreview
+        fontFamily={previewFontFamily}
+        fontSize={fontSize}
+        fontWeight={fontWeight}
+        fontWeightBold={fontWeightBold}
+        lineHeight={lineHeight}
+        letterSpacing={letterSpacing}
+      />
     </SettingsSection>
   );
 }

--- a/src/components/views/TerminalSettingsPage.tsx
+++ b/src/components/views/TerminalSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { Field, SettingsSection, ValueRow } from "~/components/views/SettingsParts";
+import { SettingCard, SettingsSection, ValueRow } from "~/components/views/SettingsParts";
 import { api, type AppSettings } from "~/lib/api";
 import { queryKeys, useSettings } from "~/queries";
 import { DEFAULT_ACCENT_COLOR } from "~/lib/accent-colors";
@@ -83,7 +83,7 @@ function TerminalPreview({
           textAlign: "center",
         }}
       >
-        Terminal preview
+        Live preview
       </div>
       <pre
         style={{
@@ -243,168 +243,177 @@ export function TerminalSettingsPage() {
       subtitle="Typography for every terminal pane. Changes apply live to open sessions."
       headingLevel="h1"
     >
-      <Field label="Font family">
-        <div style={{ display: "flex", flexDirection: "column", gap: 6, maxWidth: 420 }}>
-          <select
-            value={fontFamily ?? ""}
-            aria-label="Terminal font family"
-            onChange={(event) => {
-              const value = event.target.value;
-              void save({ terminalFontFamily: value === "" ? null : value });
-            }}
-            style={{
-              width: "100%",
-              padding: "9px 10px",
-              borderRadius: 7,
-              border: "1px solid var(--border)",
-              background: "var(--surface-0)",
-              color: "var(--text)",
-              fontFamily: "var(--mono)",
-              fontSize: 12,
-            }}
-          >
-            <option value="">Theme default</option>
-            <optgroup label="Bundled">
-              {BUNDLED_TERMINAL_FONTS.map((family) => (
-                <option key={family} value={family}>
-                  {family}
-                </option>
-              ))}
-            </optgroup>
-            {(systemFonts.length > 0 || strayFamily) && (
-              <optgroup label="Installed on this Mac">
-                {strayFamily && (
-                  <option value={strayFamily}>{strayFamily} (not found)</option>
+      <div className="term-settings-shell">
+        <div className="term-settings">
+          <div className="term-settings__controls">
+            <SettingCard
+              title="Font family"
+              description="Bundled faces plus monospace fonts detected on your system. Theme default follows the active theme’s bundled face."
+            >
+              <select
+                value={fontFamily ?? ""}
+                aria-label="Terminal font family"
+                className="term-select"
+                onChange={(event) => {
+                  const value = event.target.value;
+                  void save({ terminalFontFamily: value === "" ? null : value });
+                }}
+                style={{
+                  width: "100%",
+                  padding: "9px 10px",
+                  borderRadius: 7,
+                  border: "1px solid var(--border)",
+                  background: "var(--surface-1)",
+                  color: "var(--text)",
+                  fontFamily: "var(--mono)",
+                  fontSize: 12,
+                }}
+              >
+                <option value="">Theme default</option>
+                <optgroup label="Bundled">
+                  {BUNDLED_TERMINAL_FONTS.map((family) => (
+                    <option key={family} value={family}>
+                      {family}
+                    </option>
+                  ))}
+                </optgroup>
+                {(systemFonts.length > 0 || strayFamily) && (
+                  <optgroup label="Installed on this Mac">
+                    {strayFamily && (
+                      <option value={strayFamily}>{strayFamily} (not found)</option>
+                    )}
+                    {systemFonts.map((family) => (
+                      <option key={family} value={family}>
+                        {family}
+                      </option>
+                    ))}
+                  </optgroup>
                 )}
-                {systemFonts.map((family) => (
-                  <option key={family} value={family}>
-                    {family}
-                  </option>
-                ))}
-              </optgroup>
-            )}
-          </select>
-          <div style={{ fontSize: 11.5, color: "var(--text-dim)", lineHeight: 1.5 }}>
-            Bundled faces plus monospace fonts detected on your system. Theme default
-            follows the active theme’s bundled face.
+              </select>
+            </SettingCard>
+
+            <SettingCard
+              title="Font weight"
+              description="Weight for regular text, and for bold runs like prompts and highlights."
+            >
+              <div className="term-weight">
+                <div className="term-weight__row">
+                  <span className="term-weight__key">Regular</span>
+                  <ValueRow
+                    values={TERMINAL_FONT_WEIGHTS}
+                    value={fontWeight}
+                    onSelect={(next) => void save({ terminalFontWeight: next })}
+                    ariaLabel="Weight for regular terminal text"
+                  />
+                </div>
+                <div className="term-weight__row">
+                  <span className="term-weight__key">Bold</span>
+                  <ValueRow
+                    values={TERMINAL_FONT_WEIGHTS}
+                    value={fontWeightBold}
+                    onSelect={(next) => void save({ terminalFontWeightBold: next })}
+                    ariaLabel="Weight for bold terminal text"
+                  />
+                </div>
+              </div>
+            </SettingCard>
+
+            <SettingCard
+              title="Default zoom"
+              description="Starting size for every terminal, until you zoom a pane from its header. Per-pane zoom is remembered separately."
+            >
+              <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 12,
+                    fontFamily: "var(--mono)",
+                    fontSize: 11.5,
+                    color: "var(--text)",
+                  }}
+                >
+                  <span>{TERMINAL_ZOOM_LABELS[level]}</span>
+                  <span style={{ color: "var(--text-dim)" }}>{fontSize}px</span>
+                </div>
+                <input
+                  type="range"
+                  min={0}
+                  max={TERMINAL_ZOOM_LEVELS.length - 1}
+                  step={1}
+                  value={TERMINAL_ZOOM_LEVELS.indexOf(level)}
+                  onChange={(event) => {
+                    const index = Number(event.currentTarget.value);
+                    const next = TERMINAL_ZOOM_LEVELS[index];
+                    if (next !== undefined)
+                      void save({ terminalZoomLevel: next as TerminalZoomLevel });
+                  }}
+                  aria-label="Default terminal zoom level"
+                  aria-valuemin={TERMINAL_ZOOM_MIN}
+                  aria-valuemax={TERMINAL_ZOOM_MAX}
+                  aria-valuenow={level}
+                  aria-valuetext={TERMINAL_ZOOM_LABELS[level]}
+                  style={{
+                    width: "100%",
+                    accentColor: "var(--accent)",
+                  }}
+                />
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    fontFamily: "var(--mono)",
+                    fontSize: 10.5,
+                    color: "var(--text-faint)",
+                  }}
+                >
+                  {TERMINAL_ZOOM_LEVELS.map((step) => (
+                    <span key={step}>{step > 0 ? `+${step}` : step}</span>
+                  ))}
+                </div>
+              </div>
+            </SettingCard>
+
+            <SettingCard
+              title="Line height"
+              description="1.0 keeps box drawing and ANSI art flush; higher adds breathing room."
+            >
+              <ValueRow
+                values={TERMINAL_LINE_HEIGHTS}
+                value={lineHeight}
+                onSelect={(next) => void save({ terminalLineHeight: next })}
+                format={(v) => v.toFixed(1)}
+                ariaLabel="Spacing between terminal lines"
+              />
+            </SettingCard>
+
+            <SettingCard
+              title="Letter spacing"
+              description="Extra horizontal space between characters, in pixels."
+            >
+              <ValueRow
+                values={TERMINAL_LETTER_SPACINGS}
+                value={letterSpacing}
+                onSelect={(next) => void save({ terminalLetterSpacing: next })}
+                format={(v) => (Number.isInteger(v) ? String(v) : v.toFixed(1))}
+                ariaLabel="Extra pixels between terminal characters"
+              />
+            </SettingCard>
           </div>
+
+          <aside className="term-settings__preview">
+            <TerminalPreview
+              fontFamily={previewFontFamily}
+              fontSize={fontSize}
+              fontWeight={fontWeight}
+              fontWeightBold={fontWeightBold}
+              lineHeight={lineHeight}
+              letterSpacing={letterSpacing}
+            />
+          </aside>
         </div>
-      </Field>
-
-      <Field label="Font weight">
-        <ValueRow
-          values={TERMINAL_FONT_WEIGHTS}
-          value={fontWeight}
-          onSelect={(next) => void save({ terminalFontWeight: next })}
-          ariaLabel="Weight for regular terminal text"
-        />
-      </Field>
-
-      <Field label="Bold font weight">
-        <ValueRow
-          values={TERMINAL_FONT_WEIGHTS}
-          value={fontWeightBold}
-          onSelect={(next) => void save({ terminalFontWeightBold: next })}
-          ariaLabel="Weight for bold terminal text"
-        />
-      </Field>
-
-      <Field label="Default zoom">
-        <div style={{ display: "flex", flexDirection: "column", gap: 10, maxWidth: 420 }}>
-          <div
-            style={{
-              fontSize: 12,
-              color: "var(--text-dim)",
-              lineHeight: 1.55,
-            }}
-          >
-            Applies to every terminal until you zoom that pane in or out from its header.
-            Per-pane zoom is remembered separately.
-          </div>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 12,
-              fontFamily: "var(--mono)",
-              fontSize: 11.5,
-              color: "var(--text)",
-            }}
-          >
-            <span>{TERMINAL_ZOOM_LABELS[level]}</span>
-            <span style={{ color: "var(--text-dim)" }}>{fontSize}px</span>
-          </div>
-          <input
-            type="range"
-            min={0}
-            max={TERMINAL_ZOOM_LEVELS.length - 1}
-            step={1}
-            value={TERMINAL_ZOOM_LEVELS.indexOf(level)}
-            onChange={(event) => {
-              const index = Number(event.currentTarget.value);
-              const next = TERMINAL_ZOOM_LEVELS[index];
-              if (next !== undefined) void save({ terminalZoomLevel: next as TerminalZoomLevel });
-            }}
-            aria-label="Default terminal zoom level"
-            aria-valuemin={TERMINAL_ZOOM_MIN}
-            aria-valuemax={TERMINAL_ZOOM_MAX}
-            aria-valuenow={level}
-            aria-valuetext={TERMINAL_ZOOM_LABELS[level]}
-            style={{
-              width: "100%",
-              accentColor: "var(--accent)",
-            }}
-          />
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              fontFamily: "var(--mono)",
-              fontSize: 10.5,
-              color: "var(--text-faint)",
-            }}
-          >
-            {TERMINAL_ZOOM_LEVELS.map((step) => (
-              <span key={step}>{step > 0 ? `+${step}` : step}</span>
-            ))}
-          </div>
-        </div>
-      </Field>
-
-      <Field label="Line height">
-        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          <ValueRow
-            values={TERMINAL_LINE_HEIGHTS}
-            value={lineHeight}
-            onSelect={(next) => void save({ terminalLineHeight: next })}
-            format={(v) => v.toFixed(1)}
-            ariaLabel="Spacing between terminal lines"
-          />
-          <div style={{ fontSize: 11.5, color: "var(--text-dim)", lineHeight: 1.5 }}>
-            1.0 keeps box drawing and ANSI art flush; higher values add breathing room.
-          </div>
-        </div>
-      </Field>
-
-      <Field label="Letter spacing">
-        <ValueRow
-          values={TERMINAL_LETTER_SPACINGS}
-          value={letterSpacing}
-          onSelect={(next) => void save({ terminalLetterSpacing: next })}
-          format={(v) => (Number.isInteger(v) ? String(v) : v.toFixed(1))}
-          ariaLabel="Extra pixels between terminal characters"
-        />
-      </Field>
-
-      <TerminalPreview
-        fontFamily={previewFontFamily}
-        fontSize={fontSize}
-        fontWeight={fontWeight}
-        fontWeightBold={fontWeightBold}
-        lineHeight={lineHeight}
-        letterSpacing={letterSpacing}
-      />
+      </div>
     </SettingsSection>
   );
 }

--- a/src/components/views/ThemeSettingsPage.tsx
+++ b/src/components/views/ThemeSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useId, type CSSProperties } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Field, SettingsSection } from "~/components/views/SettingsParts";
+import { Field, SettingCard, SettingsSection } from "~/components/views/SettingsParts";
 import { AccentColorGrid } from "~/components/views/AccentColorPicker";
 import { ThemeStylePreview } from "~/components/views/ThemeStylePreview";
 import { Icon } from "~/components/ui/Icon";
@@ -271,53 +271,51 @@ export function ThemeSettingsPage() {
       <Field label="Surface tint">
         <SurfaceTintToggle tint={surfaceTint} onChange={setSurfaceTint} />
       </Field>
-      <Field label="Interface font family">
-        <div style={{ display: "flex", flexDirection: "column", gap: 6, maxWidth: 420 }}>
-          <select
-            value={interfaceFontFamily ?? ""}
-            aria-label="Interface font family"
-            onChange={(event) => {
-              const value = event.target.value;
-              void setInterfaceFontFamily(value === "" ? null : value);
-            }}
-            style={{
-              width: "100%",
-              padding: "9px 10px",
-              borderRadius: 7,
-              border: "1px solid var(--border)",
-              background: "var(--surface-0)",
-              color: "var(--text)",
-              fontFamily: "var(--mono)",
-              fontSize: 12,
-            }}
-          >
-            <option value="">Theme default</option>
-            {strayInterfaceFamily && (
-              <option value={strayInterfaceFamily}>
-                {strayInterfaceFamily} (not found)
-              </option>
-            )}
-            {detectedInterfaceFonts.map((family) => (
-              <option key={family} value={family}>
-                {family}
-              </option>
-            ))}
-          </select>
-          <div style={{ fontSize: 11.5, color: "var(--text-dim)", lineHeight: 1.5 }}>
-            Used for the application UI. Pulls from fonts installed on your system;
-            terminal text is configured on the Terminal tab.
-          </div>
-        </div>
-      </Field>
-      <Field label="Interface font scale">
-        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          <InterfaceScaleRow scale={interfaceFontScale} onChange={setInterfaceFontScale} />
-          <div style={{ fontSize: 11.5, color: "var(--text-dim)", lineHeight: 1.5 }}>
-            Adjusts the size of all UI elements. Currently{" "}
-            {Math.round(interfaceFontScale * 100)}%.
-          </div>
-        </div>
-      </Field>
+      <SettingCard
+        title="Interface font family"
+        description="Used for the application UI. Pulls from fonts installed on your system; terminal text is configured on the Terminal tab."
+      >
+        <select
+          value={interfaceFontFamily ?? ""}
+          aria-label="Interface font family"
+          className="term-select"
+          onChange={(event) => {
+            const value = event.target.value;
+            void setInterfaceFontFamily(value === "" ? null : value);
+          }}
+          style={{
+            width: "100%",
+            maxWidth: 440,
+            padding: "9px 10px",
+            borderRadius: 7,
+            border: "1px solid var(--border)",
+            background: "var(--surface-1)",
+            color: "var(--text)",
+            fontFamily: "var(--mono)",
+            fontSize: 12,
+          }}
+        >
+          <option value="">Theme default</option>
+          {strayInterfaceFamily && (
+            <option value={strayInterfaceFamily}>
+              {strayInterfaceFamily} (not found)
+            </option>
+          )}
+          {detectedInterfaceFonts.map((family) => (
+            <option key={family} value={family}>
+              {family}
+            </option>
+          ))}
+        </select>
+      </SettingCard>
+      <SettingCard
+        title="Interface font scale"
+        description={`Adjusts the size of all UI elements. Currently ${Math.round(
+          interfaceFontScale * 100,
+        )}%.`}
+      >
+        <InterfaceScaleRow scale={interfaceFontScale} onChange={setInterfaceFontScale} />
+      </SettingCard>
     </SettingsSection>
   );
 }

--- a/src/components/views/ThemeSettingsPage.tsx
+++ b/src/components/views/ThemeSettingsPage.tsx
@@ -24,6 +24,23 @@ import {
   readCachedLaunchIntroEnabled,
 } from "~/lib/launch-intro";
 import { DEFAULT_TERMINAL_ZOOM_LEVEL } from "~/shared/terminal-zoom";
+import {
+  DEFAULT_INTERFACE_FONT_SCALE,
+  DEFAULT_TERMINAL_FONT_WEIGHT,
+  DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+  DEFAULT_TERMINAL_LETTER_SPACING,
+  DEFAULT_TERMINAL_LINE_HEIGHT,
+  INTERFACE_FONT_SCALES,
+  type InterfaceFontScale,
+} from "~/shared/terminal-appearance";
+import {
+  applyInterfaceFontFamily,
+  applyInterfaceFontScale,
+} from "~/lib/interface-appearance";
+import {
+  INTERFACE_FONT_CANDIDATES,
+  useDetectedFonts,
+} from "~/lib/font-detection";
 import { emptyVoiceCommandAliases } from "~/shared/voice-command-aliases";
 import { DEFAULT_SESSION_HEADER_BUTTON_VISIBILITY } from "~/shared/session-header-buttons";
 import { DEFAULT_SHIP_PROMPT } from "~/shared/ship-defaults";
@@ -36,6 +53,15 @@ export function ThemeSettingsPage() {
   const themeStyle = settings?.themeStyle ?? DEFAULT_THEME_STYLE;
   const surfaceTint = settings?.surfaceTint ?? DEFAULT_SURFACE_TINT;
   const minimalTheme = settings?.minimalTheme ?? false;
+  const interfaceFontFamily = settings?.interfaceFontFamily ?? null;
+  const interfaceFontScale =
+    settings?.interfaceFontScale ?? DEFAULT_INTERFACE_FONT_SCALE;
+  const detectedInterfaceFonts = useDetectedFonts(INTERFACE_FONT_CANDIDATES);
+  // A stored family that's no longer installed still needs to appear selected.
+  const strayInterfaceFamily =
+    interfaceFontFamily && !detectedInterfaceFonts.includes(interfaceFontFamily)
+      ? interfaceFontFamily
+      : null;
   const launchOverlayEnabled = typeof settings?.launchOverlayEnabled === "boolean"
     ? settings.launchOverlayEnabled
     : hasCachedLaunchIntroPreference()
@@ -44,7 +70,15 @@ export function ThemeSettingsPage() {
 
   const optimisticSettings = (
     patch: Partial<
-      Pick<AppSettings, "accentColor" | "themeStyle" | "surfaceTint" | "minimalTheme">
+      Pick<
+        AppSettings,
+        | "accentColor"
+        | "themeStyle"
+        | "surfaceTint"
+        | "minimalTheme"
+        | "interfaceFontFamily"
+        | "interfaceFontScale"
+      >
     >,
   ): AppSettings => ({
     agentSystemBannerDisabled: settings?.agentSystemBannerDisabled ?? false,
@@ -70,6 +104,15 @@ export function ThemeSettingsPage() {
     selectedWorktreeByProject: settings?.selectedWorktreeByProject ?? null,
     commitCli: settings?.commitCli ?? null,
     terminalZoomLevel: settings?.terminalZoomLevel ?? DEFAULT_TERMINAL_ZOOM_LEVEL,
+    terminalFontFamily: settings?.terminalFontFamily ?? null,
+    terminalFontWeight: settings?.terminalFontWeight ?? DEFAULT_TERMINAL_FONT_WEIGHT,
+    terminalFontWeightBold:
+      settings?.terminalFontWeightBold ?? DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+    terminalLineHeight: settings?.terminalLineHeight ?? DEFAULT_TERMINAL_LINE_HEIGHT,
+    terminalLetterSpacing:
+      settings?.terminalLetterSpacing ?? DEFAULT_TERMINAL_LETTER_SPACING,
+    interfaceFontFamily: settings?.interfaceFontFamily ?? null,
+    interfaceFontScale: settings?.interfaceFontScale ?? DEFAULT_INTERFACE_FONT_SCALE,
     sessionHeaderButtons:
       settings?.sessionHeaderButtons ?? DEFAULT_SESSION_HEADER_BUTTON_VISIBILITY,
     defaultAgent: settings?.defaultAgent ?? "claude-code",
@@ -162,6 +205,42 @@ export function ThemeSettingsPage() {
     }
   };
 
+  const setInterfaceFontFamily = async (next: string | null) => {
+    applyInterfaceFontFamily(next);
+    const previous = queryClient.getQueryData<AppSettings>(queryKeys.settings);
+    const optimistic = optimisticSettings({ interfaceFontFamily: next });
+    queryClient.setQueryData(queryKeys.settings, optimistic);
+    try {
+      const updated = await api.updateSettings({ interfaceFontFamily: next });
+      queryClient.setQueryData(queryKeys.settings, { ...optimistic, ...updated });
+    } catch (error) {
+      if (previous) {
+        queryClient.setQueryData(queryKeys.settings, previous);
+        applyInterfaceFontFamily(previous.interfaceFontFamily ?? null);
+      }
+      throw error;
+    }
+  };
+
+  const setInterfaceFontScale = async (next: InterfaceFontScale) => {
+    applyInterfaceFontScale(next);
+    const previous = queryClient.getQueryData<AppSettings>(queryKeys.settings);
+    const optimistic = optimisticSettings({ interfaceFontScale: next });
+    queryClient.setQueryData(queryKeys.settings, optimistic);
+    try {
+      const updated = await api.updateSettings({ interfaceFontScale: next });
+      queryClient.setQueryData(queryKeys.settings, { ...optimistic, ...updated });
+    } catch (error) {
+      if (previous) {
+        queryClient.setQueryData(queryKeys.settings, previous);
+        applyInterfaceFontScale(
+          previous.interfaceFontScale ?? DEFAULT_INTERFACE_FONT_SCALE,
+        );
+      }
+      throw error;
+    }
+  };
+
   return (
     <SettingsSection
       title="Theme"
@@ -192,7 +271,102 @@ export function ThemeSettingsPage() {
       <Field label="Surface tint">
         <SurfaceTintToggle tint={surfaceTint} onChange={setSurfaceTint} />
       </Field>
+      <Field label="Interface font family">
+        <div style={{ display: "flex", flexDirection: "column", gap: 6, maxWidth: 420 }}>
+          <select
+            value={interfaceFontFamily ?? ""}
+            aria-label="Interface font family"
+            onChange={(event) => {
+              const value = event.target.value;
+              void setInterfaceFontFamily(value === "" ? null : value);
+            }}
+            style={{
+              width: "100%",
+              padding: "9px 10px",
+              borderRadius: 7,
+              border: "1px solid var(--border)",
+              background: "var(--surface-0)",
+              color: "var(--text)",
+              fontFamily: "var(--mono)",
+              fontSize: 12,
+            }}
+          >
+            <option value="">Theme default</option>
+            {strayInterfaceFamily && (
+              <option value={strayInterfaceFamily}>
+                {strayInterfaceFamily} (not found)
+              </option>
+            )}
+            {detectedInterfaceFonts.map((family) => (
+              <option key={family} value={family}>
+                {family}
+              </option>
+            ))}
+          </select>
+          <div style={{ fontSize: 11.5, color: "var(--text-dim)", lineHeight: 1.5 }}>
+            Used for the application UI. Pulls from fonts installed on your system;
+            terminal text is configured on the Terminal tab.
+          </div>
+        </div>
+      </Field>
+      <Field label="Interface font scale">
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <InterfaceScaleRow scale={interfaceFontScale} onChange={setInterfaceFontScale} />
+          <div style={{ fontSize: 11.5, color: "var(--text-dim)", lineHeight: 1.5 }}>
+            Adjusts the size of all UI elements. Currently{" "}
+            {Math.round(interfaceFontScale * 100)}%.
+          </div>
+        </div>
+      </Field>
     </SettingsSection>
+  );
+}
+
+function InterfaceScaleRow({
+  scale,
+  onChange,
+}: {
+  scale: InterfaceFontScale;
+  onChange: (next: InterfaceFontScale) => void;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Interface font scale"
+      style={{ display: "flex", alignItems: "baseline", gap: 2, flexWrap: "wrap" }}
+    >
+      {INTERFACE_FONT_SCALES.map((candidate, index) => {
+        const selected = candidate === scale;
+        return (
+          <button
+            key={candidate}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-label={`${Math.round(candidate * 100)}%`}
+            title={`${Math.round(candidate * 100)}%`}
+            onClick={() => onChange(candidate)}
+            style={{
+              background: "transparent",
+              border: "none",
+              borderBottom: selected
+                ? "2px solid var(--accent)"
+                : "2px solid transparent",
+              color: selected ? "var(--accent)" : "var(--text-dim)",
+              fontFamily: "var(--sans)",
+              // The glyph itself communicates the step, like a type-size ramp.
+              fontSize: 10 + index * 1.5,
+              fontWeight: selected ? 700 : 500,
+              padding: "3px 7px 2px",
+              cursor: "pointer",
+              lineHeight: 1,
+            }}
+          >
+            A
+          </button>
+        );
+      })}
+    </div>
   );
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -35,6 +35,12 @@ import type {
   SelectedWorktreeByProject,
 } from "~/shared/ui-preferences";
 import type { TerminalZoomLevel } from "~/shared/terminal-zoom";
+import type {
+  InterfaceFontScale,
+  TerminalFontWeight,
+  TerminalLetterSpacing,
+  TerminalLineHeight,
+} from "~/shared/terminal-appearance";
 import type { ThemeStyle } from "~/shared/theme-style";
 import type { SurfaceTint } from "~/shared/surface-tint";
 import type {
@@ -105,6 +111,20 @@ export type AppSettings = {
   commitCli: CommitCli | null;
   /** Default terminal text zoom (-2 … +2). Per-pane overrides live in localStorage. */
   terminalZoomLevel: TerminalZoomLevel;
+  /** Terminal font face; `null` = the active theme's bundled face. */
+  terminalFontFamily: string | null;
+  /** CSS weight for regular terminal text (100–900). */
+  terminalFontWeight: TerminalFontWeight;
+  /** CSS weight for bold terminal text (100–900). */
+  terminalFontWeightBold: TerminalFontWeight;
+  /** Terminal row height multiplier (1.0–1.8; 1.0 keeps ANSI art flush). */
+  terminalLineHeight: TerminalLineHeight;
+  /** Extra px between terminal characters (0–3). */
+  terminalLetterSpacing: TerminalLetterSpacing;
+  /** UI font face; `null` = the active theme's UI face. */
+  interfaceFontFamily: string | null;
+  /** Window zoom factor scaling all UI elements (1 = 100%). */
+  interfaceFontScale: InterfaceFontScale;
   /**
    * Which discretionary session-pane header buttons are shown. Zoom is hidden
    * by default (it's driven by keyboard shortcuts); the rest default on.
@@ -607,6 +627,13 @@ export const api = {
         | "selectedWorktreeByProject"
         | "commitCli"
         | "terminalZoomLevel"
+        | "terminalFontFamily"
+        | "terminalFontWeight"
+        | "terminalFontWeightBold"
+        | "terminalLineHeight"
+        | "terminalLetterSpacing"
+        | "interfaceFontFamily"
+        | "interfaceFontScale"
         | "sessionHeaderButtons"
         | "defaultAgent"
         | "defaultModel"

--- a/src/lib/font-detection.ts
+++ b/src/lib/font-detection.ts
@@ -1,0 +1,119 @@
+// Detects which of a curated list of font families are installed, by
+// measuring text width against the generic fallback families on a canvas —
+// a candidate that renders differently from every generic fallback is real.
+// (queryLocalFonts needs a permission prompt; this is silent and instant.)
+import { useEffect, useState } from "react";
+
+/** Faces shipped with the app via @fontsource — always available. */
+export const BUNDLED_TERMINAL_FONTS = ["Geist Mono", "JetBrains Mono"] as const;
+
+/** Common monospace faces worth probing for on a dev machine. */
+export const SYSTEM_MONO_FONT_CANDIDATES = [
+  "SF Mono",
+  "Menlo",
+  "Monaco",
+  "Consolas",
+  "Courier New",
+  "Andale Mono",
+  "PT Mono",
+  "Fira Code",
+  "Fira Mono",
+  "Hack",
+  "Source Code Pro",
+  "Cascadia Code",
+  "Cascadia Mono",
+  "IBM Plex Mono",
+  "Roboto Mono",
+  "Ubuntu Mono",
+  "Inconsolata",
+  "Victor Mono",
+  "Iosevka",
+  "Berkeley Mono",
+  "Commit Mono",
+  "Monaspace Neon",
+  "Space Mono",
+  "Anonymous Pro",
+  "DejaVu Sans Mono",
+  "Droid Sans Mono",
+  "Input Mono",
+  "Operator Mono",
+  "Red Hat Mono",
+  "MonoLisa",
+  "Comic Mono",
+] as const;
+
+/** Common UI faces worth probing for the interface font picker. */
+export const INTERFACE_FONT_CANDIDATES = [
+  "SF Pro",
+  "SF Pro Text",
+  "Helvetica Neue",
+  "Inter",
+  "Roboto",
+  "Segoe UI",
+  "Arial",
+  "Avenir Next",
+  "Futura",
+  "Gill Sans",
+  "Verdana",
+  "Lato",
+  "Open Sans",
+  "Source Sans Pro",
+  "IBM Plex Sans",
+  "Nunito",
+  "Work Sans",
+  "DM Sans",
+  "Manrope",
+  "Georgia",
+  "Iowan Old Style",
+  "Palatino",
+  "Optima",
+] as const;
+
+// Wide glyph mix: repeated wides for signal, plus narrow/odd glyphs so two
+// different faces are unlikely to produce identical widths by coincidence.
+const SAMPLE = "mmmmmmmmmmlli1I0O@#WwQq";
+const GENERIC_FALLBACKS = ["monospace", "serif", "sans-serif"] as const;
+
+/**
+ * Measure `SAMPLE` in `family, generic` against `generic` alone for each
+ * generic fallback. If any pair differs, the browser found a real face for
+ * `family` (identical metrics across ALL generics means it fell back).
+ */
+export function detectAvailableFonts(candidates: readonly string[]): string[] {
+  if (typeof document === "undefined") return [];
+  const ctx = document.createElement("canvas").getContext("2d");
+  if (!ctx) return [];
+  const baseline = new Map<string, number>();
+  for (const generic of GENERIC_FALLBACKS) {
+    ctx.font = `16px ${generic}`;
+    baseline.set(generic, ctx.measureText(SAMPLE).width);
+  }
+  return candidates.filter((family) => {
+    const quoted = `"${family.replace(/"/g, "")}"`;
+    return GENERIC_FALLBACKS.some((generic) => {
+      ctx.font = `16px ${quoted}, ${generic}`;
+      return ctx.measureText(SAMPLE).width !== baseline.get(generic);
+    });
+  });
+}
+
+/**
+ * Detected system fonts from `candidates`, refreshed once webfonts settle
+ * (document.fonts.ready) so late-loading faces don't skew the measurement.
+ */
+export function useDetectedFonts(candidates: readonly string[]): string[] {
+  const [fonts, setFonts] = useState<string[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    const run = () => {
+      if (!cancelled) setFonts(detectAvailableFonts(candidates));
+    };
+    run();
+    document.fonts?.ready?.then(run).catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+    // candidates lists are module constants; identity is stable per call site.
+  }, [candidates]);
+  return fonts;
+}

--- a/src/lib/interface-appearance.ts
+++ b/src/lib/interface-appearance.ts
@@ -1,0 +1,35 @@
+// Applies the interface (UI) appearance settings: font face and scale.
+// The face overrides the theme's --sans/--font-sans via inline vars on <html>
+// (inline wins over every theme stylesheet block; clearing hands control back
+// to the active theme). The scale rides the Electron window zoom factor so
+// every px-sized element grows together; the browser fallback uses CSS zoom.
+import { getElectron } from "~/lib/electron";
+import type { InterfaceFontScale } from "~/shared/terminal-appearance";
+
+const SANS_VARS = ["--sans", "--font-sans"] as const;
+
+/** Wrap a user-picked family in quotes and append the UI sans fallback stack. */
+export function interfaceFontStack(family: string): string {
+  return `"${family.replace(/"/g, "")}", ui-sans-serif, system-ui, sans-serif`;
+}
+
+export function applyInterfaceFontFamily(family: string | null): void {
+  if (typeof document === "undefined") return;
+  const style = document.documentElement.style;
+  for (const name of SANS_VARS) {
+    if (family) style.setProperty(name, interfaceFontStack(family));
+    else style.removeProperty(name);
+  }
+}
+
+export function applyInterfaceFontScale(scale: InterfaceFontScale): void {
+  if (typeof document === "undefined") return;
+  const electron = getElectron();
+  if (electron?.setZoomFactor) {
+    void electron.setZoomFactor(scale);
+    return;
+  }
+  // Browser dev fallback: CSS zoom scales layout the same way, minus the
+  // crisper native rasterization the Electron zoom factor gives.
+  document.documentElement.style.zoom = scale === 1 ? "" : String(scale);
+}

--- a/src/lib/terminal-appearance.ts
+++ b/src/lib/terminal-appearance.ts
@@ -1,0 +1,118 @@
+// Applies the terminal appearance settings (font face/weights/line height/
+// letter spacing) to the DOM as inline CSS vars on <html>. Terminals don't
+// read the settings query directly: createTerminalOptions resolves these vars
+// when a terminal is built, and watchTerminalColorScheme (which already
+// observes <html> style mutations) re-fires for live terminals, so an inline
+// var write here restyles every open pane. The font var override also feeds
+// the settings-page preview and any CSS that renders "terminal-looking" text.
+import {
+  DEFAULT_TERMINAL_FONT_WEIGHT,
+  DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+  DEFAULT_TERMINAL_LETTER_SPACING,
+  DEFAULT_TERMINAL_LINE_HEIGHT,
+  normalizeTerminalFontWeight,
+  normalizeTerminalLetterSpacing,
+  normalizeTerminalLineHeight,
+  type TerminalFontWeight,
+  type TerminalLetterSpacing,
+  type TerminalLineHeight,
+} from "~/shared/terminal-appearance";
+
+export const TERMINAL_FONT_VAR = "--mc-terminal-font";
+export const TERMINAL_FONT_WEIGHT_VAR = "--mc-terminal-font-weight";
+export const TERMINAL_FONT_WEIGHT_BOLD_VAR = "--mc-terminal-font-weight-bold";
+export const TERMINAL_LINE_HEIGHT_VAR = "--mc-terminal-line-height";
+export const TERMINAL_LETTER_SPACING_VAR = "--mc-terminal-letter-spacing";
+
+export type TerminalAppearance = {
+  /** `null` = the active theme's bundled face. */
+  fontFamily: string | null;
+  fontWeight: TerminalFontWeight;
+  fontWeightBold: TerminalFontWeight;
+  lineHeight: TerminalLineHeight;
+  letterSpacing: TerminalLetterSpacing;
+};
+
+/** Wrap a user-picked family in quotes and append the mono fallback stack. */
+export function terminalFontStack(family: string): string {
+  return `"${family.replace(/"/g, "")}", ui-monospace, "SF Mono", Menlo, monospace`;
+}
+
+/**
+ * Write the appearance to inline CSS vars on <html>. An inline
+ * `--mc-terminal-font` outranks every theme stylesheet block, so clearing it
+ * (family = null) hands control back to the active theme's bundled face.
+ */
+export function applyTerminalAppearance(appearance: TerminalAppearance): void {
+  if (typeof document === "undefined") return;
+  const style = document.documentElement?.style;
+  if (!style) return;
+  if (appearance.fontFamily) {
+    style.setProperty(TERMINAL_FONT_VAR, terminalFontStack(appearance.fontFamily));
+  } else {
+    style.removeProperty(TERMINAL_FONT_VAR);
+  }
+  const setOrClear = (name: string, value: number, fallback: number) => {
+    if (value === fallback) style.removeProperty(name);
+    else style.setProperty(name, String(value));
+  };
+  setOrClear(
+    TERMINAL_FONT_WEIGHT_VAR,
+    appearance.fontWeight,
+    DEFAULT_TERMINAL_FONT_WEIGHT,
+  );
+  setOrClear(
+    TERMINAL_FONT_WEIGHT_BOLD_VAR,
+    appearance.fontWeightBold,
+    DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+  );
+  setOrClear(
+    TERMINAL_LINE_HEIGHT_VAR,
+    appearance.lineHeight,
+    DEFAULT_TERMINAL_LINE_HEIGHT,
+  );
+  setOrClear(
+    TERMINAL_LETTER_SPACING_VAR,
+    appearance.letterSpacing,
+    DEFAULT_TERMINAL_LETTER_SPACING,
+  );
+}
+
+function readVar(name: string): string {
+  // Optional chaining throughout: tests stub a partial `document`.
+  if (typeof document === "undefined") return "";
+  return document.documentElement?.style?.getPropertyValue?.(name)?.trim() ?? "";
+}
+
+/** The currently applied weights/spacing, read back from the inline vars. */
+export function getCurrentTerminalAppearanceOptions(): {
+  fontWeight: TerminalFontWeight;
+  fontWeightBold: TerminalFontWeight;
+  lineHeight: TerminalLineHeight;
+  letterSpacing: TerminalLetterSpacing;
+} {
+  const weightRaw = readVar(TERMINAL_FONT_WEIGHT_VAR);
+  const boldRaw = readVar(TERMINAL_FONT_WEIGHT_BOLD_VAR);
+  const lineHeightRaw = readVar(TERMINAL_LINE_HEIGHT_VAR);
+  const letterSpacingRaw = readVar(TERMINAL_LETTER_SPACING_VAR);
+  return {
+    fontWeight: weightRaw
+      ? normalizeTerminalFontWeight(weightRaw, DEFAULT_TERMINAL_FONT_WEIGHT)
+      : DEFAULT_TERMINAL_FONT_WEIGHT,
+    fontWeightBold: boldRaw
+      ? normalizeTerminalFontWeight(boldRaw, DEFAULT_TERMINAL_FONT_WEIGHT_BOLD)
+      : DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+    lineHeight: lineHeightRaw
+      ? normalizeTerminalLineHeight(lineHeightRaw)
+      : DEFAULT_TERMINAL_LINE_HEIGHT,
+    letterSpacing: letterSpacingRaw
+      ? normalizeTerminalLetterSpacing(letterSpacingRaw)
+      : DEFAULT_TERMINAL_LETTER_SPACING,
+  };
+}
+
+/** Cache-key fragment so terminal watchers re-fire when appearance vars change. */
+export function terminalAppearanceKey(): string {
+  const current = getCurrentTerminalAppearanceOptions();
+  return `${current.fontWeight}:${current.fontWeightBold}:${current.lineHeight}:${current.letterSpacing}`;
+}

--- a/src/lib/terminal-options.ts
+++ b/src/lib/terminal-options.ts
@@ -1,4 +1,8 @@
 import type { ITerminalOptions } from "@xterm/xterm";
+import {
+  getCurrentTerminalAppearanceOptions,
+  terminalAppearanceKey,
+} from "~/lib/terminal-appearance";
 
 const DEFAULT_CURSOR_COLOR = "#ff5a1f";
 
@@ -236,8 +240,10 @@ export function watchTerminalColorScheme(
   };
   // Font is part of the key so switching to/from the flat theme (which ships a
   // bundled face) re-fires and the consumer can restyle + refit the terminal.
+  // Appearance (weights/line height/letter spacing) rides along the same way —
+  // the settings page writes inline vars on <html>, which this observer sees.
   const currentKey = () =>
-    `${getTerminalColorScheme()}:${getCurrentAccentColor()}:${getCurrentTerminalFont()}:${styleFlags()}`;
+    `${getTerminalColorScheme()}:${getCurrentAccentColor()}:${getCurrentTerminalFont()}:${styleFlags()}:${terminalAppearanceKey()}`;
   let previous = currentKey();
   const observer = new MutationObserver(() => {
     const next = currentKey();
@@ -261,12 +267,16 @@ export function createTerminalOptions({
   colorScheme?: TerminalColorScheme;
   fontSize?: number;
 } = {}): ITerminalOptions {
+  const appearance = getCurrentTerminalAppearanceOptions();
   return {
     fontFamily: getCurrentTerminalFont(),
     fontSize,
-    // Keep xterm's default line height so multi-row ANSI art (OpenCode's
-    // startup wordmark, box drawing, background fills) renders flush.
-    lineHeight: 1,
+    fontWeight: appearance.fontWeight,
+    fontWeightBold: appearance.fontWeightBold,
+    // 1.0 (the default) keeps multi-row ANSI art (OpenCode's startup wordmark,
+    // box drawing, background fills) flush; users can trade that for air.
+    lineHeight: appearance.lineHeight,
+    letterSpacing: appearance.letterSpacing,
     cursorBlink: true,
     theme: createTerminalTheme({ colorScheme, cursorColor }),
     // Flat dark clears the canvas to transparent (glass panes over the

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -47,6 +47,17 @@ import {
   applyAccentColor,
   DEFAULT_ACCENT_COLOR,
 } from "~/lib/accent-colors";
+import { applyTerminalAppearance } from "~/lib/terminal-appearance";
+import {
+  applyInterfaceFontFamily,
+  applyInterfaceFontScale,
+} from "~/lib/interface-appearance";
+import {
+  DEFAULT_TERMINAL_FONT_WEIGHT,
+  DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+  DEFAULT_TERMINAL_LETTER_SPACING,
+  DEFAULT_TERMINAL_LINE_HEIGHT,
+} from "~/shared/terminal-appearance";
 import {
   SettingsPanel,
   SETTINGS_PANEL_IDS,
@@ -417,6 +428,47 @@ function Shell() {
   useEffect(() => {
     applyAccentColor(settings?.accentColor ?? DEFAULT_ACCENT_COLOR);
   }, [settings?.accentColor]);
+
+  // Appearance settings land as inline CSS vars on <html>; live terminals
+  // pick them up through watchTerminalColorScheme's style observer.
+  const terminalFontFamily = settings?.terminalFontFamily ?? null;
+  const terminalFontWeight =
+    settings?.terminalFontWeight ?? DEFAULT_TERMINAL_FONT_WEIGHT;
+  const terminalFontWeightBold =
+    settings?.terminalFontWeightBold ?? DEFAULT_TERMINAL_FONT_WEIGHT_BOLD;
+  const terminalLineHeight =
+    settings?.terminalLineHeight ?? DEFAULT_TERMINAL_LINE_HEIGHT;
+  const terminalLetterSpacing =
+    settings?.terminalLetterSpacing ?? DEFAULT_TERMINAL_LETTER_SPACING;
+  useEffect(() => {
+    if (!settings) return;
+    applyTerminalAppearance({
+      fontFamily: terminalFontFamily,
+      fontWeight: terminalFontWeight,
+      fontWeightBold: terminalFontWeightBold,
+      lineHeight: terminalLineHeight,
+      letterSpacing: terminalLetterSpacing,
+    });
+  }, [
+    settings,
+    terminalFontFamily,
+    terminalFontWeight,
+    terminalFontWeightBold,
+    terminalLineHeight,
+    terminalLetterSpacing,
+  ]);
+
+  const interfaceFontFamily = settings?.interfaceFontFamily ?? null;
+  useEffect(() => {
+    if (!settings) return;
+    applyInterfaceFontFamily(interfaceFontFamily);
+  }, [settings, interfaceFontFamily]);
+
+  const interfaceFontScale = settings?.interfaceFontScale;
+  useEffect(() => {
+    if (interfaceFontScale === undefined) return;
+    applyInterfaceFontScale(interfaceFontScale);
+  }, [interfaceFontScale]);
 
   const launchOverlayEnabled = settings?.launchOverlayEnabled;
   const themeStyle = settings?.themeStyle;

--- a/src/server/controllers/settings.controller.ts
+++ b/src/server/controllers/settings.controller.ts
@@ -57,6 +57,21 @@ import {
   normalizeTerminalZoomLevel,
 } from "~/shared/terminal-zoom";
 import {
+  DEFAULT_INTERFACE_FONT_SCALE,
+  DEFAULT_TERMINAL_FONT_WEIGHT,
+  DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+  FONT_FAMILY_MAX_LENGTH,
+  INTERFACE_FONT_SCALES,
+  TERMINAL_FONT_WEIGHTS,
+  TERMINAL_LETTER_SPACINGS,
+  TERMINAL_LINE_HEIGHTS,
+  normalizeFontFamily,
+  normalizeInterfaceFontScale,
+  normalizeTerminalFontWeight,
+  normalizeTerminalLetterSpacing,
+  normalizeTerminalLineHeight,
+} from "~/shared/terminal-appearance";
+import {
   emptyVoiceCommandAliases,
   normalizeVoiceCommandAliases,
   type VoiceCommandAliases,
@@ -92,6 +107,13 @@ const CLAUDE_USAGE_LIMITS_SHOW_SESSION_KEY = "claude_usage_limits_show_session";
 const CLAUDE_USAGE_LIMITS_SHOW_WEEKLY_KEY = "claude_usage_limits_show_weekly";
 const PROVIDER_USAGE_ENABLED_KEY = "provider_usage_enabled";
 const PROVIDER_USAGE_IDS_KEY = "provider_usage_ids";
+const TERMINAL_FONT_FAMILY_KEY = "terminal_font_family";
+const TERMINAL_FONT_WEIGHT_KEY = "terminal_font_weight";
+const TERMINAL_FONT_WEIGHT_BOLD_KEY = "terminal_font_weight_bold";
+const TERMINAL_LINE_HEIGHT_KEY = "terminal_line_height";
+const TERMINAL_LETTER_SPACING_KEY = "terminal_letter_spacing";
+const INTERFACE_FONT_FAMILY_KEY = "interface_font_family";
+const INTERFACE_FONT_SCALE_KEY = "interface_font_scale";
 
 const voiceCommandAliasesBody = z.unknown().transform((value, ctx): VoiceCommandAliases => {
   try {
@@ -151,6 +173,42 @@ const updateSettingsBody = z
     selectedWorktreeByProject: z.record(z.string(), z.string()).nullable(),
     commitCli: z.union([z.enum(COMMIT_CLI_VALUES), z.null()]),
     terminalZoomLevel: z.number().int().min(TERMINAL_ZOOM_MIN).max(TERMINAL_ZOOM_MAX),
+    terminalFontFamily: z
+      .string()
+      .max(FONT_FAMILY_MAX_LENGTH)
+      .nullable()
+      .transform((value) => normalizeFontFamily(value)),
+    terminalFontWeight: z
+      .number()
+      .refine((value) => (TERMINAL_FONT_WEIGHTS as readonly number[]).includes(value), {
+        message: "invalid terminalFontWeight",
+      }),
+    terminalFontWeightBold: z
+      .number()
+      .refine((value) => (TERMINAL_FONT_WEIGHTS as readonly number[]).includes(value), {
+        message: "invalid terminalFontWeightBold",
+      }),
+    terminalLineHeight: z
+      .number()
+      .refine((value) => (TERMINAL_LINE_HEIGHTS as readonly number[]).includes(value), {
+        message: "invalid terminalLineHeight",
+      }),
+    terminalLetterSpacing: z
+      .number()
+      .refine(
+        (value) => (TERMINAL_LETTER_SPACINGS as readonly number[]).includes(value),
+        { message: "invalid terminalLetterSpacing" },
+      ),
+    interfaceFontFamily: z
+      .string()
+      .max(FONT_FAMILY_MAX_LENGTH)
+      .nullable()
+      .transform((value) => normalizeFontFamily(value)),
+    interfaceFontScale: z
+      .number()
+      .refine((value) => (INTERFACE_FONT_SCALES as readonly number[]).includes(value), {
+        message: "invalid interfaceFontScale",
+      }),
     sessionHeaderButtons: z
       .record(z.string(), z.boolean())
       .transform(
@@ -263,6 +321,41 @@ function getTerminalZoomLevelSetting() {
   return normalizeTerminalZoomLevel(getSetting(TERMINAL_ZOOM_LEVEL_KEY)) ?? DEFAULT_TERMINAL_ZOOM_LEVEL;
 }
 
+function getTerminalFontFamilySetting(): string | null {
+  return normalizeFontFamily(getSetting(TERMINAL_FONT_FAMILY_KEY));
+}
+
+function getTerminalFontWeightSetting() {
+  return normalizeTerminalFontWeight(
+    getSetting(TERMINAL_FONT_WEIGHT_KEY),
+    DEFAULT_TERMINAL_FONT_WEIGHT,
+  );
+}
+
+function getTerminalFontWeightBoldSetting() {
+  return normalizeTerminalFontWeight(
+    getSetting(TERMINAL_FONT_WEIGHT_BOLD_KEY),
+    DEFAULT_TERMINAL_FONT_WEIGHT_BOLD,
+  );
+}
+
+function getTerminalLineHeightSetting() {
+  return normalizeTerminalLineHeight(getSetting(TERMINAL_LINE_HEIGHT_KEY));
+}
+
+function getTerminalLetterSpacingSetting() {
+  return normalizeTerminalLetterSpacing(getSetting(TERMINAL_LETTER_SPACING_KEY));
+}
+
+function getInterfaceFontFamilySetting(): string | null {
+  return normalizeFontFamily(getSetting(INTERFACE_FONT_FAMILY_KEY));
+}
+
+function getInterfaceFontScaleSetting() {
+  const raw = getSetting(INTERFACE_FONT_SCALE_KEY);
+  return raw === null ? DEFAULT_INTERFACE_FONT_SCALE : normalizeInterfaceFontScale(raw);
+}
+
 function getSessionHeaderButtonsSetting(): SessionHeaderButtonVisibility {
   return normalizeSessionHeaderButtonVisibility(
     safeJsonParse<unknown>(getSetting(SESSION_HEADER_BUTTONS_KEY), null),
@@ -323,6 +416,13 @@ function settingsPayload() {
     selectedWorktreeByProject: getSelectedWorktreeByProjectSetting(),
     commitCli: getCommitCliSetting(),
     terminalZoomLevel: getTerminalZoomLevelSetting(),
+    terminalFontFamily: getTerminalFontFamilySetting(),
+    terminalFontWeight: getTerminalFontWeightSetting(),
+    terminalFontWeightBold: getTerminalFontWeightBoldSetting(),
+    terminalLineHeight: getTerminalLineHeightSetting(),
+    terminalLetterSpacing: getTerminalLetterSpacingSetting(),
+    interfaceFontFamily: getInterfaceFontFamilySetting(),
+    interfaceFontScale: getInterfaceFontScaleSetting(),
     sessionHeaderButtons: getSessionHeaderButtonsSetting(),
     defaultAgent: getDefaultAgentSetting(),
     defaultModel: getDefaultModelSetting(),
@@ -486,6 +586,35 @@ export async function update(request: Request): Promise<Response> {
   }
   if (body.terminalZoomLevel !== undefined) {
     setSetting(TERMINAL_ZOOM_LEVEL_KEY, String(body.terminalZoomLevel));
+  }
+  if (body.terminalFontFamily !== undefined) {
+    if (body.terminalFontFamily === null) {
+      deleteSetting(TERMINAL_FONT_FAMILY_KEY);
+    } else {
+      setSetting(TERMINAL_FONT_FAMILY_KEY, body.terminalFontFamily);
+    }
+  }
+  if (body.terminalFontWeight !== undefined) {
+    setSetting(TERMINAL_FONT_WEIGHT_KEY, String(body.terminalFontWeight));
+  }
+  if (body.terminalFontWeightBold !== undefined) {
+    setSetting(TERMINAL_FONT_WEIGHT_BOLD_KEY, String(body.terminalFontWeightBold));
+  }
+  if (body.terminalLineHeight !== undefined) {
+    setSetting(TERMINAL_LINE_HEIGHT_KEY, String(body.terminalLineHeight));
+  }
+  if (body.terminalLetterSpacing !== undefined) {
+    setSetting(TERMINAL_LETTER_SPACING_KEY, String(body.terminalLetterSpacing));
+  }
+  if (body.interfaceFontFamily !== undefined) {
+    if (body.interfaceFontFamily === null) {
+      deleteSetting(INTERFACE_FONT_FAMILY_KEY);
+    } else {
+      setSetting(INTERFACE_FONT_FAMILY_KEY, body.interfaceFontFamily);
+    }
+  }
+  if (body.interfaceFontScale !== undefined) {
+    setSetting(INTERFACE_FONT_SCALE_KEY, String(body.interfaceFontScale));
   }
   if (body.sessionHeaderButtons !== undefined) {
     setSetting(SESSION_HEADER_BUTTONS_KEY, JSON.stringify(body.sessionHeaderButtons));

--- a/src/shared/__tests__/terminal-appearance.test.ts
+++ b/src/shared/__tests__/terminal-appearance.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_INTERFACE_FONT_SCALE,
+  DEFAULT_TERMINAL_FONT_WEIGHT,
+  DEFAULT_TERMINAL_LETTER_SPACING,
+  DEFAULT_TERMINAL_LINE_HEIGHT,
+  FONT_FAMILY_MAX_LENGTH,
+  isTerminalFontWeight,
+  normalizeFontFamily,
+  normalizeInterfaceFontScale,
+  normalizeTerminalFontWeight,
+  normalizeTerminalLetterSpacing,
+  normalizeTerminalLineHeight,
+} from "~/shared/terminal-appearance";
+
+describe("terminal appearance normalizers", () => {
+  it("accepts every hundred weight and rejects the rest", () => {
+    expect(isTerminalFontWeight(400)).toBe(true);
+    expect(isTerminalFontWeight(900)).toBe(true);
+    expect(isTerminalFontWeight(450)).toBe(false);
+    expect(isTerminalFontWeight("400")).toBe(false);
+  });
+
+  it("normalizes weights from stored strings and snaps to the nearest step", () => {
+    expect(normalizeTerminalFontWeight("300", DEFAULT_TERMINAL_FONT_WEIGHT)).toBe(300);
+    expect(normalizeTerminalFontWeight(449, DEFAULT_TERMINAL_FONT_WEIGHT)).toBe(400);
+    expect(normalizeTerminalFontWeight(451, DEFAULT_TERMINAL_FONT_WEIGHT)).toBe(500);
+    expect(normalizeTerminalFontWeight("junk", 700)).toBe(700);
+    expect(normalizeTerminalFontWeight(null, 700)).toBe(700);
+  });
+
+  it("normalizes line height within 1.0–1.8", () => {
+    expect(normalizeTerminalLineHeight("1.2")).toBe(1.2);
+    expect(normalizeTerminalLineHeight(99)).toBe(1.8);
+    expect(normalizeTerminalLineHeight(-1)).toBe(1.0);
+    expect(normalizeTerminalLineHeight(undefined)).toBe(DEFAULT_TERMINAL_LINE_HEIGHT);
+  });
+
+  it("normalizes letter spacing to half-pixel steps", () => {
+    expect(normalizeTerminalLetterSpacing("0.5")).toBe(0.5);
+    expect(normalizeTerminalLetterSpacing(0.6)).toBe(0.5);
+    expect(normalizeTerminalLetterSpacing(100)).toBe(3);
+    expect(normalizeTerminalLetterSpacing("junk")).toBe(
+      DEFAULT_TERMINAL_LETTER_SPACING,
+    );
+  });
+
+  it("normalizes interface scale to the offered steps", () => {
+    expect(normalizeInterfaceFontScale("1.1")).toBe(1.1);
+    expect(normalizeInterfaceFontScale(3)).toBe(1.3);
+    expect(normalizeInterfaceFontScale(0)).toBe(0.85);
+    expect(normalizeInterfaceFontScale(null)).toBe(DEFAULT_INTERFACE_FONT_SCALE);
+  });
+
+  it("trims, caps, and nulls empty font families", () => {
+    expect(normalizeFontFamily("  Fira Code  ")).toBe("Fira Code");
+    expect(normalizeFontFamily("")).toBeNull();
+    expect(normalizeFontFamily("   ")).toBeNull();
+    expect(normalizeFontFamily(42)).toBeNull();
+    expect(normalizeFontFamily("x".repeat(500))).toHaveLength(FONT_FAMILY_MAX_LENGTH);
+  });
+});

--- a/src/shared/electron-contract.ts
+++ b/src/shared/electron-contract.ts
@@ -345,6 +345,8 @@ export type ElectronBridge = {
   /** Sync the native window background with the renderer theme (dark/light)
    *  so resize gutters and the launch frame match the page ground. */
   setWindowBackgroundColor: (color: string) => Promise<{ ok: true } | { ok: false; error: string }>;
+  /** Scale the whole UI via the window zoom factor (interface font scale). 1 = 100%. */
+  setZoomFactor: (factor: number) => Promise<{ ok: true } | { ok: false; error: string }>;
   notifications: {
     getPermission: () => Promise<"granted" | "unsupported">;
     showSessionFinished: (payload: {

--- a/src/shared/terminal-appearance.ts
+++ b/src/shared/terminal-appearance.ts
@@ -1,0 +1,112 @@
+// Terminal + interface appearance settings — font face, weights, line height,
+// letter spacing for xterm panes, plus the interface (UI) font face and scale.
+// Shared by the settings controller (persistence + validation) and the
+// renderer (xterm options + DOM application), so the ranges live here rather
+// than in src/lib.
+
+/** CSS font weights offered for terminal text (regular and bold runs). */
+export const TERMINAL_FONT_WEIGHTS = [
+  100, 200, 300, 400, 500, 600, 700, 800, 900,
+] as const;
+
+export type TerminalFontWeight = (typeof TERMINAL_FONT_WEIGHTS)[number];
+
+export const DEFAULT_TERMINAL_FONT_WEIGHT: TerminalFontWeight = 400;
+export const DEFAULT_TERMINAL_FONT_WEIGHT_BOLD: TerminalFontWeight = 700;
+
+export function isTerminalFontWeight(value: unknown): value is TerminalFontWeight {
+  return (
+    typeof value === "number" &&
+    (TERMINAL_FONT_WEIGHTS as readonly number[]).includes(value)
+  );
+}
+
+/**
+ * Line height multipliers for terminal rows. 1.0 is xterm's default and the
+ * only value where multi-row ANSI art (box drawing, background fills, startup
+ * wordmarks) renders flush — higher values trade that for readability, which
+ * is why this is a user choice rather than a theme default.
+ */
+export const TERMINAL_LINE_HEIGHTS = [
+  1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8,
+] as const;
+
+export type TerminalLineHeight = (typeof TERMINAL_LINE_HEIGHTS)[number];
+
+export const DEFAULT_TERMINAL_LINE_HEIGHT: TerminalLineHeight = 1.0;
+
+/** Extra horizontal pixels added between terminal cells (xterm letterSpacing). */
+export const TERMINAL_LETTER_SPACINGS = [0, 0.5, 1, 1.5, 2, 2.5, 3] as const;
+
+export type TerminalLetterSpacing = (typeof TERMINAL_LETTER_SPACINGS)[number];
+
+export const DEFAULT_TERMINAL_LETTER_SPACING: TerminalLetterSpacing = 0;
+
+/** `null` = the active theme's bundled face (Geist Mono; JetBrains Mono on flat). */
+export const DEFAULT_TERMINAL_FONT_FAMILY: string | null = null;
+
+/** Longest font family name accepted from the client. */
+export const FONT_FAMILY_MAX_LENGTH = 120;
+
+/**
+ * Interface (UI) scale multipliers, applied as the window zoom factor.
+ * 1 = 100%; the range mirrors browser zoom's useful span for a dense UI.
+ */
+export const INTERFACE_FONT_SCALES = [
+  0.85, 0.9, 0.95, 1, 1.05, 1.1, 1.15, 1.2, 1.25, 1.3,
+] as const;
+
+export type InterfaceFontScale = (typeof INTERFACE_FONT_SCALES)[number];
+
+export const DEFAULT_INTERFACE_FONT_SCALE: InterfaceFontScale = 1;
+
+/** `null` = the active theme's UI face (Space Grotesk; Plus Jakarta Sans on flat). */
+export const DEFAULT_INTERFACE_FONT_FAMILY: string | null = null;
+
+function nearest<T extends number>(values: readonly T[], value: number): T {
+  let best = values[0]!;
+  for (const candidate of values) {
+    if (Math.abs(candidate - value) < Math.abs(best - value)) best = candidate;
+  }
+  return best;
+}
+
+export function normalizeTerminalFontWeight(
+  value: unknown,
+  fallback: TerminalFontWeight,
+): TerminalFontWeight {
+  const parsed = typeof value === "string" ? Number(value) : value;
+  if (typeof parsed !== "number" || !Number.isFinite(parsed)) return fallback;
+  return nearest(TERMINAL_FONT_WEIGHTS, parsed);
+}
+
+export function normalizeTerminalLineHeight(value: unknown): TerminalLineHeight {
+  const parsed = typeof value === "string" ? Number(value) : value;
+  if (typeof parsed !== "number" || !Number.isFinite(parsed)) {
+    return DEFAULT_TERMINAL_LINE_HEIGHT;
+  }
+  return nearest(TERMINAL_LINE_HEIGHTS, parsed);
+}
+
+export function normalizeTerminalLetterSpacing(value: unknown): TerminalLetterSpacing {
+  const parsed = typeof value === "string" ? Number(value) : value;
+  if (typeof parsed !== "number" || !Number.isFinite(parsed)) {
+    return DEFAULT_TERMINAL_LETTER_SPACING;
+  }
+  return nearest(TERMINAL_LETTER_SPACINGS, parsed);
+}
+
+export function normalizeInterfaceFontScale(value: unknown): InterfaceFontScale {
+  const parsed = typeof value === "string" ? Number(value) : value;
+  if (typeof parsed !== "number" || !Number.isFinite(parsed)) {
+    return DEFAULT_INTERFACE_FONT_SCALE;
+  }
+  return nearest(INTERFACE_FONT_SCALES, parsed);
+}
+
+/** Trim + cap a stored/user font family; empty collapses to null (theme default). */
+export function normalizeFontFamily(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().slice(0, FONT_FAMILY_MAX_LENGTH);
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3452,6 +3452,107 @@ body[data-card-glow] .cursor-glow {
   transform: translateX(22px);
 }
 
+/* ── Terminal / appearance settings: quiet control column + live preview hero ── */
+/* The shell owns the size query so the grid can re-flow to one column when the
+   settings panel is narrow, independent of the window's viewport width. */
+.term-settings-shell {
+  container-type: inline-size;
+}
+
+.term-settings {
+  display: grid;
+  grid-template-columns: minmax(0, 440px) minmax(0, 1fr);
+  align-items: start;
+  gap: 36px;
+}
+
+/* Each setting sits on its own surface card; stack them with a steady rhythm. */
+.term-settings__controls {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.term-settings__preview {
+  min-width: 0;
+  position: sticky;
+  top: 4px;
+  align-self: start;
+}
+
+@container (max-width: 720px) {
+  .term-settings {
+    grid-template-columns: 1fr;
+    gap: 26px;
+  }
+  .term-settings__preview {
+    position: static;
+  }
+}
+
+/* Regular + Bold read as one weight control, not two identical fields. */
+.term-weight {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.term-weight__row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.term-weight__key {
+  flex: 0 0 auto;
+  min-width: 52px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+/* Segmented value pickers gain the hover/focus feedback product UI expects. */
+.term-value {
+  border-radius: 5px;
+  transition:
+    color 0.12s ease,
+    background 0.12s ease;
+}
+
+.term-value:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+}
+
+.term-value:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.term-select {
+  transition:
+    border-color 0.12s ease,
+    box-shadow 0.12s ease;
+}
+
+.term-select:hover {
+  border-color: var(--border-strong);
+}
+
+.term-select:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 32%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .term-value,
+  .term-select {
+    transition: none;
+  }
+}
+
 /* Push-to-talk recording indicator pulse. */
 @keyframes mc-voice-pulse {
   0%,

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,14 +4,27 @@
 @import "@fontsource/space-grotesk/500.css";
 @import "@fontsource/space-grotesk/600.css";
 @import "@fontsource/space-grotesk/700.css";
+/* Full weight ranges so the terminal font-weight settings bind to real faces
+   (browsers only fetch the weights a page actually uses). */
+@import "@fontsource/geist-mono/100.css";
+@import "@fontsource/geist-mono/200.css";
+@import "@fontsource/geist-mono/300.css";
 @import "@fontsource/geist-mono/400.css";
 @import "@fontsource/geist-mono/500.css";
 @import "@fontsource/geist-mono/600.css";
-/* Flat theme's bundled terminal + UI mono face — clearer, warmer mono. */
+@import "@fontsource/geist-mono/700.css";
+@import "@fontsource/geist-mono/800.css";
+@import "@fontsource/geist-mono/900.css";
+/* Flat theme's bundled terminal + UI mono face — clearer, warmer mono.
+   (JetBrains Mono ships 100–800; there is no 900 cut.) */
+@import "@fontsource/jetbrains-mono/100.css";
+@import "@fontsource/jetbrains-mono/200.css";
+@import "@fontsource/jetbrains-mono/300.css";
 @import "@fontsource/jetbrains-mono/400.css";
 @import "@fontsource/jetbrains-mono/500.css";
 @import "@fontsource/jetbrains-mono/600.css";
 @import "@fontsource/jetbrains-mono/700.css";
+@import "@fontsource/jetbrains-mono/800.css";
 /* Flat theme's UI sans face. */
 @import "@fontsource/plus-jakarta-sans/400.css";
 @import "@fontsource/plus-jakarta-sans/500.css";


### PR DESCRIPTION

<img width="1676" height="922" alt="image" src="https://github.com/user-attachments/assets/c9b1a1f3-30f3-4880-8903-af71c4f13f58" />
<img width="1431" height="587" alt="image" src="https://github.com/user-attachments/assets/24ace25a-5dba-4828-9d57-44a6af81e6c4" />

## What

Adds the appearance/typography settings and unifies how they're presented, so the Terminal and Theme pages speak one consistent settings-card language.

### Settings
- **Terminal typography** — font family (bundled + detected system monospace faces), regular/bold weight, default zoom, line height, letter spacing, with a live preview.
- **Interface typography** — application UI font family and font scale on the Theme page.

### Layout / design
- Extract a reusable **`SettingCard`** from `ToggleRow`'s card chrome — each setting is one surface card (title + description + control), matching the existing Session-buttons rows.
- **Terminal page**: two-column layout with a **sticky live-preview hero** on the right (previously the preview was buried below a long single column), and the duplicate *Font weight* / *Bold font weight* fields collapsed into one **Font weight** card with Regular/Bold rows.
- **Theme page**: `Interface font family` and `Interface font scale` converted to `SettingCard`s to match the Surface-tint card above them.
- Added hover/focus affordances to the segmented value pickers and font selects, with a `prefers-reduced-motion` fallback. Responsive: the two-column terminal layout collapses to a single column (preview below) on narrow panels via a container query.

## Verify
- `npx tsc --noEmit` and `eslint` clean on all changed files.
- Visually battle-tested both pages at wide and narrow widths.