### PR TITLE
fix(screenshot): persist edits to history when attaching to session

### DIFF
--- a/src/components/views/ScreenshotAnnotator.tsx
+++ b/src/components/views/ScreenshotAnnotator.tsx
@@ -1116,12 +1116,16 @@ export function ScreenshotAnnotator({
     if (status !== "ready" || busy) return;
     setBusy("attach");
     try {
-      const { path } = await exportPng();
+      const { path, previewDataUrl } = await exportPng();
+      // Persist the edits back to the source entry first, so the annotated
+      // image is what history keeps — attaching should never silently drop the
+      // changes it just baked into the sent PNG. Then attach the same file.
+      onSave(path, previewDataUrl, { originalPath: basePath, shapes: shapesRef.current, crop });
       onAttach(path);
     } catch {
       setBusy(null);
     }
-  }, [busy, exportPng, onAttach, status]);
+  }, [basePath, busy, crop, exportPng, onAttach, onSave, status]);
 
   const save = useCallback(async () => {
     if (status !== "ready" || busy) return;


### PR DESCRIPTION
## Problem

When editing a screenshot in the annotator and clicking **Attach to session**, the edits were baked into the sent image but never written back to the screenshot history entry. Reopening the screenshots history — or re-editing the screenshot — showed the original, un-annotated image.

## Root cause

The annotator has two footer actions that both flatten edits via `exportPng()`:

- **Save** → `onSave(...)` → `updateScreenshot(...)`, persisting the annotated image + editable shapes/crop into the history entry.
- **Attach to session** → only called `onAttach(path)`. It flattened the edits into the *sent* PNG but never called `onSave`, so `updateScreenshot` never ran and history kept pointing at the original.

## Fix

`attach` now persists the edits (using the exact same editable payload as the Save button) before attaching the file. Centralized in `ScreenshotAnnotator`, so it fixes both call sites (`ScreenshotHistory` and the pending `ScreenshotThumbnail`).

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on the changed file — clean