### PR TITLE
fix(terminal): close session pane on clean shell exit

### DIFF
--- a/src/components/views/TerminalPane.tsx
+++ b/src/components/views/TerminalPane.tsx
@@ -464,6 +464,11 @@ export function TerminalPane({
   // latest task status without rebuilding the terminal. Used to re-arm the
   // Cursor/Codex Enter→running fallback after a turn finishes.
   const liveTaskStatusRef = useRef(task.status);
+  // Latest onHide (the header's close button) read from a ref so the once-per-
+  // surface PTY-exit handler can invoke it without rebuilding on every render.
+  // Lets a clean shell exit (typing `exit`) close the pane just like the X.
+  const onHideRef = useRef(onHide);
+  onHideRef.current = onHide;
   // When a sandbox project's repo isn't cloned into the container yet, offer to
   // clone it (remote detected from the host project) instead of opening empty.
   const [cloneOffer, setCloneOffer] = useState<{ remote: string; slug: string } | null>(null);
@@ -1014,6 +1019,13 @@ export function TerminalPane({
             queryClient.invalidateQueries({ queryKey: queryKeys.project(project.id) }),
             queryClient.invalidateQueries({ queryKey: queryKeys.projects }),
           ]);
+          // A clean shell exit (the user typed `exit`) should dismiss the pane
+          // just like clicking the header's close button — otherwise a dead
+          // "Session finished" cell lingers in the grid. Fire after the status
+          // patch + invalidation so the close path sees a non-running task and
+          // archives without a confirm prompt. Terminated (crashed) sessions
+          // stay put so their output can be inspected.
+          if (status === "finished") onHideRef.current?.();
         })();
       };
 


### PR DESCRIPTION
## Problem

Typing `exit` in a session terminal exits the shell (code=0), but the pane stays open showing `[Session finished (code=0).]` — leaving a dead cell in the grid. It should behave like the header's **X** close button.

## Fix

In `TerminalPane`'s `handlePtyExit`, on a clean exit (status `finished`) invoke the header's close handler (`onHide`) after the status patch + query invalidation. Firing after invalidation means the close path sees a non-running task and archives without a confirm prompt.

- Reuses `onHide`, so it matches the topbar close in each context (archive in the grid, dismiss in the single panel, no-op in the focus route).
- Read through a ref (`onHideRef`) since the PTY-exit handler is wired once per surface and isn't in that effect's deps.
- **Terminated** (non-zero / crashed) exits are left untouched so their output can still be inspected.

## Test

`npx tsc --noEmit` and `npx eslint` pass. Manually: type `exit` in a grid session — the cell now closes instead of lingering as "Session finished".