### PR TITLE
fix(focus): zoom the terminal session on Cmd/Ctrl +/- instead of the Electron app

### DIFF
--- a/src/lib/__tests__/terminal-xterm-focus.test.ts
+++ b/src/lib/__tests__/terminal-xterm-focus.test.ts
@@ -41,4 +41,11 @@ describe("isXtermWithinScope", () => {
     expect(isXtermWithinScope(gridEl, "[data-session-terminal-panel]")).toBe(false);
     expect(isXtermWithinScope(gridEl, "[data-user-terminal-panel]")).toBe(false);
   });
+
+  it("matches an xterm nested inside the focus-mode terminal, so Cmd/Ctrl +/- zooms the session", () => {
+    const el = fakeElement([".xterm", "[data-focus-terminal-panel]"]);
+    expect(isXtermWithinScope(el, "[data-focus-terminal-panel]")).toBe(true);
+    // stays distinct from the other terminal scopes
+    expect(isXtermWithinScope(el, "[data-grid-cell]")).toBe(false);
+  });
 });

--- a/src/lib/terminal-pane-helpers.ts
+++ b/src/lib/terminal-pane-helpers.ts
@@ -68,11 +68,17 @@ export function isGridTerminalXtermFocused(): boolean {
   return activeXtermIsWithin("[data-grid-cell]");
 }
 
+/** True when keyboard focus is inside an xterm surface in the focus-mode terminal. */
+export function isFocusTerminalXtermFocused(): boolean {
+  return activeXtermIsWithin("[data-focus-terminal-panel]");
+}
+
 export function isTerminalXtermFocused(): boolean {
   return (
     isUserTerminalXtermFocused() ||
     isSessionTerminalXtermFocused() ||
-    isGridTerminalXtermFocused()
+    isGridTerminalXtermFocused() ||
+    isFocusTerminalXtermFocused()
   );
 }
 

--- a/src/routes/focus.$taskId.tsx
+++ b/src/routes/focus.$taskId.tsx
@@ -366,9 +366,13 @@ function FocusSessionPage() {
       {/* data-task-id makes the terminal a drop target for thumbnail drags
           (sessionHostAtPoint), matching the grid cells / docked panel; the
           relative position anchors the focus-variant stack to the terminal
-          area so it always clears the header and session bar. */}
+          area so it always clears the header and session bar.
+          data-focus-terminal-panel scopes Cmd/Ctrl +/-/0 to the per-session
+          terminal zoom (see isTerminalXtermFocused) instead of Electron's
+          native app zoom. */}
       <div
         data-task-id={session.taskId}
+        data-focus-terminal-panel
         style={{
           flex: 1,
           minHeight: 0,


### PR DESCRIPTION
## Problem

In **focus mode**, pressing `Cmd/Ctrl` + `+` / `-` / `0` zoomed the entire Electron window instead of the terminal session.

## Root cause

The global key handler in `src/routes/__root.tsx` only suppresses Electron's native app zoom — and dispatches the existing per-session terminal-zoom events — when focus is inside a *recognized* terminal surface (`isTerminalXtermFocused()`). That check covered the user panel, session panel, and grid cells, but **not** the focus-mode terminal, whose wrapper matched none of those scopes. So in focus mode the handler bailed early and native app zoom took over.

## Fix

- Tag the focus-mode terminal container with `data-focus-terminal-panel` (`src/routes/focus.\$taskId.tsx`).
- Add `isFocusTerminalXtermFocused()` and include it in `isTerminalXtermFocused()` (`src/lib/terminal-pane-helpers.ts`).

No new zoom logic was needed — `TerminalPane` already listens for the zoom events via `useTerminalPaneZoomShortcuts`. Once focus mode is recognized as a terminal surface, the existing per-session zoom just works: `+`/`-` step the terminal font size and `0` resets it, with no app-level zoom.

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run src/lib/__tests__/terminal-xterm-focus.test.ts` — 6 passed (added a case for the new focus scope)