### PR TITLE
fix(screenshot): keep the capture stack visible across projects

### DIFF
--- a/src/components/views/ScreenshotThumbnail.tsx
+++ b/src/components/views/ScreenshotThumbnail.tsx
@@ -439,11 +439,22 @@ export function ScreenshotThumbnail({
   projectId,
   variant = "floating",
 }: {
-  projectId: string;
+  // The current-project id, used as the attach target for the plain-click /
+  // attach-button path. Null when the user is on no project route (the global
+  // floating stack still renders — drag-to-attach and per-card origin fallback
+  // keep working). The focus variant always receives a concrete project id.
+  projectId: string | null;
   variant?: "floating" | "focus";
 }) {
   const { pendingScreenshots } = useTerminals();
-  const shots = pendingScreenshots.filter((s) => s.projectId === projectId);
+  // The focus window is a single-project surface, so it only shows that
+  // project's shots. The global floating stack follows the user across
+  // projects — show the whole pile so a capture in one project can be dragged
+  // onto (or attached from) a session in another.
+  const shots =
+    variant === "focus"
+      ? pendingScreenshots.filter((s) => s.projectId === projectId)
+      : pendingScreenshots;
 
   if (shots.length === 0) return null;
 
@@ -467,7 +478,12 @@ export function ScreenshotThumbnail({
         }}
       >
         {[...shots].reverse().map((shot) => (
-          <ScreenshotStackCard key={shot.id} shot={shot} projectId={projectId} compact />
+          <ScreenshotStackCard
+            key={shot.id}
+            shot={shot}
+            projectId={projectId ?? shot.projectId}
+            compact
+          />
         ))}
       </div>
     );
@@ -494,7 +510,7 @@ export function ScreenshotThumbnail({
       }}
     >
       {shots.map((shot) => (
-        <ScreenshotStackCard key={shot.id} shot={shot} projectId={projectId} />
+        <ScreenshotStackCard key={shot.id} shot={shot} projectId={projectId ?? shot.projectId} />
       ))}
     </div>,
     document.body,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -12,6 +12,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { getPinnedProjects } from "~/lib/pinned-project-order";
 import { getElectron } from "~/lib/electron";
 import { isFocusPath } from "~/lib/focus-session";
+import { screenshotSupported } from "~/lib/screenshot";
 import { TopBar, type Crumb } from "~/components/ui/TopBar";
 import { Btn } from "~/components/ui/Btn";
 import { ConfirmDialog } from "~/components/ui/ConfirmDialog";
@@ -28,6 +29,7 @@ import { TerminalPanel } from "~/components/views/TerminalPanel";
 import { UserTerminalPanel } from "~/components/views/UserTerminalPanel";
 import { ProjectPicker } from "~/components/views/ProjectPicker";
 import { ProjectBar } from "~/components/views/ProjectBar";
+import { ScreenshotThumbnail } from "~/components/views/ScreenshotThumbnail";
 import { AddProjectProvider } from "~/lib/add-project-store";
 import { PromptSearchProvider } from "~/lib/prompt-search-store";
 import { PromptSearchButton } from "~/components/views/PromptSearchButton";
@@ -349,6 +351,11 @@ function Shell() {
   // Focused Session Mode strips the whole shell: the /focus route renders the
   // only visible chrome, and the Electron window is a small floating card.
   const focusActive = isFocusPath(path);
+  // The captured-screenshot stack is mounted here (not in the per-project route)
+  // so it survives navigation between projects; the focus branch below returns
+  // before it, so the focus window keeps its own scoped stack. macOS + Electron
+  // only, mirroring the project route's gate.
+  const screenshotsSupported = useMemo(() => screenshotSupported(), []);
 
   // Boot resync guard: if the main process says the window is still in focus
   // mode but we didn't land on a focus path (e.g. state drifted across a dev
@@ -599,6 +606,7 @@ function Shell() {
 
   return (
     <>
+      {screenshotsSupported && <ScreenshotThumbnail projectId={projectId} />}
       <div id="root">
         <div
           aria-hidden

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -13,7 +13,6 @@ import { openExternal } from "~/lib/open-external";
 import { ProjectIcon } from "~/components/ui/ProjectIcon";
 import { EmptyState } from "~/components/ui/EmptyState";
 import { TaskColumn } from "~/components/views/TaskColumn";
-import { ScreenshotThumbnail } from "~/components/views/ScreenshotThumbnail";
 import { NewAgentDialog } from "~/components/views/NewAgentDialog";
 import {
   CodexHooksNoticeDialog,
@@ -3255,8 +3254,6 @@ function ProjectPage() {
         </>
         )}
       </CardFrame>
-
-      {screenshotSupported && <ScreenshotThumbnail projectId={id} />}
 
       <GitDiffModal
         open={showDiffView}


### PR DESCRIPTION
## Problem

When you capture a screen region (`⌘⇧S` / camera button), the shot appears as a floating thumbnail card pinned bottom-right. Switching to a different project made that card **disappear**, so a screenshot captured in one project couldn't be carried over and attached to a session in another.

## Root cause

The screenshot data already survived navigation — it lives in the global `TerminalProvider` store, which stays mounted across route changes. The disappearance was purely in the view layer:

1. **Mounted inside the per-project route** (`projects.$id.tsx`), which TanStack Router unmounts when you switch projects.
2. **Filtered by `s.projectId === projectId`** at render time, so even a still-mounted instance only showed its own project's shots.

## Fix

Mount the floating stack **once, globally** in the persistent app `Shell` and show the **full** pending pile regardless of origin project. Conceptually this matches the model that a screen capture isn't owned by a project until it's attached — drag-to-attach already hit-tested by session cell across projects.

- **`ScreenshotThumbnail.tsx`** — the floating variant shows all pending shots; the `focus` variant stays project-scoped. `projectId` becomes the attach target (nullable), with each card falling back to its own origin project.
- **`projects.$id.tsx`** — removed the per-project mount + now-unused import (capture handler, hotkey, and camera button stay).
- **`__root.tsx`** — mounted the stack once in the `Shell` (which early-returns for focus mode, so the focus window keeps its own scoped stack), using the current route's project as the attach target.

Now: capture in project A → switch to project B → the card is still there; drag it onto any B session, or hit the `+` to attach to B's active session.

## Notes

- **Attach-button semantics**: the plain-click / `+` path follows the *currently viewed* project's active session (fallback to the shot's origin when on no project route). Drag-and-drop is unambiguous (drops on the session under the cursor).
- Out of scope: a per-card project badge and a soft cap on the pile — potential polish if the global stack ever feels cluttered.

## Verification

- `tsc --noEmit`, `eslint` on the 3 files, and `vitest` (547 tests in `src/lib/__tests__`) all pass.
- Runtime is macOS + Electron only; manual pass: capture in A, switch to B, confirm the card persists and attaches; focus mode still shows its own scoped stack.