### PR TITLE
fix(pet): harden persistence and alert reconciliation after E2E audit

### DIFF
--- a/src/lib/pet/pet-store.test.ts
+++ b/src/lib/pet/pet-store.test.ts
@@ -953,3 +953,119 @@ describe("level progression: evolve + molt", () => {
     expect(getPetPersistentState()!.species).toBe("ember");
   });
 });
+
+describe("stale question reconciliation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Later than every earlier suite — the module-level rate limiter carries
+    // real timestamps across suites, so the clock must only move forward.
+    vi.setSystemTime(new Date(2026, 6, 29, 10, 0, 0));
+  });
+  afterEach(() => {
+    petSetEnabled(false, true, false);
+    vi.useRealTimers();
+  });
+
+  it("clears a question whose cleared/deleted event never arrived once aggregates repeatedly say zero", () => {
+    petHydrate(null);
+    petSetEnabled(true, true, false);
+    vi.advanceTimersByTime(700_000);
+
+    petIngestServerEvent({
+      type: "task:question",
+      taskId: "t-lost",
+      projectId: "p1",
+    } as never);
+    expect(getPetSnapshot().mood).toBe("alert");
+
+    // One or two zero reports must NOT cull it — aggregates can lag a fresh
+    // question by a refetch.
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+    expect(getPetSnapshot().mood).toBe("alert");
+
+    // The third consecutive authoritative zero means the id is stale.
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+    vi.advanceTimersByTime(MOOD_DEBOUNCE_MS + 100);
+    expect(getPetSnapshot().mood).not.toBe("alert");
+    expect(getPetSnapshot().alert).toBeNull();
+  });
+
+  it("a non-zero report resets the stale counter", () => {
+    petHydrate(null);
+    petSetEnabled(true, true, false);
+    vi.advanceTimersByTime(700_000);
+
+    petIngestServerEvent({
+      type: "task:question",
+      taskId: "t-live",
+      projectId: "p1",
+    } as never);
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+    // The aggregates catch up — the question is real after all.
+    petSetAggregates({ running: 0, needsInput: 1, interrupted: 0 });
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+    expect(getPetSnapshot().mood).toBe("alert");
+
+    // Clean up module-level state for later suites.
+    petIngestServerEvent({ type: "task:question-cleared", taskId: "t-live" } as never);
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+  });
+
+  it("a fresh question event restarts the stale count", () => {
+    petHydrate(null);
+    petSetEnabled(true, true, false);
+    vi.advanceTimersByTime(700_000);
+
+    petIngestServerEvent({ type: "task:question", taskId: "t-a", projectId: "p1" } as never);
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+    petIngestServerEvent({ type: "task:question", taskId: "t-b", projectId: "p1" } as never);
+    // Two zero reports predate t-b; it must get a full window of its own.
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+    expect(getPetSnapshot().mood).toBe("alert");
+
+    petIngestServerEvent({ type: "task:question-cleared", taskId: "t-a" } as never);
+    petIngestServerEvent({ type: "task:question-cleared", taskId: "t-b" } as never);
+    petSetAggregates({ running: 0, needsInput: 0, interrupted: 0 });
+  });
+});
+
+describe("molt announcement preempts a visible bubble", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 30, 15, 0, 0));
+  });
+  afterEach(() => {
+    petSetEnabled(false, true, false);
+    vi.useRealTimers();
+  });
+
+  it("the molt line replaces whatever bubble is still up instead of being dropped", () => {
+    petHydrate(null);
+    petSetEnabled(true, true, false);
+    vi.advanceTimersByTime(700_000);
+
+    // Reach the cap, aging each PR bubble out along the way.
+    while (getPetPersistentState()!.xp < 3_000) {
+      petShipResult("pr-created");
+      vi.advanceTimersByTime(30_000);
+    }
+    expect(getPetPersistentState()!.level).toBe(PET_MAX_LEVEL);
+    vi.advanceTimersByTime(600_000); // clear cooldown/bucket residue
+
+    // Put a fresh bubble on screen (petting bypasses a full bucket)…
+    petInteract();
+    const before = getPetSnapshot().bubble;
+    expect(before).not.toBeNull();
+
+    // …and molt while it is still visible. The announcement of the pet's
+    // rarest event must preempt, not silently vanish behind the petting line.
+    expect(petMolt()).toBe(true);
+    const bubble = getPetSnapshot().bubble;
+    expect(bubble).not.toBeNull();
+    expect(bubble!.id).not.toBe(before!.id);
+  });
+});

--- a/src/lib/pet/pet-store.ts
+++ b/src/lib/pet/pet-store.ts
@@ -314,6 +314,14 @@ let heldByUser = false;
 // question events maintain their own live set; needs-input uses whichever is
 // larger.
 const questionTaskIds = new Set<string>();
+// The set is pruned by task:question-cleared / task:deleted / a tool run — but
+// those all arrive over SSE, so a dropped event (reconnect gap) would leave the
+// pet alert forever. The aggregates are authoritative once refetched: after
+// this many consecutive zero needs-input reports with the set still non-empty,
+// the entries are stale — clear them. (>1 so a fresh question isn't culled by
+// a refetch that raced in before its status landed.)
+const STALE_QUESTION_ZERO_REPORTS = 3;
+let staleQuestionZeroReports = 0;
 let aggregateNeedsInput = 0;
 let aggregateInterrupted = 0;
 // prompt:submitted timestamps, so session:finished can tell a long run.
@@ -634,8 +642,12 @@ function schedulePulseExpiry(now: number): void {
 function say(trigger: PetTrigger, opts?: { key?: string }): boolean {
   if (!enabled || !messagesEnabled || !persistent) return false;
   const priority = TRIGGER_PRIORITY[trigger];
-  // A visible bubble blocks new lines; only critical preempts it.
-  if (bubble && priority !== "critical") return false;
+  // A visible bubble blocks new lines; only critical preempts it — plus the
+  // molt announcement: it answers an explicit user action and is rare enough
+  // that dropping it behind whatever line is still up (typically the level-10
+  // one) would read as a silent no-op. Plain level-up/evolve stay blocked on
+  // purpose: the finish's story (comeback, milestone) outranks them.
+  if (bubble && priority !== "critical" && trigger !== "molt") return false;
   if (!limiter.allow(trigger, opts?.key)) return false;
   const favorite = favoriteProjectOf(persistent.projectXp);
   const text = pickLine(trigger, persistent.personality, {
@@ -773,6 +785,22 @@ export function petSetEnabled(
     statsOpen = false;
     alertWalkX = null;
     heldByUser = false;
+    // A disabled pet should cost nothing: stop the ambient loops and any
+    // in-flight one-shot timers. ensureClock/ensureBehaviorLoop re-arm on
+    // the next enable.
+    if (clockTimer !== null) {
+      clearInterval(clockTimer);
+      clockTimer = null;
+    }
+    if (behaviorTimer !== null) {
+      clearInterval(behaviorTimer);
+      behaviorTimer = null;
+    }
+    for (const timer of [pendingTimer, pulseTimer, watchTimer, arriveTimer, flourishTimer]) {
+      if (timer !== null) clearTimeout(timer);
+    }
+    pendingTimer = pulseTimer = watchTimer = arriveTimer = flourishTimer = null;
+    pendingMood = null;
   }
   invalidate();
 }
@@ -859,6 +887,7 @@ export function petIngestServerEvent(event: ServerEvent): void {
       const projectId = typeof event.projectId === "string" ? event.projectId : "";
       if (!taskId || !projectId) return;
       questionTaskIds.add(taskId);
+      staleQuestionZeroReports = 0;
       alert = { taskId, projectId };
       recompute();
       say("needs-input", { key: taskId });
@@ -1039,6 +1068,19 @@ export function petSetAggregates(counts: {
   inputs.runningCount = counts.running;
   aggregateNeedsInput = counts.needsInput;
   aggregateInterrupted = counts.interrupted;
+  // Reconcile against dropped SSE events: enough consecutive authoritative
+  // "nothing needs input" reports mean the tracked question ids are stale
+  // (their cleared/deleted events never arrived) — without this the pet stays
+  // alert forever on a task that already resumed or vanished.
+  if (counts.needsInput === 0 && questionTaskIds.size > 0) {
+    staleQuestionZeroReports += 1;
+    if (staleQuestionZeroReports >= STALE_QUESTION_ZERO_REPORTS) {
+      staleQuestionZeroReports = 0;
+      questionTaskIds.clear();
+    }
+  } else {
+    staleQuestionZeroReports = 0;
+  }
   if (aggregateNeedsInput === 0 && questionTaskIds.size === 0) {
     alert = null;
     clearAlertWalk();

--- a/src/server/__tests__/settings-api.test.ts
+++ b/src/server/__tests__/settings-api.test.ts
@@ -1013,7 +1013,40 @@ describe("settings API", () => {
     expect(await jsonBody(read!)).toMatchObject({ petEnabled: false, petState: expected });
   });
 
-  it("clears stored pet state when sent garbage", async () => {
+  it("rejects garbage pet state instead of erasing the stored pet", async () => {
+    await handleApiRequest(
+      authedRequest("http://localhost/api/settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          petState: {
+            version: 1,
+            name: "Pixel",
+            xp: 10,
+            level: 1,
+            personality: { snark: 1, wisdom: 1, chaos: 1, zen: 1 },
+            createdAt: 1700000000000,
+          },
+        }),
+      }),
+    );
+    const rejected = await handleApiRequest(
+      authedRequest("http://localhost/api/settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ petState: "not a pet" }),
+      }),
+    );
+    const read = await handleApiRequest(authedRequest("http://localhost/api/settings"));
+
+    // A malformed write must never destroy the pet — only an explicit null may.
+    expect(rejected?.status).toBe(400);
+    expect(await jsonBody(read!)).toMatchObject({
+      petState: { name: "Pixel", xp: 10 },
+    });
+  });
+
+  it("clears stored pet state on an explicit null", async () => {
     await handleApiRequest(
       authedRequest("http://localhost/api/settings", {
         method: "POST",
@@ -1034,13 +1067,66 @@ describe("settings API", () => {
       authedRequest("http://localhost/api/settings", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ petState: "not a pet" }),
+        body: JSON.stringify({ petState: null }),
       }),
     );
     const read = await handleApiRequest(authedRequest("http://localhost/api/settings"));
 
     expect(cleared?.status).toBe(200);
     expect(await jsonBody(read!)).toMatchObject({ petState: null });
+  });
+
+  it("a stale window's write cannot revert a molt or shrink progression", async () => {
+    const personality = { snark: 1, wisdom: 1, chaos: 1, zen: 1 };
+    // Window A persisted a molt: prestige 1, fresh xp, ember unlocked.
+    await handleApiRequest(
+      authedRequest("http://localhost/api/settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          petState: {
+            version: 1,
+            name: "Zezo",
+            species: "ember",
+            xp: 5,
+            prestige: 1,
+            personality,
+            stats: { sessions: 12, longSessions: 0, ships: 3, prs: 1, memories: 0, failures: 2, worstStreak: 2, pets: 20 },
+            createdAt: 1700000000000,
+          },
+        }),
+      }),
+    );
+    // Window B hydrated before the molt and blind-writes its stale copy.
+    const staleWrite = await handleApiRequest(
+      authedRequest("http://localhost/api/settings", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          petState: {
+            version: 1,
+            name: "Zezo",
+            species: "chick",
+            xp: 2980,
+            prestige: 0,
+            personality,
+            stats: { sessions: 11, longSessions: 0, ships: 3, prs: 1, memories: 0, failures: 2, worstStreak: 2, pets: 25 },
+            createdAt: 1700000000000,
+          },
+        }),
+      }),
+    );
+    const read = await handleApiRequest(authedRequest("http://localhost/api/settings"));
+
+    expect(staleWrite?.status).toBe(200);
+    expect(await jsonBody(read!)).toMatchObject({
+      petState: {
+        prestige: 1, // the molt survives
+        xp: 5,
+        species: "chick", // cosmetic choice still follows the latest write
+        stats: { sessions: 12, pets: 25 }, // lifetime counters keep their max
+      },
+    });
   });
 
   // Regression: GET /api/settings used to anonymously return the API bearer

--- a/src/server/controllers/settings.controller.ts
+++ b/src/server/controllers/settings.controller.ts
@@ -82,8 +82,9 @@ import {
 } from "~/shared/session-header-buttons";
 import { readRecallSettings, writeRecallSettings } from "../services/recall-settings";
 import { DEFAULT_SHIP_PROMPT, normalizeShipPrompt } from "~/shared/ship-defaults";
-import { normalizePetState } from "~/shared/pet";
-import { json, parseJsonBody } from "./_helpers";
+import { mergePetStateWrite, normalizePetState } from "~/shared/pet";
+import { HTTP_BAD_REQUEST } from "~/shared/http-status";
+import { json, jsonError, parseJsonBody } from "./_helpers";
 
 const COMMIT_CLI_SETTING_KEY = "commit_cli";
 const DEFAULT_AGENT_SETTING_KEY = "default_agent";
@@ -247,8 +248,10 @@ const updateSettingsBody = z
     petEnabled: z.boolean(),
     petMessagesEnabled: z.boolean(),
     petSoundsEnabled: z.boolean(),
-    // Garbage in → null → the stored state is cleared (pet re-rolls on next boot).
-    petState: z.unknown().transform((value) => normalizePetState(value)),
+    // Raw on purpose: update() distinguishes an explicit null (reset the pet)
+    // from a payload that fails normalization (rejected — a malformed write
+    // must never erase the stored pet).
+    petState: z.unknown(),
   })
   .partial();
 
@@ -711,7 +714,13 @@ export async function update(request: Request): Promise<Response> {
     if (body.petState === null) {
       deleteSetting(PET_STATE_KEY);
     } else {
-      setSetting(PET_STATE_KEY, JSON.stringify(body.petState));
+      const incoming = normalizePetState(body.petState);
+      if (!incoming) return jsonError(HTTP_BAD_REQUEST, "invalid petState");
+      // Merge against the stored state so a stale renderer window (each holds
+      // its own copy, hydrated once at boot) can't revert a molt, level-up, or
+      // lifetime counters that another window already persisted.
+      const stored = normalizePetState(safeJsonParse<unknown>(getSetting(PET_STATE_KEY), null));
+      setSetting(PET_STATE_KEY, JSON.stringify(mergePetStateWrite(stored, incoming)));
     }
   }
   writeRecallSettings({

--- a/src/shared/__tests__/pet.test.ts
+++ b/src/shared/__tests__/pet.test.ts
@@ -9,6 +9,8 @@ import {
   favoriteProjectOf,
   isPetSpeciesUnlocked,
   levelForXp,
+  MAX_PET_XP,
+  mergePetStateWrite,
   moltPetState,
   mulberry32,
   normalizePetState,
@@ -269,5 +271,92 @@ describe("project xp + favorite", () => {
     expect(
       favoriteProjectOf({ a: { name: "Alpha", xp: 25 }, b: { name: "Beta", xp: 20 } }),
     ).toEqual({ projectId: "a", name: "Alpha", xp: 25 });
+  });
+});
+
+describe("MAX_PET_XP clamp", () => {
+  it("clamps absurd xp magnitudes instead of storing them", () => {
+    const state = normalizePetState({
+      ...createDefaultPetState(),
+      xp: 1e300,
+    })!;
+    expect(state.xp).toBe(MAX_PET_XP);
+    expect(state.level).toBe(PET_MAX_LEVEL);
+  });
+});
+
+describe("mergePetStateWrite", () => {
+  const base = () => {
+    const s = createDefaultPetState(1_000);
+    return { ...s, name: "Zezo" };
+  };
+
+  it("adopts the incoming state when nothing is stored", () => {
+    const incoming = base();
+    expect(mergePetStateWrite(null, incoming)).toBe(incoming);
+  });
+
+  it("a lower-prestige write cannot revert a molt — only identity fields land", () => {
+    const stored = { ...base(), prestige: 1, xp: 40, level: levelForXp(40), species: "ember" as const };
+    const incoming = { ...base(), prestige: 0, xp: 900, level: levelForXp(900), name: "Renamed", size: "l" as const, species: "bunny" as const };
+    const merged = mergePetStateWrite(stored, incoming);
+    expect(merged.prestige).toBe(1);
+    expect(merged.xp).toBe(40);
+    expect(merged.level).toBe(levelForXp(40));
+    // The freely-editable identity bits still follow the write.
+    expect(merged.name).toBe("Renamed");
+    expect(merged.size).toBe("l");
+    expect(merged.species).toBe("bunny");
+  });
+
+  it("a lower-prestige write keeps a species that the stored prestige has unlocked", () => {
+    // The stale window legitimately wears ember (unlocked by the STORED
+    // prestige, even though the writer's own prestige is lower).
+    const merged = mergePetStateWrite(
+      { ...base(), prestige: 2, species: "ember" as const },
+      { ...base(), prestige: 1, species: "ember" as const },
+    );
+    expect(merged.species).toBe("ember");
+    expect(merged.prestige).toBe(2);
+  });
+
+  it("a higher-prestige write wins wholesale", () => {
+    const stored = { ...base(), prestige: 0, xp: 2900, level: levelForXp(2900) };
+    const incoming = { ...base(), prestige: 1, xp: 0, level: 1 };
+    expect(mergePetStateWrite(stored, incoming)).toBe(incoming);
+  });
+
+  it("same prestige: xp and lifetime counters never decrease", () => {
+    const stored = base();
+    stored.xp = 120;
+    stored.level = levelForXp(120);
+    stored.stats = { ...stored.stats, sessions: 10, pets: 4 };
+    const incoming = base();
+    incoming.xp = 90;
+    incoming.level = levelForXp(90);
+    incoming.stats = { ...incoming.stats, sessions: 7, pets: 6, ships: 2 };
+    const merged = mergePetStateWrite(stored, incoming);
+    expect(merged.xp).toBe(120);
+    expect(merged.level).toBe(levelForXp(120));
+    expect(merged.stats.sessions).toBe(10);
+    expect(merged.stats.pets).toBe(6);
+    expect(merged.stats.ships).toBe(2);
+  });
+
+  it("same week merges counters per-field; project affection unions with per-project max", () => {
+    const stored = base();
+    stored.weekly = { ...stored.weekly, sessions: 3, ships: 1 };
+    stored.projectXp = { a: { name: "alpha", xp: 30 }, b: { name: "beta", xp: 5 } };
+    const incoming = base();
+    incoming.weekly = { ...incoming.weekly, sessions: 2, ships: 4 };
+    incoming.projectXp = { a: { name: "alpha", xp: 10 }, c: { name: "gamma", xp: 8 } };
+    const merged = mergePetStateWrite(stored, incoming);
+    expect(merged.weekly.sessions).toBe(3);
+    expect(merged.weekly.ships).toBe(4);
+    expect(merged.projectXp).toEqual({
+      a: { name: "alpha", xp: 30 },
+      b: { name: "beta", xp: 5 },
+      c: { name: "gamma", xp: 8 },
+    });
   });
 });

--- a/src/shared/pet.ts
+++ b/src/shared/pet.ts
@@ -130,6 +130,13 @@ const LEVEL_THRESHOLDS = [0, 50, 150, 300, 500, 800, 1200, 1700, 2300, 3000] as 
 export const PET_MAX_LEVEL = LEVEL_THRESHOLDS.length;
 
 /**
+ * Ceiling on persisted XP. Real work can't get anywhere near this within one
+ * prestige (the cap sits at 3000), so anything larger is a corrupt or
+ * hand-edited payload — clamp it instead of storing absurd magnitudes.
+ */
+export const MAX_PET_XP = 1_000_000;
+
+/**
  * Levels where the sprite gains a permanent visible detail: the growing
  * sparkle at 3, a scarf at 5, a tool belt at 8, a tiny crown at the cap.
  * The store announces these with their own trigger instead of the plain
@@ -381,7 +388,7 @@ export function normalizePetState(value: unknown): PetPersistentState | null {
 
   const xpRaw = raw.xp;
   if (typeof xpRaw !== "number" || !Number.isFinite(xpRaw)) return null;
-  const xp = Math.max(0, Math.floor(xpRaw));
+  const xp = Math.min(MAX_PET_XP, Math.max(0, Math.floor(xpRaw)));
 
   const name =
     typeof raw.name === "string" && raw.name.trim()
@@ -425,6 +432,86 @@ export function normalizePetState(value: unknown): PetPersistentState | null {
     stats: normalizeLifetimeStats(raw.stats),
     weekly: normalizeWeeklyStats(raw.weekly, Date.now()),
     projectXp: normalizeProjectXp(raw.projectXp),
+    createdAt,
+  };
+}
+
+/**
+ * Guard a full-state write against a stale writer. Every renderer window
+ * (main shell, focus mode) holds its own copy of the pet, hydrated once at
+ * boot, and blind-writes it back on change — so a window that hydrated before
+ * a molt or a level-up in another window would revert that progression
+ * wholesale. Progression is monotonic within a life, so merge accordingly:
+ *
+ * - prestige only ever climbs; a lower-prestige write is a stale window, keep
+ *   the stored progression and adopt only its freely-editable identity bits.
+ * - at equal prestige, XP only accrues, so the larger XP wins; lifetime
+ *   counters never decrease, so take the per-field max.
+ * - name and size follow the incoming write (the settings page edits them);
+ *   species follows it too when the unlock allows.
+ */
+export function mergePetStateWrite(
+  stored: PetPersistentState | null,
+  incoming: PetPersistentState,
+): PetPersistentState {
+  if (!stored) return incoming;
+  // A molt just landed: the molter's write is the new truth wholesale.
+  if (incoming.prestige > stored.prestige) return incoming;
+
+  // Lifetime counters survive molts, so they merge per-field regardless of
+  // which side's prestige wins.
+  const stats = { ...incoming.stats };
+  for (const key of Object.keys(stats) as (keyof PetLifetimeStats)[]) {
+    stats[key] = Math.max(stats[key], stored.stats[key]);
+  }
+  // Same week: counters only accrue, take the max; otherwise the newer
+  // weekStart's counters win.
+  let weekly = incoming.weekly;
+  if (stored.weekly.weekStart === incoming.weekly.weekStart) {
+    weekly = {
+      weekStart: incoming.weekly.weekStart,
+      sessions: Math.max(stored.weekly.sessions, incoming.weekly.sessions),
+      ships: Math.max(stored.weekly.ships, incoming.weekly.ships),
+      prs: Math.max(stored.weekly.prs, incoming.weekly.prs),
+      failures: Math.max(stored.weekly.failures, incoming.weekly.failures),
+    };
+  } else if (stored.weekly.weekStart > incoming.weekly.weekStart) {
+    weekly = stored.weekly;
+  }
+  // Project affection only accrues too — union, per-project max.
+  const projectXp: PetProjectXp = { ...incoming.projectXp };
+  for (const [projectId, entry] of Object.entries(stored.projectXp)) {
+    const mine = projectXp[projectId];
+    if (!mine || entry.xp > mine.xp) projectXp[projectId] = entry;
+  }
+  const createdAt = Math.min(stored.createdAt, incoming.createdAt);
+
+  if (incoming.prestige < stored.prestige) {
+    // Stale window: keep the stored progression (prestige, xp, level); adopt
+    // only the freely-editable identity bits and the merged accruals.
+    const species = isPetSpeciesUnlocked(incoming.species, stored.prestige)
+      ? incoming.species
+      : stored.species;
+    return {
+      ...stored,
+      name: incoming.name,
+      size: incoming.size,
+      species,
+      stats,
+      weekly,
+      projectXp,
+      createdAt,
+    };
+  }
+
+  const xp = Math.max(stored.xp, incoming.xp);
+  return {
+    ...incoming,
+    xp,
+    level: levelForXp(xp),
+    stats,
+    weekly,
+    projectXp,
     createdAt,
   };
 }


### PR DESCRIPTION
Follow-ups to the Mission Pet end-to-end test pass run against #100 after it merged. All issues below were reproduced live (dev build, real hook pipeline over HTTP + SSE) before being fixed.

## Fixes

### Multi-window writes could erase progression (High)
Every renderer window (main shell, focus mode) holds its own copy of the pet, hydrates once at boot, and blind-writes `petState` back on change. A window that hydrated before a molt reverted the molt, species unlock, and XP with its next debounced save — reproduced live: `ember / prestige 1` was overwritten back to `chick / prestige 0`.

**Fix:** `mergePetStateWrite()` (in `src/shared/pet.ts`, applied server-side in the settings controller). Prestige is monotonic — a lower-prestige write keeps the stored progression and only lands identity edits (name, size, species where unlocked). At equal prestige, XP takes the max; lifetime/weekly counters and per-project XP merge per-field max.

### Malformed `petState` deleted the stored pet (Medium)
The zod `transform(normalizePetState)` turned any invalid payload into `null`, and `null` meant "delete the row" — one bad field destroyed the whole identity. Now an invalid payload is rejected with 400 and the stored pet is untouched; only an explicit `null` resets.

### Pet stuck permanently alert after a dropped SSE event (Medium)
`questionTaskIds` was only pruned by `task:question-cleared` / `task:deleted` / a tool run — all SSE-delivered. A missed clear (reconnect gap) left `needsInputCount = max(0, 1)` forever. Now three consecutive authoritative zero needs-input aggregate reports prune the stale ids; any question event or non-zero report resets the counter, so a fresh question racing a refetch can't be culled.

### Molt announcement silently dropped (Low)
`say("molt")` was blocked by whatever bubble was still visible (typically the level-10 line). The molt line now preempts like critical lines do. Level-up/evolve deliberately stay blocked — the existing tests pin that a finish's story (comeback, milestone) outranks them.

### Smaller
- Clamp persisted XP to `MAX_PET_XP` (1e300 was previously accepted and stored).
- Disabling the pet now clears the ambient clock/behavior intervals and pending one-shot timers instead of leaving them ticking; they re-arm on enable.

## Tests
10 new tests: merge-guard semantics (5), XP clamp, reject-vs-explicit-null server behavior (3, one inverted from the old pinned wipe behavior), stale-alert pruning (3), molt-preempt. Full suite: **195 files / 1,836 tests passing**; `tsc --noEmit` (app + electron) and eslint clean.