### PR TITLE
feat(pet): settings field guide + make the sleep command a real nap

### DIFF
--- a/src/components/pet/PetGuideModal.tsx
+++ b/src/components/pet/PetGuideModal.tsx
@@ -1,0 +1,315 @@
+import type { CSSProperties, ReactNode } from "react";
+import { Modal } from "~/components/ui/Modal";
+import { Icon } from "~/components/ui/Icon";
+import {
+  DEFAULT_PET_NAME,
+  PET_MAX_LEVEL,
+  PET_EVOLUTION_LEVELS,
+  PET_DRIFT_LIMIT,
+  xpForNextLevel,
+} from "~/shared/pet";
+import { PET_XP_AWARDS } from "~/lib/pet/pet-store";
+
+/**
+ * "How the pet works" — a field guide opened from the Mission Pet settings.
+ * Everything here reads from the same constants the store grants from
+ * (PET_XP_AWARDS, level thresholds via xpForNextLevel), so the numbers shown
+ * are always the numbers in effect.
+ */
+
+const XP_SOURCES: ReadonlyArray<{ label: string; detail: string; xp: number }> = [
+  { label: "PR created", detail: "An agent opens a pull request", xp: PET_XP_AWARDS.prCreated },
+  { label: "Ship success", detail: "A push lands cleanly", xp: PET_XP_AWARDS.shipSuccess },
+  {
+    label: "Long session",
+    detail: "A finished session that ran long",
+    xp: PET_XP_AWARDS.sessionFinishedLong,
+  },
+  {
+    label: "Session finished",
+    detail: "Any agent session wraps up",
+    xp: PET_XP_AWARDS.sessionFinished,
+  },
+  {
+    label: "Memory learned",
+    detail: "Recall saves a new project fact",
+    xp: PET_XP_AWARDS.memoryLearned,
+  },
+  { label: "Petting", detail: "Click the pet (rate-limited — no farming)", xp: PET_XP_AWARDS.petting },
+];
+
+const TRAITS: ReadonlyArray<{ name: string; flavor: string; grows: string }> = [
+  {
+    name: "Snark",
+    flavor: "Dry, sarcastic lines",
+    grows: "Grows by surviving failure streaks — and by being spam-clicked dizzy.",
+  },
+  {
+    name: "Wisdom",
+    flavor: "Practical, advice-flavored lines",
+    grows: "Grows each time Recall learns a new memory.",
+  },
+  {
+    name: "Chaos",
+    flavor: "Absurdist lines",
+    grows: "Grows when you run a whole fleet of agents at once.",
+  },
+  {
+    name: "Zen",
+    flavor: "Calm, understated lines",
+    grows: "Grows through long sessions and marathon uptimes.",
+  },
+];
+
+function interactionsFor(name: string): ReadonlyArray<{ action: string; result: ReactNode }> {
+  return [
+    {
+      action: "Click",
+      result:
+        "Pet it — hearts, a line, a trickle of XP. If a session is blocked, the click jumps you to it instead.",
+    },
+    {
+      action: "Right-click",
+      result: "Open the stats card — level, XP, personality, lifetime counters.",
+    },
+    {
+      action: "Call its name",
+      result: (
+        <>
+          Mention it in any session prompt — <Quote>{name}, show your stats</Quote> opens the
+          stats card. It also answers to <Quote>dance</Quote>, <Quote>sing</Quote>, and{" "}
+          <Quote>sleep</Quote> — a short nap that agent chatter can&apos;t interrupt; only a
+          blocked session (or petting it) wakes it early.
+        </>
+      ),
+    },
+    { action: "Hold + rub", result: "Stroke it. It notices." },
+    { action: "Drag", result: "Pick it up and toss it. It sits dazed where it lands, then trots home." },
+  ];
+}
+
+/** An inline "type this" phrase — mono and slightly lifted off the prose. */
+function Quote({ children }: { children: ReactNode }) {
+  return (
+    <span
+      style={{
+        fontFamily: "var(--mono)",
+        fontSize: 11,
+        color: "var(--text)",
+        background: "var(--surface-2)",
+        border: "1px solid var(--border)",
+        borderRadius: 4,
+        padding: "1px 5px",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+const sectionTitleStyle: CSSProperties = {
+  fontFamily: "var(--mono)",
+  fontSize: 11,
+  fontWeight: 600,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--text-dim)",
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+};
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <div style={sectionTitleStyle}>{title}</div>
+      {children}
+    </section>
+  );
+}
+
+function XpBadge({ xp }: { xp: number }) {
+  return (
+    <span
+      style={{
+        fontFamily: "var(--mono)",
+        fontSize: 11,
+        fontWeight: 600,
+        color: "var(--accent)",
+        background: "var(--accent-faint)",
+        borderRadius: 4,
+        padding: "2px 6px",
+        whiteSpace: "nowrap",
+      }}
+    >
+      +{xp} xp
+    </span>
+  );
+}
+
+/** The ten levels as a track: cumulative XP under each, evolutions marked. */
+function LevelTrack() {
+  const levels = Array.from({ length: PET_MAX_LEVEL }, (_, i) => {
+    const level = i + 1;
+    // Cumulative XP required to reach this level (level 1 is free).
+    const threshold = level === 1 ? 0 : (xpForNextLevel(level - 1) ?? 0);
+    return { level, threshold, evolves: PET_EVOLUTION_LEVELS.has(level) };
+  });
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${PET_MAX_LEVEL}, 1fr)`,
+        gap: 3,
+      }}
+    >
+      {levels.map(({ level, threshold, evolves }) => (
+        <div
+          key={level}
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 4,
+            padding: "6px 2px",
+            borderRadius: 6,
+            border: `1px solid ${evolves ? "var(--accent)" : "var(--border)"}`,
+            background: evolves ? "var(--accent-faint)" : "transparent",
+          }}
+          title={
+            level === PET_MAX_LEVEL
+              ? "Max level — the pet may molt"
+              : evolves
+                ? "Evolution — a permanent new detail"
+                : undefined
+          }
+        >
+          <span
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 11,
+              fontWeight: 600,
+              color: evolves ? "var(--accent)" : "var(--text)",
+            }}
+          >
+            {level === PET_MAX_LEVEL ? "★" : level}
+          </span>
+          <span style={{ fontFamily: "var(--mono)", fontSize: 9, color: "var(--text-dim)" }}>
+            {threshold}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function PetGuideModal({
+  open,
+  onClose,
+  petName,
+}: {
+  open: boolean;
+  onClose: () => void;
+  /** The pet's current name, used in the "call its name" example. */
+  petName?: string;
+}) {
+  const interactions = interactionsFor(petName?.trim() || DEFAULT_PET_NAME);
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      width={560}
+      title={
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+          <Icon name="sparkles" size={13} />
+          How the pet works
+        </span>
+      }
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 22, fontSize: 12.5, lineHeight: 1.55 }}>
+        <p style={{ margin: 0, color: "var(--text-dim)" }}>
+          The pet has no care chores — your work is its life. It earns XP only from real agent
+          activity, and its character is shaped by how your sessions tend to go.
+        </p>
+
+        <Section title="Interacting">
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {interactions.map(({ action, result }) => (
+              <div key={action} style={{ display: "flex", gap: 10, alignItems: "baseline" }}>
+                <span
+                  style={{
+                    fontFamily: "var(--mono)",
+                    fontSize: 11,
+                    fontWeight: 600,
+                    minWidth: 96,
+                    flexShrink: 0,
+                    color: "var(--text)",
+                  }}
+                >
+                  {action}
+                </span>
+                <span style={{ color: "var(--text-dim)" }}>{result}</span>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <Section title="Earning XP">
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {XP_SOURCES.map(({ label, detail, xp }) => (
+              <div key={label} style={{ display: "flex", gap: 10, alignItems: "baseline" }}>
+                <XpBadge xp={xp} />
+                <span style={{ fontWeight: 600 }}>{label}</span>
+                <span style={{ color: "var(--text-dim)" }}>— {detail}</span>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <Section title={`Levels 1–${PET_MAX_LEVEL}`}>
+          <LevelTrack />
+          <p style={{ margin: 0, color: "var(--text-dim)" }}>
+            The number under each level is the total XP to reach it. Highlighted levels are{" "}
+            <strong style={{ color: "var(--text)" }}>evolutions</strong> — the pet gains a
+            permanent new detail. At level {PET_MAX_LEVEL} it may{" "}
+            <strong style={{ color: "var(--text)" }}>molt</strong>: back to level 1 with a
+            forever ★, everything lived-in kept, and the Ember species unlocked.
+          </p>
+        </Section>
+
+        <Section title="Personality">
+          <p style={{ margin: 0, color: "var(--text-dim)" }}>
+            The four traits are rolled once at hatch (0–10 each) and pick which flavor of
+            lines the pet favors. Experience slowly bends each trait — at most ±
+            {PET_DRIFT_LIMIT} points, over weeks of real work, never an afternoon. A ▲ or ▼
+            on the stats card marks a trait that has drifted from its rolled base.
+          </p>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+            {TRAITS.map(({ name, flavor, grows }) => (
+              <div
+                key={name}
+                style={{
+                  border: "1px solid var(--border)",
+                  borderRadius: 8,
+                  padding: "8px 10px",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 3,
+                }}
+              >
+                <span style={{ fontFamily: "var(--mono)", fontSize: 11, fontWeight: 600 }}>
+                  {name}
+                </span>
+                <span style={{ fontSize: 11, fontStyle: "italic", color: "var(--text-dim)" }}>
+                  {flavor}
+                </span>
+                <span style={{ fontSize: 11, color: "var(--text-dim)" }}>{grows}</span>
+              </div>
+            ))}
+          </div>
+        </Section>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/views/GeneralSettingsPage.tsx
+++ b/src/components/views/GeneralSettingsPage.tsx
@@ -51,6 +51,7 @@ import {
 } from "~/shared/pet";
 import { petRename, petSetSize, petSetSpecies, usePetSnapshot } from "~/lib/pet/pet-store";
 import { PET_SPECIES } from "~/components/pet/PetSprite";
+import { PetGuideModal } from "~/components/pet/PetGuideModal";
 import { TextField } from "~/components/ui/TextField";
 
 export function GeneralSettingsPage() {
@@ -76,6 +77,7 @@ export function GeneralSettingsPage() {
   const petSoundsEnabled = settings?.petSoundsEnabled ?? false;
   const petState = settings?.petState ?? null;
   const [petNameDraft, setPetNameDraft] = useState("");
+  const [petGuideOpen, setPetGuideOpen] = useState(false);
 
   useEffect(() => {
     setPetNameDraft(petState?.name ?? "");
@@ -426,6 +428,22 @@ export function GeneralSettingsPage() {
         title="Mission Pet"
         subtitle="An ambient companion that reacts to real agent activity — no care chores, your work is its life."
       >
+        <Field label="Guide">
+          <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+            <Btn variant="frame" size="sm" icon="info" onClick={() => setPetGuideOpen(true)}>
+              How the pet works
+            </Btn>
+            <div style={{ fontSize: 12, color: "var(--text-dim)", lineHeight: 1.5 }}>
+              XP sources, levels &amp; evolutions, molting, and personality drift — plus a tip:
+              right-click the pet anytime for its live stats card.
+            </div>
+          </div>
+        </Field>
+        <PetGuideModal
+          open={petGuideOpen}
+          onClose={() => setPetGuideOpen(false)}
+          petName={petState?.name}
+        />
         <Field label="Pet">
           <ToggleRow
             title="Show pet"

--- a/src/lib/pet/pet-store.test.ts
+++ b/src/lib/pet/pet-store.test.ts
@@ -39,6 +39,7 @@ function inputs(overrides: Partial<PetInputs> = {}): PetInputs {
     lastKeyAt: 0,
     lastActivityAt: NOW,
     hiddenSince: null,
+    napUntil: 0,
     ...overrides,
   };
 }
@@ -98,6 +99,26 @@ describe("resolvePetMood priority", () => {
   it("recent keystrokes read as watching, decaying after 8s", () => {
     expect(resolvePetMood(inputs({ lastKeyAt: NOW - 3_000 }), NOW).mood).toBe("watching");
     expect(resolvePetMood(inputs({ lastKeyAt: NOW - 9_000 }), NOW).mood).toBe("idle");
+  });
+
+  it("a commanded nap sleeps through work chatter — running, celebrating, watching", () => {
+    // The exact churn that follows a "sleep" prompt: the agent responds
+    // (running), the session finishes (celebrate pulse), keys were just hit.
+    const napping = {
+      napUntil: NOW + 60_000,
+      runningCount: 2,
+      celebrateUntil: NOW + 5_000,
+      lastKeyAt: NOW,
+      shippingActive: true,
+    };
+    expect(resolvePetMood(inputs(napping), NOW).mood).toBe("sleeping");
+    // Only a blocked session or a startle interrupts the nap.
+    expect(resolvePetMood(inputs({ ...napping, needsInputCount: 1 }), NOW).mood).toBe("alert");
+    expect(resolvePetMood(inputs({ ...napping, startleUntil: NOW + 1_000 }), NOW).mood).toBe(
+      "startled",
+    );
+    // An expired nap resolves normally again.
+    expect(resolvePetMood(inputs({ ...napping, napUntil: NOW - 1 }), NOW).mood).toBe("shipping");
   });
 
   it("sleeps after 5 minutes without activity or 60s hidden", () => {

--- a/src/lib/pet/pet-store.ts
+++ b/src/lib/pet/pet-store.ts
@@ -164,6 +164,8 @@ export type PetInputs = {
   lastKeyAt: number;
   lastActivityAt: number;
   hiddenSince: number | null;
+  /** A commanded nap ("Pixel, sleep") holds until this passes — see PET_NAP_MS. */
+  napUntil: number;
 };
 
 export const MOOD_DEBOUNCE_MS = 1_200;
@@ -172,6 +174,13 @@ const IDLE_AFTER_MS = 5 * 60_000;
 const HIDDEN_SLEEP_AFTER_MS = 60_000;
 const CELEBRATE_MS = 5_000;
 const STARTLE_MS = 3_000;
+/**
+ * How long a commanded nap ("Pixel, sleep") lasts. Long enough to be a real
+ * state — the agent answering and the session finishing must not wake it
+ * (that churn is exactly what the command escapes) — short enough that the
+ * pet is back on duty without being poked.
+ */
+export const PET_NAP_MS = 90_000;
 const LONG_RUN_MS = 20 * 60_000;
 const PETTING_XP_COOLDOWN_MS = 60_000;
 const CLOCK_TICK_MS = 30_000;
@@ -207,6 +216,19 @@ const XP_PR_CREATED = 15;
 const XP_MEMORY_LEARNED = 3;
 const XP_PETTING = 1;
 
+/**
+ * XP awards per event, grouped for the settings guide so its numbers can
+ * never drift from what the store actually grants.
+ */
+export const PET_XP_AWARDS = {
+  sessionFinished: XP_SESSION_FINISHED,
+  sessionFinishedLong: XP_SESSION_FINISHED_LONG,
+  shipSuccess: XP_SHIP_SUCCESS,
+  prCreated: XP_PR_CREATED,
+  memoryLearned: XP_MEMORY_LEARNED,
+  petting: XP_PETTING,
+} as const;
+
 /** Cached uncommitted-file count that earns the evening nudge. */
 const UNCOMMITTED_NUDGE_THRESHOLD = 10;
 /** How long a tossed pet sits dazed where it landed before trotting home. */
@@ -230,6 +252,11 @@ export function resolvePetMood(
   const intensity: 1 | 2 | 3 = inputs.runningCount >= 4 ? 3 : inputs.runningCount >= 2 ? 2 : 1;
   if (inputs.needsInputCount > 0) return { mood: "alert", intensity };
   if (now < inputs.startleUntil) return { mood: "startled", intensity };
+  // A commanded nap outranks the work chatter below it: without this the
+  // response to the very prompt that ordered the nap (running → finished →
+  // celebrating) would wake the pet within a second. Only a blocked session
+  // or a startle interrupts.
+  if (now < inputs.napUntil) return { mood: "sleeping", intensity };
   if (inputs.shippingActive) return { mood: "shipping", intensity };
   if (now < inputs.celebrateUntil) return { mood: "celebrating", intensity };
   if (inputs.runningCount > 0) return { mood: "working", intensity };
@@ -280,6 +307,7 @@ const inputs: PetInputs = {
   lastKeyAt: 0,
   lastActivityAt: Date.now(),
   hiddenSince: null,
+  napUntil: 0,
 };
 
 let mood: PetMood = "idle";
@@ -601,6 +629,9 @@ function recompute(): void {
   } else if (now - pendingSince >= MOOD_DEBOUNCE_MS) {
     pendingMood = null;
     commitMood(candidate);
+    // Timed moods that landed through the debounce path (a commanded nap)
+    // still need their expiry re-check scheduled.
+    schedulePulseExpiry(now);
     return;
   }
   if (pendingTimer) clearTimeout(pendingTimer);
@@ -630,7 +661,7 @@ function commitMood(next: { mood: PetMood; intensity: 1 | 2 | 3 }): void {
 }
 
 function schedulePulseExpiry(now: number): void {
-  const until = Math.max(inputs.startleUntil, inputs.celebrateUntil);
+  const until = Math.max(inputs.startleUntil, inputs.celebrateUntil, inputs.napUntil);
   if (until <= now || typeof window === "undefined") return;
   if (pulseTimer) clearTimeout(pulseTimer);
   pulseTimer = setTimeout(() => {
@@ -785,6 +816,7 @@ export function petSetEnabled(
     statsOpen = false;
     alertWalkX = null;
     heldByUser = false;
+    inputs.napUntil = 0;
     // A disabled pet should cost nothing: stop the ambient loops and any
     // in-flight one-shot timers. ensureClock/ensureBehaviorLoop re-arm on
     // the next enable.
@@ -957,22 +989,32 @@ export function petIngestServerEvent(event: ServerEvent): void {
       const snippet = typeof event.snippet === "string" ? event.snippet : "";
       const now = Date.now();
       if (taskId) promptStartedAt.set(taskId, now);
+      // Its own name in the prompt is addressed to the pet, not the agents —
+      // parse it up front so a "sleep" order starts the nap BEFORE the
+      // excited hop below (which it suppresses), not after.
+      const addressed = Boolean(
+        snippet && persistent && mentionsPetName(snippet, persistent.name),
+      );
+      const command = addressed ? parsePetCommand(snippet) : null;
+      // Being addressed by name wakes a napping pet — unless the order IS
+      // the nap. Un-addressed prompts leave the nap alone: it was an
+      // explicit command, and ambient work shouldn't undo it.
+      if (command === "sleep") inputs.napUntil = now + PET_NAP_MS;
+      else if (addressed) inputs.napUntil = 0;
+      const napping = now < inputs.napUntil;
       // Visibly react to the hand-off: count it as fresh activity (wakes a
       // sleeping pet, calls a wanderer home, perks it to "watching") and play
       // an excited hop — the way a companion looks up when you give it a task.
       inputs.lastActivityAt = now;
       inputs.lastKeyAt = now;
       recompute();
-      if (!prefersReducedMotion()) doFlourish(pickExcitedReaction());
-      // Its own name in the prompt is addressed to the pet, not the agents —
-      // it outranks keyword flavor and carries no cooldown. Otherwise
-      // acknowledge: a keyword-flavored line when the snippet matches, or a
-      // generic "on it". The rate limiter keeps rapid sends from each popping
-      // a bubble even though the hop plays every time.
-      if (snippet && persistent && mentionsPetName(snippet, persistent.name)) {
-        // Addressed by name — maybe with a command verb. Commands beat the
-        // plain name-answer: "Pixel, dance" gets a dance, not a "you rang?".
-        const command = parsePetCommand(snippet);
+      if (!prefersReducedMotion() && !napping) doFlourish(pickExcitedReaction());
+      // Commands beat the plain name-answer: "Pixel, dance" gets a dance,
+      // not a "you rang?". Otherwise acknowledge: a keyword-flavored line
+      // when the snippet matches, or a generic "on it". The rate limiter
+      // keeps rapid sends from each popping a bubble even though the hop
+      // plays every time.
+      if (addressed) {
         if (command === "dance") {
           if (!prefersReducedMotion()) doFlourish("dance");
           say("command-dance");
@@ -988,7 +1030,7 @@ export function petIngestServerEvent(event: ServerEvent): void {
         } else {
           say("name-mentioned");
         }
-      } else {
+      } else if (!napping) {
         say((snippet && classifyPromptSnippet(snippet)) || "prompt-sent");
       }
       return;
@@ -1195,6 +1237,11 @@ export function petInteract(): { navigateTo: { taskId: string; projectId: string
   if (!enabled) return { navigateTo: null };
   if (alert && mood === "alert") return { navigateTo: alert };
   const now = Date.now();
+  // A click wakes a commanded nap — physical affection outranks the order.
+  if (inputs.napUntil > now) {
+    inputs.napUntil = 0;
+    recompute();
+  }
   // Spam-clicking overwhelms the pet: it spins out dizzy (startled) instead
   // of endlessly lapping up affection.
   recentPetClicks = recentPetClicks.filter((t) => now - t < DIZZY_WINDOW_MS);
@@ -1262,6 +1309,8 @@ export function petNoteUncommitted(count: number): void {
 export function petGrabbed(visualX: number): void {
   if (!enabled) return;
   heldByUser = true;
+  // Being picked up ends a commanded nap.
+  inputs.napUntil = 0;
   if (arriveTimer) {
     clearTimeout(arriveTimer);
     arriveTimer = null;


### PR DESCRIPTION

<img width="1433" height="894" alt="image" src="https://github.com/user-attachments/assets/48fe97db-104e-45db-9131-cf07c5431608" />

## What

Two things the pet was missing:

### 1. "How the pet works" guide in Settings

None of the pet mechanics (XP, levels, personality) were documented anywhere in-app. Settings → General → Mission Pet now has a **How the pet works** button that opens a field-guide modal:

- **Interacting** — click to pet, right-click for the stats card, call it by name in any session prompt (`Pixel, show your stats` / `dance` / `sing` / `sleep`), hold + rub, drag to toss. The name example uses the pet's actual name.
- **Earning XP** — all six sources with amounts (+15 PR, +10 ship, +8 long session, +5 session, +3 memory, +1 petting).
- **Levels 1–10** — a visual track with cumulative XP under each level, evolution levels (3/5/8/10) highlighted, and the molt/★/Ember explanation at the cap.
- **Personality** — the four traits, that they're rolled once at hatch, drift at most ±2, and what behavior grows each.

The numbers are read from the store's own constants (new `PET_XP_AWARDS` export, `xpForNextLevel`, `PET_EVOLUTION_LEVELS`, `PET_DRIFT_LIMIT`) so the guide can never drift from actual behavior.

### 2. `sleep` command actually sleeps now

`Zezo sleep` only said a goodnight line — it never touched mood, so the churn from that very prompt (agent responds → `working`, session finishes → `celebrating`) visibly overrode the command within a second.

The command now starts a real **90s nap** (`napUntil` input + a mood row above the work-chatter rows). Only a blocked session (alert) or a startle outranks it; clicking the pet, picking it up, or another name command wakes it early. Un-addressed prompts no longer play the excited hop or the "on it" ack while it naps, and the nap expiry is scheduled through the existing pulse-expiry timer.

## Testing

- `tsc --noEmit` (both tsconfigs), eslint clean
- Pet suites: 104 tests pass, including a new `resolvePetMood` priority test reproducing the exact report: nap + running + celebrating + fresh keys → still `sleeping`; alert/startle wake; expired nap resolves normally
- Guide modal + settings trigger visually verified against the dev server