### PR TITLE
fix(pets): settle dragged Mission Pet when pointer capture is lost

### DIFF
--- a/src/components/pet/PetWidget.tsx
+++ b/src/components/pet/PetWidget.tsx
@@ -284,10 +284,11 @@ export function PetWidget() {
     const origin = dragOrigin.current;
     if (!origin || origin.pointerId !== event.pointerId) return;
     // A drag needs a held button. If the release was missed somehow (capture
-    // lost, window switch), drop the stale origin instead of letting plain
-    // hover movement fake a drag.
+    // lost, window switch), settle the pet where it is instead of leaving the
+    // imperative stage transform stuck on screen — then let plain hover
+    // movement stop faking a drag.
     if (event.buttons === 0) {
-      dragOrigin.current = null;
+      if (!endDrag(event)) stopStroking();
       return;
     }
     const rawDx = event.clientX - origin.startX;
@@ -548,6 +549,10 @@ export function PetWidget() {
                 onPointerMove={handlePointerMove}
                 onPointerUp={handlePointerUp}
                 onPointerCancel={handlePointerUp}
+                // A fast drag can make Chromium drop the implicit pointer
+                // capture and fire lostpointercapture *instead of* pointerup —
+                // without this the drag never ends and the pet stays stuck.
+                onLostPointerCapture={handlePointerUp}
                 aria-label={`${pet.name || "Pet"} — ${MOOD_DESCRIPTION[pet.mood]}`}
                 title={`${pet.name || "Pet"} · Lv ${pet.level}${pet.prestige > 0 ? ` ★${pet.prestige}` : ""} · ${MOOD_DESCRIPTION[pet.mood]}`}
                 data-mood={pet.mood}


### PR DESCRIPTION
## Problem

Sometimes when dragging the Mission Pet quickly, it gets stuck frozen on screen at the drop position and won't return.

## Root cause

On a fast drag, Chromium/Electron can drop the implicit pointer capture (the pointer briefly exits the window) and fire `lostpointercapture` **instead of** `pointerup`/`pointercancel`. The drag teardown (`endDrag`) only ran from `pointerup`/`pointercancel`, so when capture was lost mid-drag:

- `dragOrigin.current` stayed set, and
- the imperative `stage.style.transform = translate(dx, dy)` was never cleared or handed to the store

…leaving the pet frozen wherever you let go. The `buttons === 0` fallback in `handlePointerMove` had the same leak — it nulled the origin but left the stuck transform in place.

## Fix

- Add `onLostPointerCapture={handlePointerUp}` so a lost capture finalizes the drag through the same `endDrag` path (settle/toss, clear transform, update store).
- Make the `buttons === 0` fallback in `handlePointerMove` settle the pet via `endDrag` instead of nulling the origin and leaking the transform.

Both paths reuse `endDrag`, which nulls the origin first and is idempotent, so the redundant `lostpointercapture` that always follows a normal `pointerup` is a harmless no-op.

## Verification

`tsc --noEmit` and `eslint` both pass.