### PR TITLE
fix(sessions): focus the terminal when a session is opened or cycled

### DIFF
--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -1942,6 +1942,9 @@ function ProjectPage() {
         const firstByPriority = pickByPriority(visible);
         if (!firstByPriority) return;
         terminals.toggle(terminalProject, firstByPriority);
+        // Focus the terminal so the keyboard drives the newly-opened session
+        // instead of leaving it blurred (see selectTerminal).
+        terminals.focusGridSession(firstByPriority.id);
         return;
       }
       const idx = ordered.findIndex((t) => t.id === currentId);
@@ -1950,6 +1953,9 @@ function ProjectPage() {
       const nextTask = ordered[nextIdx];
       if (!nextTask || nextTask.id === currentId) return;
       terminals.toggle(terminalProject, nextTask);
+      // Carry keyboard focus into the session we cycled to, so successive
+      // presses keep cycling and the caret is ready to type (see selectTerminal).
+      terminals.focusGridSession(nextTask.id);
     },
     [
       project,
@@ -2258,6 +2264,12 @@ function ProjectPage() {
     const task = tasks.find((t) => t.id === taskId);
     if (!task || !terminalProject) return;
     terminals.openSession(terminalProject, task);
+    // Move the caret into the session's terminal so the user can type right
+    // away. Switching to an already-built (cached) surface reattaches without
+    // focusing, so without this the card click selects the session but leaves
+    // the terminal blurred until a second manual click. TerminalPanel consumes
+    // this request and re-asserts focus across the pane remount.
+    terminals.focusGridSession(taskId);
   };
 
   const toggleSessionPinned = async (taskId: string) => {

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -1022,6 +1022,23 @@ function ProjectPage() {
     if (task) rehydrateTerminal(terminalProject, task);
   }, [activeTaskId, terminalProject, tasks, rehydrateTerminal]);
 
+  // The rehydrate above re-shows the active session on a project/worktree switch,
+  // but its cached terminal surface reattaches blurred (it doesn't self-focus),
+  // so the newly-shown session drops keystrokes until a manual click. Re-assert
+  // keyboard focus once per scope switch — guarded by scope so it fires on the
+  // switch (and first mount), not on every task refetch, which would yank the
+  // caret while the user is typing. focusGridSession retries until the pane
+  // mounts and is consumed by both SessionGrid (grid view) and TerminalPanel
+  // (normal view), so a single call covers both layouts.
+  const focusedScopeRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!terminalProject) return;
+    if (focusedScopeRef.current === selectedScopeKey) return;
+    if (!activeTaskId) return;
+    focusedScopeRef.current = selectedScopeKey;
+    terminals.focusGridSession(activeTaskId);
+  }, [selectedScopeKey, terminalProject, activeTaskId, terminals]);
+
   const openRequestedSession = useCallback(
     (request: PendingSessionOpen) => {
       void (async () => {

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -788,10 +788,17 @@ function ProjectPage() {
       // last-focused cell reported to the store (a header-button click moved
       // focus off the grid).
       const focused = readFocusedGridTaskId() ?? terminals.getGridFocusedTaskId();
+      terminals.setGridView(false);
       if (focused && terminalProject && tasks.some((t) => t.id === focused)) {
         terminals.setActiveSession(terminalProject, focused);
+        // setActiveSession only picks which session docks in normal view; the
+        // cached terminal surface reattaches blurred, so without this the pane
+        // is shown but drops keystrokes until a click. Post the focus request
+        // in the same (batched) update that leaves grid view — SessionGrid is
+        // unmounting so it won't consume the nonce; the now-mounting
+        // TerminalPanel picks it up and retries until the pane settles.
+        terminals.focusGridSession(focused);
       }
-      terminals.setGridView(false);
       // List view no longer has the Active/Pinned/Archived scope toggle — pinned
       // is grid-only, so drop back to the active list when leaving the grid.
       setSessionView((prev) => (prev === "pinned" ? "active" : prev));


### PR DESCRIPTION
## Summary

Opening, cycling to, switching into, or toggling views onto a session selected it but left the terminal **blurred**, so keyboard input was dropped until a manual click. A cached terminal surface reattaches without focusing — that's the root cause across every path.

This re-asserts keyboard focus via `terminals.focusGridSession(...)` at every point where a session becomes active. `focusGridSession` posts a nonce'd request consumed by both `SessionGrid` (grid view) and `TerminalPanel` (normal view) — which are mutually exclusive — so one call covers whichever layout is mounting.

**Session open / cycle (normal view)**
- **Cycle to first session by priority** — focus follows the newly-opened session.
- **Cycle to next session** — successive presses keep cycling with the caret ready to type.
- **Click a session card (`openSession`)** — caret lands in the terminal on click instead of after a second click.

**Project / worktree switch (normal *and* grid view)**
- Switching projects/worktrees rehydrates the active session (panel reopens) but the cached surface reattaches blurred. A scope-guarded effect re-asserts focus **once per switch** (not on every background task refetch, which would yank the caret mid-typing).

**Grid ↔ normal view toggle**
- Entering grid already focused the active session (`enterGridView`). Leaving grid carried the session via `setActiveSession` but never asserted focus, so the docked pane reattached blurred. The focus request is now posted in the same batched update that leaves grid view — `SessionGrid` is unmounting so it won't consume the nonce, and the mounting `TerminalPanel` picks it up.

All changes are in `src/routes/projects.$id.tsx`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx eslint src/routes/projects.$id.tsx` clean
- [x] Manual: click a cached session card → caret lands in the terminal, type immediately
- [x] Manual: cycle sessions via hotkey → keyboard focus follows each session
- [x] Manual: switch to another project → active session's terminal is focused, in both normal and grid view
- [x] Manual: toggle grid → normal and normal → grid → the active session stays focused and ready to type
- [x] Manual: keep a session focused and let tasks refetch in the background → caret is NOT stolen back