### PR TITLE
feat(project-bar): floating hover label for pinned projects

### DIFF
--- a/src/components/views/ProjectBar.tsx
+++ b/src/components/views/ProjectBar.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type PointerEvent as ReactPointerEvent } from "react";
+import { createPortal } from "react-dom";
 import { useRouter } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { CircleAlert } from "lucide-react";
@@ -85,6 +86,21 @@ export const ProjectBar = memo(function ProjectBar({ disabled = false }: { disab
   );
   const [editingProject, setEditingProject] = useState<ProjectWithCounts | null>(null);
   const [draggingProjectId, setDraggingProjectId] = useState<string | null>(null);
+  // A single floating name label that slides out to the right of the hovered
+  // tile. Kept alive while the pointer sweeps between tiles (only the rail's
+  // own onMouseLeave clears it) so it glides vertically to the newly-hovered
+  // project instead of flickering out and back in.
+  const [hoverLabel, setHoverLabel] = useState<{ name: string; top: number; left: number } | null>(
+    null,
+  );
+  const showHoverLabel = useCallback(
+    (name: string, event: ReactMouseEvent<HTMLButtonElement>) => {
+      const rect = event.currentTarget.getBoundingClientRect();
+      setHoverLabel({ name, top: rect.top + rect.height / 2, left: rect.right + 10 });
+    },
+    [],
+  );
+  const clearHoverLabel = useCallback(() => setHoverLabel(null), []);
   const [reorderSaving, setReorderSaving] = useState(false);
   const pointerReorderRef = useRef<PointerReorderState | null>(null);
   const cleanupPointerReorderRef = useRef<(() => void) | null>(null);
@@ -206,6 +222,7 @@ export const ProjectBar = memo(function ProjectBar({ disabled = false }: { disab
     (projectId: string, event: ReactPointerEvent<HTMLButtonElement>) => {
       if (reorderSavingRef.current) return;
       if (event.button !== 0) return;
+      clearHoverLabel();
       cleanupPointerReorder();
       dragOrderRef.current = null;
       setDragOrder(null);
@@ -280,7 +297,7 @@ export const ProjectBar = memo(function ProjectBar({ disabled = false }: { disab
       window.addEventListener("pointercancel", onPointerCancel);
       cleanupPointerReorderRef.current = cleanupListeners;
     },
-    [cleanupPointerReorder, clearDragState, moveDraggedProject, persistPinnedOrder],
+    [cleanupPointerReorder, clearDragState, clearHoverLabel, moveDraggedProject, persistPinnedOrder],
   );
 
   const movePinnedProjectByKeyboard = useCallback(
@@ -332,6 +349,7 @@ export const ProjectBar = memo(function ProjectBar({ disabled = false }: { disab
       className="mc-project-rail"
       aria-label="Pinned projects"
       aria-disabled={disabled || undefined}
+      onMouseLeave={clearHoverLabel}
       style={{
         width: BAR_WIDTH,
         flexShrink: 0,
@@ -416,6 +434,10 @@ export const ProjectBar = memo(function ProjectBar({ disabled = false }: { disab
             aria-keyshortcuts="Shift+ArrowUp Shift+ArrowDown"
             onPointerDown={(e) => startPointerReorder(project.id, e)}
             onDragStart={(e) => e.preventDefault()}
+            onMouseEnter={(e) => {
+              if (disabled || draggingProjectId) return;
+              showHoverLabel(project.name, e);
+            }}
             onKeyDown={(e) => {
               if (disabled) return;
               if (!e.shiftKey || (e.key !== "ArrowUp" && e.key !== "ArrowDown")) return;
@@ -616,6 +638,17 @@ export const ProjectBar = memo(function ProjectBar({ disabled = false }: { disab
         </ContextMenuPopover>
       )}
     </CardFrame>
+    {hoverLabel &&
+      !draggingProjectId &&
+      createPortal(
+        <div
+          className="mc-project-hover-label"
+          style={{ top: hoverLabel.top, left: hoverLabel.left }}
+        >
+          {hoverLabel.name}
+        </div>,
+        document.body,
+      )}
     {editingProject && (
       <ProjectDialog
         open

--- a/src/styles.css
+++ b/src/styles.css
@@ -2644,6 +2644,49 @@ body[data-card-glow] .cursor-glow {
   background: color-mix(in srgb, var(--text) 6%, transparent);
 }
 
+/* Floating name label for the pinned-project rail (ProjectBar.tsx). A single
+   element slides out to the right of the hovered tile; while the pointer sweeps
+   between tiles it stays mounted and its `top` transition glides it vertically
+   to the newly-hovered project, so the name tracks the pointer. */
+.mc-project-hover-label {
+  position: fixed;
+  z-index: 9999;
+  pointer-events: none;
+  transform: translateY(-50%);
+  max-width: 260px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: 6px 11px;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.2;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.32);
+  animation: mc-project-hover-label-in 160ms cubic-bezier(0.22, 1, 0.36, 1);
+  transition: top 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+@keyframes mc-project-hover-label-in {
+  from {
+    opacity: 0;
+    transform: translateY(-50%) translateX(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mc-project-hover-label {
+    animation-duration: 1ms;
+    transition: none;
+  }
+}
+
 /* Status pills (StatusDot.tsx) and project activity badges
    (ProjectStatusBadge.tsx). Painted keeps the hairlines; flat drops them —
    the tonal fill + status dot carry the pill on their own. */


### PR DESCRIPTION
<img width="1437" height="240" alt="image" src="https://github.com/user-attachments/assets/82d85dd4-4c41-49f9-9ab4-ce58f856eb8e" />

## Summary
- Adds a single floating name label that slides out to the right of the hovered pinned-project tile in the project bar.
- The label stays mounted while the pointer sweeps between tiles and glides vertically to the newly-hovered project instead of flickering.
- The label is suppressed during drag-reorder and honors `prefers-reduced-motion`.

## Test plan
- Hover pinned project tiles and confirm the label slides out and glides smoothly between tiles without flickering.
- Drag-reorder a pinned project and confirm the label stays hidden during the drag.
- Enable reduced-motion (macOS: Accessibility → Reduce Motion) and confirm the label appears without motion.
- `npx tsc --noEmit` passes clean.