### PR TITLE
fix(sessions): keep scope toggle visible in archived view

### DIFF
--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -799,6 +799,12 @@ function ProjectPage() {
   // between Active and Pinned (SessionGrid handles the empty-Pinned state).
   const showGrid =
     gridViewActive && sessionView !== "archived" && gridScopeSessionCount > 0;
+  // The Active/Pinned/Archived scope toggle must stay mounted even while the
+  // archived list is showing. Archived is a list-only view, so selecting it drops
+  // showGrid to false — gating the toggle on showGrid would unmount the very
+  // control the user needs to get back to Active/Pinned, stranding them in the
+  // archived list. Keep it visible whenever grid mode is engaged for this scope.
+  const showSessionScopeToggle = gridViewActive && gridScopeSessionCount > 0;
   const syncTask = terminals.syncTask;
   const rehydrateTerminal = terminals.rehydrate;
   const toggleTerminalSession = terminals.toggle;
@@ -3072,7 +3078,7 @@ function ProjectPage() {
             onRun={runScript}
             disabled={!projectPathUsable}
           />
-          {showGrid && (
+          {showSessionScopeToggle && (
             <SessionScopeToggle
               view={sessionView}
               activeCount={activeTasks.length}


### PR DESCRIPTION
<img width="1440" height="244" alt="image" src="https://github.com/user-attachments/assets/2d946d3f-c7b9-4347-af1c-ca9ecf620b51" />

## Summary

Fixes a navigation dead-end in the session scope switcher. Selecting **Archived** from the Active/Pinned/Archived dropdown made the dropdown itself disappear, stranding the user in the archived list with no obvious way back to Active/Pinned.

**Root cause:** Archived is a list-only view, so picking it sets `sessionView = "archived"`, which forces `showGrid` to `false`. The `SessionScopeToggle` was gated on `showGrid`, so switching to Archived unmounted the very control needed to switch back.

**Fix:** Gate the toggle on a new `showSessionScopeToggle` (grid mode engaged for the scope, regardless of the archived sub-view) instead of `showGrid`. The toggle stays mounted while archived is shown — it already highlights whichever tab matches the current `view`, so "Archived" reads as selected and the user can switch straight back to Active or Pinned. `showGrid` is unchanged, so the workspace still correctly renders the list layout for archived.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/routes/projects.$id.tsx` — clean
- [x] In grid view with ≥1 session: open the scope dropdown, pick **Archived** → dropdown stays visible with Archived highlighted; pick **Active**/**Pinned** → returns correctly.