### PR TITLE
fix(projects): unify dashboard toolbar action heights and segment view toggle

### DIFF
--- a/src/components/views/ProjectsDashboardViewToggle.tsx
+++ b/src/components/views/ProjectsDashboardViewToggle.tsx
@@ -1,4 +1,4 @@
-import { Btn } from "~/components/ui/Btn";
+import { Icon } from "~/components/ui/Icon";
 import { Tooltip } from "~/components/ui/Tooltip";
 import type { ProjectsDashboardView } from "~/shared/ui-preferences";
 
@@ -13,30 +13,69 @@ export function ProjectsDashboardViewToggle({
     <div
       role="group"
       aria-label="Projects layout"
-      style={{ display: "inline-flex", alignItems: "center", gap: 0 }}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: 2,
+        border: "1px solid var(--border)",
+        borderRadius: 5,
+        background: "var(--surface-1)",
+        flexShrink: 0,
+      }}
     >
       <Tooltip content="Card view">
-        <Btn
-          variant={view === "cards" ? "primary" : "ghost"}
+        <ProjectsDashboardViewButton
           icon="grid"
-          aria-label="Card view"
-          aria-pressed={view === "cards"}
-          className="mc-btn-attached-right"
-          style={{ minWidth: 52, paddingInline: 0 }}
+          label="Card view"
+          active={view === "cards"}
           onClick={() => onChange("cards")}
         />
       </Tooltip>
       <Tooltip content="Table view">
-        <Btn
-          variant={view === "table" ? "primary" : "ghost"}
+        <ProjectsDashboardViewButton
           icon="list"
-          aria-label="Table view"
-          aria-pressed={view === "table"}
-          className="mc-btn-attached-left"
-          style={{ minWidth: 52, paddingInline: 0 }}
+          label="Table view"
+          active={view === "table"}
           onClick={() => onChange("table")}
         />
       </Tooltip>
     </div>
+  );
+}
+
+function ProjectsDashboardViewButton({
+  icon,
+  label,
+  active,
+  onClick,
+}: {
+  icon: "grid" | "list";
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      style={{
+        width: 34,
+        height: 30,
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        border: 0,
+        borderRadius: 4,
+        background: active ? "var(--surface-3)" : "transparent",
+        color: active ? "var(--text)" : "var(--text-dim)",
+        cursor: "pointer",
+        padding: 0,
+      }}
+    >
+      <Icon name={icon} size={13} />
+    </button>
   );
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -299,11 +299,27 @@ function MissionControlPage() {
                 onChange={persistDashboardView}
               />
 
-              <Btn variant="ghost" icon="group" onClick={() => setShowGroups(true)}>
+              <Btn
+                variant="ghost"
+                icon="group"
+                onClick={() => setShowGroups(true)}
+                style={{
+                  height: 36,
+                  ["--mc-btn-height" as string]: "36px",
+                }}
+              >
                 Groups
               </Btn>
               <HotkeyTooltip action="project.add">
-                <Btn variant="primary" icon="plus" onClick={openAddProject}>
+                <Btn
+                  variant="primary"
+                  icon="plus"
+                  onClick={openAddProject}
+                  style={{
+                    height: 36,
+                    ["--mc-btn-height" as string]: "36px",
+                  }}
+                >
                   Add project
                 </Btn>
               </HotkeyTooltip>


### PR DESCRIPTION
<img width="1975" height="258" alt="image" src="https://github.com/user-attachments/assets/d2508c33-80e6-4f91-96f3-71d7d5fe3a76" />

## Summary

Cleans up the Projects dashboard toolbar so all action elements read as one consistent row.

- **Segmented view toggle** — reworked the card/table toggle into a single segmented control matching the existing `FileFinderViewToggle` idiom: one bordered track with the active cell shown as a subtle raised chip (`--surface-3`), inactive dimmed and transparent. Previously it was a `primary`/`ghost` button pair that read as two separated buttons and used a heavy solid-blue active state inconsistent with the app's other toggles.
- **Unified heights** — all four toolbar action elements are now 36px tall. The Groups and Add project buttons were the default `mc-btn-md` height of 32px; they now match the 36px search input and view toggle (via the `--mc-btn-height` inline override already used in `ProjectDialog.tsx`).

| Element | Before | After |
|---|---|---|
| Search input | 36 | 36 |
| View toggle | 36 | 36 |
| Groups button | 32 | **36** |
| Add project button | 32 | **36** |

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes on changed files
- [ ] Visual: dashboard toolbar renders the toggle as one segmented control with a raised active cell, and all four action elements share the same height