### PR TITLE
feat(projects): keyboard-first Add-project onboarding

### DIFF
--- a/electron/ipc-channels.ts
+++ b/electron/ipc-channels.ts
@@ -1,5 +1,8 @@
 export const IPC = {
   dialogBrowseFolder: "dialog:browseFolder",
+  dialogListFolders: "dialog:listFolders",
+  dialogGrantFolder: "dialog:grantFolder",
+  dialogCreateFolder: "dialog:createFolder",
   dialogPickImage: "dialog:pickImage",
   fileSaveProjectImage: "file:saveProjectImage",
   shellOpenPath: "shell:openPath",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1580,8 +1580,22 @@ safeHandle(IPC.dialogPickImage, async () => {
   if (!PROJECT_IMAGE_EXTENSION_SET.has(ext)) {
     return { error: `Unsupported file type: .${ext}` };
   }
-  ALLOWED_PICKED_PATHS.add(sourcePath);
-  return { sourcePath, extension: ext };
+  // Validate size and build an inline preview here, at pick time — the create
+  // flow renders the image before it's uploaded, and an oversized file should
+  // fail in the picker rather than on save.
+  try {
+    const stat = fs.statSync(sourcePath);
+    if (stat.size > MAX_PROJECT_IMAGE_BYTES) {
+      return { error: `Image exceeds ${MAX_PROJECT_IMAGE_BYTES / 1024 / 1024}MB` };
+    }
+    const mime = ext === "jpg" || ext === "jpeg" ? "image/jpeg" : `image/${ext}`;
+    const previewDataUrl = `data:${mime};base64,${fs.readFileSync(sourcePath).toString("base64")}`;
+    ALLOWED_PICKED_PATHS.add(sourcePath);
+    return { sourcePath, extension: ext, previewDataUrl };
+  } catch (err) {
+    log.warn("project-image.pick-read-failed", { error: String(err) });
+    return { error: "could not read the selected image" };
+  }
 });
 
 safeHandle(

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1538,6 +1538,11 @@ function registerProjectImageProtocol() {
 // from copying arbitrary FS paths (e.g. /etc/passwd) into project-images/.
 const ALLOWED_PICKED_PATHS = new Set<string>();
 
+// NOTE on attestation: grants originally attested "the user picked this in a
+// main-process OS dialog". dialog:grantFolder (in-app folder browser / dialog
+// submit) records renderer-asserted paths, so a grant no longer proves an OS
+// dialog gesture — any consumer of directory-grants.json must not treat it as
+// stronger than "the app was asked to use this directory".
 function recordPickedDirectoryGrant(dir: string): void {
   const realDir = fs.realpathSync(dir);
   const target = path.join(missionControlUserDataDir, DIRECTORY_GRANTS_FILE);
@@ -1646,6 +1651,131 @@ safeHandle(IPC.dialogBrowseFolder, async () => {
     log.warn("directory-grant.record-failed", { path: selected, error: String(err) });
   }
   return selected;
+});
+
+// In-app folder browser (ProjectDialog). Directories only, dotfolders hidden;
+// capped so a giant directory can't flood the renderer with entries.
+const FOLDER_LIST_MAX = 400;
+
+safeHandle(IPC.dialogListFolders, async (_evt, requested: unknown) => {
+  // Everything here is async: a cold network volume or a huge directory must
+  // not freeze the main process (this fires on every arrow-key drill).
+  const fsp = fs.promises;
+  const home = app.getPath("home");
+  const raw = typeof requested === "string" && requested.trim() ? requested : home;
+  let dir: string;
+  try {
+    dir = await fsp.realpath(path.resolve(raw));
+    if (!(await fsp.stat(dir)).isDirectory()) return { ok: false as const, error: "Not a folder" };
+  } catch {
+    return { ok: false as const, error: "Folder not found" };
+  }
+  let dirents: fs.Dirent[];
+  try {
+    dirents = await fsp.readdir(dir, { withFileTypes: true });
+  } catch {
+    return { ok: false as const, error: "Can't read this folder" };
+  }
+  const visible = dirents
+    .filter((d) => d.isDirectory() && !d.name.startsWith("."))
+    .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+  const entries = await Promise.all(
+    visible.slice(0, FOLDER_LIST_MAX).map(async (d) => {
+      // Subfolder count powers the "n" badge and the drill-in affordance; an
+      // unreadable child (permissions) just reads as a leaf.
+      let childCount = 0;
+      try {
+        childCount = (await fsp.readdir(path.join(dir, d.name), { withFileTypes: true })).filter(
+          (c) => c.isDirectory() && !c.name.startsWith("."),
+        ).length;
+      } catch {}
+      return { name: d.name, childCount };
+    }),
+  );
+  const parent = path.dirname(dir);
+  const roots = [
+    { label: "Home", path: home },
+    ...(
+      await Promise.all(
+        ["Developer", "Documents", "Desktop", "Downloads"].map(async (label) => {
+          const p = path.join(home, label);
+          try {
+            return (await fsp.stat(p)).isDirectory() ? { label, path: p } : null;
+          } catch {
+            return null;
+          }
+        }),
+      )
+    ).filter((r): r is { label: string; path: string } => r !== null),
+  ];
+  return {
+    ok: true as const,
+    path: dir,
+    parent: parent === dir ? null : parent,
+    home,
+    roots,
+    entries,
+    truncated: visible.length > FOLDER_LIST_MAX,
+  };
+});
+
+// One plain (non-recursive) mkdir for the browser's "＋ Create folder" row.
+// Name is a single path segment — separators, traversal, and hidden names are
+// rejected here even though the renderer pre-filters them.
+safeHandle(IPC.dialogCreateFolder, async (_evt, parentRaw: unknown, nameRaw: unknown) => {
+  if (typeof parentRaw !== "string" || !parentRaw.trim()) {
+    return { ok: false as const, error: "Invalid location" };
+  }
+  const name = typeof nameRaw === "string" ? nameRaw.trim() : "";
+  if (
+    !name ||
+    name === ".." ||
+    name.startsWith(".") || // hidden folders are filtered from the listing; one would vanish on create
+    name.includes("\0") ||
+    // path separators + Windows-invalid characters (spaces are fine)
+    /[\\/:*?"<>|]/.test(name)
+  ) {
+    return { ok: false as const, error: "Invalid folder name" };
+  }
+  let parent: string;
+  try {
+    parent = await fs.promises.realpath(path.resolve(parentRaw));
+    if (!(await fs.promises.stat(parent)).isDirectory()) {
+      return { ok: false as const, error: "Location is not a folder" };
+    }
+  } catch {
+    return { ok: false as const, error: "Location not found" };
+  }
+  const target = path.join(parent, name);
+  try {
+    await fs.promises.mkdir(target);
+    return { ok: true as const, path: target };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "EEXIST") {
+      return { ok: false as const, error: "Something with that name already exists here" };
+    }
+    if (code === "EACCES" || code === "EPERM" || code === "EROFS") {
+      return { ok: false as const, error: "No permission to create a folder here" };
+    }
+    log.warn("folder-create.failed", { target, error: String(err) });
+    return { ok: false as const, error: "Could not create the folder" };
+  }
+});
+
+// Committing a folder from the in-app browser records the same directory
+// grant an OS-dialog pick would, so both paths stay equivalent downstream.
+safeHandle(IPC.dialogGrantFolder, async (_evt, requested: unknown) => {
+  if (typeof requested !== "string" || !requested.trim()) return { ok: false as const };
+  try {
+    const dir = fs.realpathSync(path.resolve(requested));
+    if (!fs.statSync(dir).isDirectory()) return { ok: false as const };
+    recordPickedDirectoryGrant(dir);
+    return { ok: true as const };
+  } catch (err) {
+    log.warn("directory-grant.record-failed", { path: requested, error: String(err) });
+    return { ok: false as const };
+  }
 });
 
 safeHandle(IPC.shellOpenPath, async (_evt, p: string) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -333,7 +333,9 @@ const electronAPI = {
       ipcRenderer.invoke(IPC.screenshotReadImage, path),
   },
   pickImage: (): Promise<
-    { sourcePath: string; extension: string } | { error: string } | null
+    | { sourcePath: string; extension: string; previewDataUrl: string }
+    | { error: string }
+    | null
   > => ipcRenderer.invoke(IPC.dialogPickImage),
   saveProjectImage: (opts: {
     projectId: string;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -298,6 +298,27 @@ const electronAPI = {
   },
   getPathForFile: (file: File): string => webUtils.getPathForFile(file),
   browseFolder: (): Promise<string | null> => ipcRenderer.invoke(IPC.dialogBrowseFolder),
+  listFolders: (
+    dir: string | null,
+  ): Promise<
+    | {
+        ok: true;
+        path: string;
+        parent: string | null;
+        home: string;
+        roots: Array<{ label: string; path: string }>;
+        entries: Array<{ name: string; childCount: number }>;
+        truncated: boolean;
+      }
+    | { ok: false; error: string }
+  > => ipcRenderer.invoke(IPC.dialogListFolders, dir),
+  grantFolder: (dir: string): Promise<{ ok: boolean }> =>
+    ipcRenderer.invoke(IPC.dialogGrantFolder, dir),
+  createFolder: (
+    parent: string,
+    name: string,
+  ): Promise<{ ok: true; path: string } | { ok: false; error: string }> =>
+    ipcRenderer.invoke(IPC.dialogCreateFolder, parent, name),
   openPath: (path: string): Promise<{ ok: true } | { ok: false; error: string }> =>
     ipcRenderer.invoke(IPC.shellOpenPath, path),
   openExternal: (url: string): Promise<{ ok: true } | { ok: false; error: string }> =>

--- a/src/components/ui/FolderBrowser.tsx
+++ b/src/components/ui/FolderBrowser.tsx
@@ -1,0 +1,795 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+} from "react";
+import { Icon } from "~/components/ui/Icon";
+import { Kbd } from "~/components/ui/Kbd";
+import { Btn } from "~/components/ui/Btn";
+import { getElectron } from "~/lib/electron";
+import type { ListFoldersResult } from "~/shared/electron-contract";
+
+type Listing = Extract<ListFoldersResult, { ok: true }>;
+
+/** Last segment of a filesystem path, ignoring trailing separators. */
+function basename(p: string): string {
+  return p.split(/[\\/]/).filter(Boolean).pop() || "";
+}
+
+/** Parent of an absolute path, computed client-side only to seed the first load. */
+function naiveDirname(p: string): string {
+  const parts = p.split(/[\\/]/).filter(Boolean);
+  parts.pop();
+  return (p.startsWith("/") ? "/" : "") + parts.join("/");
+}
+
+/** `path` with the home prefix shown as ~, for breadcrumbs and hints. */
+function tildify(p: string, home: string): string {
+  return p === home ? "~" : p.startsWith(home + "/") ? "~" + p.slice(home.length) : p;
+}
+
+const headerIconBtnStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 24,
+  height: 24,
+  flex: "0 0 auto",
+  background: "none",
+  border: 0,
+  borderRadius: 6,
+  color: "var(--text-dim)",
+  cursor: "pointer",
+  padding: 0,
+};
+
+const chipStyle = (active: boolean): CSSProperties => ({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 6,
+  fontFamily: "var(--mono)",
+  fontSize: 11,
+  color: active ? "var(--accent)" : "var(--text-dim)",
+  background: active ? "var(--accent-faint)" : "var(--surface-1)",
+  border: `1px solid ${active ? "var(--accent-border)" : "var(--border)"}`,
+  borderRadius: 999,
+  padding: "3px 10px",
+  cursor: "pointer",
+  flex: "0 0 auto",
+  whiteSpace: "nowrap",
+});
+
+/**
+ * Inline, keyboard-first directory picker: the in-app replacement for the OS
+ * "browse folder" dialog in the Add/Edit-project flow. Moving the highlight
+ * previews (onPreview fires with the would-be path); Enter or the footer
+ * button commits; Esc cancels back to whatever the caller had.
+ *
+ * Keys: ↑/↓ move · →/⏎-on-leaf drill/commit · ←/⌫ up · type to filter · Esc.
+ */
+export function FolderBrowser({
+  initialPath,
+  autoFocus,
+  onPreview,
+  onCommit,
+  onCancel,
+}: {
+  /** Currently committed path — the browser opens at its parent with it highlighted. */
+  initialPath: string | null;
+  autoFocus?: boolean;
+  onPreview: (path: string) => void;
+  onCommit: (path: string) => void;
+  onCancel: () => void;
+}) {
+  const [listing, setListing] = useState<Listing | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [hi, setHi] = useState(0);
+  const [filter, setFilter] = useState("");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const filterRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const requestSeq = useRef(0);
+  // Highlight the just-committed folder on the first listing only.
+  const seedHighlightRef = useRef(initialPath ? basename(initialPath) : null);
+
+  // Mirrors `listing` for the async load closure, which would otherwise read
+  // a stale snapshot when deciding whether a failed load leaves us stranded.
+  const listingRef = useRef<Listing | null>(null);
+  listingRef.current = listing;
+
+  const load = async (dir: string | null) => {
+    const electron = getElectron();
+    if (!electron) return;
+    const seq = ++requestSeq.current;
+    const result = await electron.listFolders(dir);
+    if (seq !== requestSeq.current) return; // a newer navigation superseded this one
+    if (!result.ok) {
+      // Stay on the last good listing so ←/breadcrumbs still work — but a
+      // failed FIRST load (e.g. a hand-typed bogus path) has nothing to stay
+      // on, so fall back to home instead of a dead panel.
+      setError(result.error);
+      seedHighlightRef.current = null;
+      if (!listingRef.current && dir !== null) void load(null);
+      return;
+    }
+    setError(null);
+    setFilter("");
+    let nextHi = 0;
+    if (seedHighlightRef.current) {
+      const idx = result.entries.findIndex((e) => e.name === seedHighlightRef.current);
+      seedHighlightRef.current = null;
+      nextHi = Math.max(0, idx);
+    }
+    setListing(result);
+    setHi(nextHi);
+  };
+
+  // Load once on mount; navigation drives subsequent loads imperatively.
+  useEffect(() => {
+    void load(initialPath ? naiveDirname(initialPath) : null);
+  }, []);
+
+  // Deferred so it lands after Modal's own panel-focus effect regardless of
+  // mount order — a plain autoFocus attribute can lose that race.
+  useEffect(() => {
+    if (!autoFocus) return;
+    const t = window.setTimeout(() => filterRef.current?.focus(), 0);
+    return () => window.clearTimeout(t);
+  }, [autoFocus]);
+
+  const entries = useMemo(() => {
+    if (!listing) return [];
+    const q = filter.trim().toLowerCase();
+    return q ? listing.entries.filter((e) => e.name.toLowerCase().includes(q)) : listing.entries;
+  }, [listing, filter]);
+
+  // Filter-as-create: typed text that names no existing folder becomes a
+  // "＋ Create folder" row after the matches (same pattern as the Group field).
+  // Names the main process would reject (separators, hidden, reserved) don't
+  // offer the row at all.
+  const createName = useMemo(() => {
+    const typed = filter.trim();
+    if (!typed || !listing) return null;
+    if (typed === ".." || typed.startsWith(".") || /[\\/:*?"<>|]/.test(typed)) return null;
+    const exists = listing.entries.some((e) => e.name.toLowerCase() === typed.toLowerCase());
+    return exists ? null : typed;
+  }, [filter, listing]);
+
+  // The create row sits at index `entries.length`, participating in ↑/↓.
+  const rowCount = entries.length + (createName ? 1 : 0);
+  const clampedHi = rowCount ? Math.min(hi, rowCount - 1) : 0;
+  const onCreateRow = !!createName && clampedHi === entries.length;
+  const highlighted = !onCreateRow && entries.length ? entries[clampedHi] : null;
+  const previewPath = listing
+    ? highlighted
+      ? `${listing.path === "/" ? "" : listing.path}/${highlighted.name}`
+      : listing.path
+    : null;
+
+  // Live preview: every highlight/navigation change is reflected in the
+  // dialog's path field (and, via the caller, the auto-filled name) — but only
+  // once the user has actually touched the panel. The browser is open by
+  // default in the create flow, and previewing on mount would fill the path
+  // field (and dirty the form) before the user has chosen anything.
+  const interactedRef = useRef(false);
+  // The first ↑/↓ press "activates" the already-highlighted row (previews it)
+  // instead of moving past it — the row the user sees highlighted is the one
+  // they expect that first keypress to pick up.
+  const activatedRef = useRef(false);
+  const onPreviewRef = useRef(onPreview);
+  onPreviewRef.current = onPreview;
+  useEffect(() => {
+    if (!interactedRef.current || !previewPath) return;
+    // A filter with zero matches falls back to the current directory — don't
+    // preview that into the form (commit refuses it too); the genuine
+    // empty-folder fallback ("press ⏎ to use this folder") still previews.
+    if (filter.trim() && !highlighted) return;
+    onPreviewRef.current(previewPath);
+  }, [previewPath, filter, highlighted]);
+
+  useEffect(() => {
+    const el = listRef.current?.querySelector<HTMLElement>('[data-hi="true"]');
+    el?.scrollIntoView({ block: "nearest" });
+  }, [hi, entries]);
+
+  const drillIn = () => {
+    if (!listing || !highlighted) return;
+    activatedRef.current = true;
+    void load(`${listing.path === "/" ? "" : listing.path}/${highlighted.name}`);
+  };
+  const goUp = () => {
+    if (!listing?.parent) return;
+    activatedRef.current = true;
+    seedHighlightRef.current = basename(listing.path);
+    void load(listing.parent);
+  };
+  const creatingRef = useRef(false);
+  const createFolder = async () => {
+    if (!listing || !createName || creatingRef.current) return;
+    const electron = getElectron();
+    if (!electron) return;
+    creatingRef.current = true;
+    try {
+      const result = await electron.createFolder(listing.path, createName);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setError(null);
+      activatedRef.current = true;
+      // Reload the listing with the new folder highlighted — Enter then
+      // commits it, → drills into it; creation deliberately doesn't
+      // auto-commit.
+      seedHighlightRef.current = createName;
+      await load(listing.path);
+    } finally {
+      creatingRef.current = false;
+    }
+  };
+
+  const commit = () => {
+    // The ＋ row shares the commit gesture set (Enter / button / click).
+    if (onCreateRow) {
+      void createFolder();
+      return;
+    }
+    if (!previewPath || !listing) return;
+    // Never commit a bare home/root by accident — require a real pick below it.
+    if (!highlighted && previewPath === listing.home) return;
+    // A filter with zero matches has nothing to pick — Enter shouldn't fall
+    // through to "use the current folder".
+    if (!highlighted && filter.trim()) return;
+    onCommit(previewPath);
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const inFilter = e.target === filterRef.current;
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        e.stopPropagation();
+        if (!rowCount) break;
+        if (!activatedRef.current) {
+          activatedRef.current = true;
+          if (highlighted && previewPath) onPreviewRef.current(previewPath);
+          break;
+        }
+        setHi((clampedHi + 1) % rowCount);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        e.stopPropagation();
+        if (!rowCount) break;
+        if (!activatedRef.current) {
+          activatedRef.current = true;
+          if (highlighted && previewPath) onPreviewRef.current(previewPath);
+          break;
+        }
+        setHi((clampedHi - 1 + rowCount) % rowCount);
+        break;
+      case "ArrowRight": {
+        // With filter text, → only moves the caret while it has somewhere to
+        // go; at the end of the text (where you are right after typing) it
+        // opens the highlighted folder — so type-to-narrow → drill flows.
+        const input = filterRef.current;
+        if (
+          inFilter &&
+          filter &&
+          input &&
+          !(input.selectionStart === input.selectionEnd && input.selectionEnd === filter.length)
+        ) {
+          return; // editing the filter text
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        drillIn();
+        break;
+      }
+      case "ArrowLeft": {
+        // Mirror of →: caret at the very start means ← means "go up".
+        const input = filterRef.current;
+        if (
+          inFilter &&
+          filter &&
+          input &&
+          !(input.selectionStart === input.selectionEnd && input.selectionStart === 0)
+        ) {
+          return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        goUp();
+        break;
+      }
+      case "Backspace":
+        if (inFilter && filter) return; // deleting filter text
+        e.preventDefault();
+        e.stopPropagation();
+        goUp();
+        break;
+      case "Enter":
+        // A focused button (crumb, chip, back, ✕) keeps its native Enter=click;
+        // only the dialog-wide Enter-submits hotkey is blocked.
+        if (e.target instanceof HTMLElement && e.target.tagName === "BUTTON") {
+          e.stopPropagation();
+          break;
+        }
+        // Swallowed here so the dialog-wide Enter-submits hotkey can't fire
+        // while the user is still picking a folder. No activation gate: the
+        // highlight is always visible, so Enter is exact parity with the
+        // "Use this folder" button (same home/no-match guards inside commit).
+        e.preventDefault();
+        e.stopPropagation();
+        commit();
+        break;
+      case "Escape":
+        e.preventDefault();
+        e.stopPropagation(); // keep the dialog itself open
+        if (filter) {
+          setFilter("");
+          setHi(0);
+        } else {
+          onCancel();
+        }
+        break;
+      default:
+        // Loose typing anywhere in the panel routes into the filter box.
+        if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey && !inFilter) {
+          filterRef.current?.focus();
+        }
+    }
+  };
+
+  const home = listing?.home ?? "";
+  const crumbs = useMemo(() => {
+    if (!listing) return [];
+    if (listing.path === "/") return [{ label: "/", path: "/" }];
+    const display = tildify(listing.path, home);
+    const segs = display.split("/").filter(Boolean);
+    const isAbs = display.startsWith("/");
+    return segs.map((seg, i) => ({
+      label: seg,
+      path: (() => {
+        const partial = segs.slice(0, i + 1).join("/");
+        const p = isAbs ? "/" + partial : partial;
+        return p.startsWith("~") ? home + p.slice(1) : p;
+      })(),
+    }));
+  }, [listing, home]);
+  // Long paths: keep the first crumb (~) and the last two, elide the middle.
+  const crumbHead = crumbs.length > 4 ? crumbs.slice(0, 1) : [];
+  const crumbTail = crumbs.length > 4 ? crumbs.slice(-2) : crumbs;
+
+  return (
+    <div
+      ref={rootRef}
+      onKeyDown={onKeyDown}
+      onKeyDownCapture={() => {
+        interactedRef.current = true;
+      }}
+      onMouseDownCapture={(e) => {
+        interactedRef.current = true;
+        // Clicks must not move focus around the panel: rows aren't focusable
+        // (focus would fall to <body> and keyboard nav dies), and chips /
+        // crumbs / back are momentary controls that would otherwise keep a
+        // focus ring after the click. Keys keep flowing through the filter
+        // box; Tab still reaches every button for keyboard users. The filter
+        // input keeps its default so caret placement works, and scrollbars
+        // (neither li nor button) stay draggable.
+        if (
+          e.target instanceof HTMLElement &&
+          !e.target.closest("input") &&
+          e.target.closest("li,button")
+        ) {
+          e.preventDefault();
+        }
+      }}
+      onClickCapture={() => {
+        // Any click in the panel's dead zones (header gaps, footer hints, a
+        // row while focus was in the name field) must leave focus somewhere
+        // inside the panel, or the keyboard model goes dark.
+        if (!rootRef.current?.contains(document.activeElement)) {
+          filterRef.current?.focus();
+        }
+      }}
+      style={{
+        background: "var(--surface-0)",
+        border: "1px solid var(--border-strong)",
+        borderRadius: 10,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "5px 8px",
+          borderBottom: "1px solid var(--border)",
+          background: "var(--surface-1)",
+        }}
+      >
+        <button
+          type="button"
+          onClick={goUp}
+          disabled={!listing?.parent}
+          aria-label="Back to parent folder"
+          title="Back (← or ⌫)"
+          style={{
+            ...headerIconBtnStyle,
+            opacity: listing?.parent ? 1 : 0.35,
+            cursor: listing?.parent ? "pointer" : "default",
+          }}
+        >
+          <Icon name="chevron-left" size={14} />
+        </button>
+        <nav
+          aria-label="Current folder path"
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: "flex",
+            alignItems: "center",
+            gap: 2,
+            fontFamily: "var(--mono)",
+            fontSize: 11,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+          }}
+        >
+          {[...crumbHead, ...(crumbs.length > 4 ? [null] : []), ...crumbTail].map((crumb, i, arr) =>
+            crumb === null ? (
+              <span key="ellipsis" style={{ color: "var(--text-faint)", padding: "0 2px" }}>
+                / … /
+              </span>
+            ) : (
+              <span
+                key={crumb.path}
+                style={{ display: "inline-flex", alignItems: "center", gap: 2 }}
+              >
+                {i > 0 && arr[i - 1] !== null && (
+                  <span style={{ color: "var(--text-faint)", opacity: 0.6 }}>/</span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => void load(crumb.path)}
+                  className="mc-folder-crumb"
+                  style={{
+                    background: "none",
+                    border: 0,
+                    cursor: "pointer",
+                    font: "inherit",
+                    padding: "2px 5px",
+                    borderRadius: 5,
+                    color: i === arr.length - 1 ? "var(--text)" : "var(--text-faint)",
+                    fontWeight: i === arr.length - 1 ? 600 : 400,
+                  }}
+                >
+                  {crumb.label}
+                </button>
+              </span>
+            ),
+          )}
+        </nav>
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Close folder browser"
+          title="Close (esc)"
+          style={headerIconBtnStyle}
+        >
+          <Icon name="x" size={13} />
+        </button>
+      </div>
+
+      {listing && listing.roots.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            gap: 6,
+            padding: "8px 10px",
+            borderBottom: "1px solid var(--border)",
+            overflowX: "auto",
+          }}
+        >
+          {listing.roots.map((root) => (
+            <button
+              key={root.path}
+              type="button"
+              onClick={() => void load(root.path)}
+              style={chipStyle(listing.path === root.path)}
+            >
+              <Icon name="folder" size={11} />
+              {root.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div style={{ padding: "8px 10px 0" }}>
+        <div style={{ position: "relative" }}>
+          <span
+            aria-hidden
+            style={{
+              position: "absolute",
+              left: 9,
+              top: "50%",
+              translate: "0 -50%",
+              color: "var(--text-faint)",
+              display: "flex",
+            }}
+          >
+            <Icon name="search" size={12} />
+          </span>
+          <input
+            ref={filterRef}
+            value={filter}
+            onChange={(e) => {
+              activatedRef.current = true;
+              setFilter(e.target.value);
+              setHi(0);
+            }}
+            placeholder="Type to filter — or name a new folder…"
+            aria-label="Filter folders"
+            style={{
+              width: "100%",
+              height: 30,
+              background: "var(--surface-1)",
+              border: "1px solid var(--border)",
+              borderRadius: 7,
+              color: "var(--text)",
+              fontFamily: "var(--mono)",
+              fontSize: 12,
+              padding: "0 10px 0 28px",
+              outline: "none",
+            }}
+          />
+        </div>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          style={{
+            margin: "8px 10px 0",
+            padding: "6px 10px",
+            borderRadius: 7,
+            background: "var(--status-needs-bg)",
+            color: "var(--status-needs)",
+            fontFamily: "var(--mono)",
+            fontSize: 11,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <ul
+        ref={listRef}
+        role="listbox"
+        aria-label="Subfolders"
+        style={{
+          listStyle: "none",
+          margin: 0,
+          padding: 6,
+          maxHeight: 218,
+          overflowY: "auto",
+        }}
+      >
+        {!listing && !error && (
+          <li
+            style={{
+              padding: "24px 12px",
+              textAlign: "center",
+              color: "var(--text-faint)",
+              fontFamily: "var(--mono)",
+              fontSize: 11,
+            }}
+          >
+            loading folders…
+          </li>
+        )}
+        {listing && entries.length === 0 && !createName && (
+          <li
+            style={{
+              padding: "24px 12px",
+              textAlign: "center",
+              color: "var(--text-faint)",
+              fontFamily: "var(--mono)",
+              fontSize: 11,
+            }}
+          >
+            {filter
+              ? `no folders matching “${filter.trim()}”`
+              : "no subfolders — press ⏎ to use this folder"}
+          </li>
+        )}
+        {entries.map((entry, i) => {
+          const isHi = i === clampedHi && !onCreateRow;
+          return (
+            <li
+              key={entry.name}
+              role="option"
+              aria-selected={isHi}
+              data-hi={isHi || undefined}
+              onClick={() => {
+                activatedRef.current = true;
+                setHi(i);
+                // Re-clicking the highlighted row still counts as a pick.
+                if (isHi && previewPath) onPreviewRef.current(previewPath);
+              }}
+              onDoubleClick={() => {
+                setHi(i);
+                if (entry.childCount > 0) drillIn();
+                else commit();
+              }}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "6px 10px",
+                borderRadius: 7,
+                cursor: "pointer",
+                userSelect: "none",
+                border: `1px solid ${isHi ? "var(--accent-border)" : "transparent"}`,
+                background: isHi ? "var(--accent-dim)" : undefined,
+              }}
+            >
+              <span
+                aria-hidden
+                style={{
+                  color: isHi ? "var(--accent)" : "var(--text-faint)",
+                  display: "flex",
+                  flex: "0 0 auto",
+                }}
+              >
+                <Icon name="folder" size={14} />
+              </span>
+              <span
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  fontSize: 13,
+                  fontWeight: isHi ? 600 : 400,
+                  color: "var(--text)",
+                }}
+              >
+                {entry.name}
+              </span>
+              {entry.childCount > 0 && (
+                <>
+                  <span
+                    style={{
+                      fontFamily: "var(--mono)",
+                      fontSize: 10,
+                      color: "var(--text-faint)",
+                      flex: "0 0 auto",
+                    }}
+                  >
+                    {entry.childCount}
+                  </span>
+                  <span
+                    aria-hidden
+                    style={{ color: "var(--text-faint)", display: "flex", flex: "0 0 auto" }}
+                  >
+                    <Icon name="chevron-right" size={12} />
+                  </span>
+                </>
+              )}
+            </li>
+          );
+        })}
+        {listing?.truncated && (
+          <li
+            style={{
+              padding: "8px 12px",
+              color: "var(--text-faint)",
+              fontFamily: "var(--mono)",
+              fontSize: 10.5,
+            }}
+          >
+            showing the first {listing.entries.length} folders — type to narrow down
+          </li>
+        )}
+      </ul>
+
+      {/* Create action, pinned below the scroll area: appears when the filter
+          names a folder that doesn't exist here (the placeholder teaches the
+          gesture), and joins the ↑/↓ cycle at index entries.length. */}
+      {listing && createName && (
+        <div style={{ padding: "0 6px 6px" }}>
+          <button
+            type="button"
+            onClick={() => {
+              activatedRef.current = true;
+              setHi(entries.length);
+              void createFolder();
+            }}
+            data-hi={onCreateRow || undefined}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              width: "100%",
+              padding: "6px 10px",
+              borderRadius: 7,
+              cursor: "pointer",
+              userSelect: "none",
+              font: "inherit",
+              textAlign: "left",
+              border: `1px dashed ${onCreateRow ? "var(--accent-border)" : "var(--border-strong)"}`,
+              background: onCreateRow ? "var(--accent-dim)" : "transparent",
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                color: onCreateRow ? "var(--accent)" : "var(--text-faint)",
+                display: "flex",
+                flex: "0 0 auto",
+              }}
+            >
+              <Icon name="plus" size={14} />
+            </span>
+            <span
+              style={{
+                flex: 1,
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                fontSize: 13,
+                fontWeight: onCreateRow ? 600 : 400,
+                color: "var(--text)",
+              }}
+            >
+              Create folder “{createName}” here
+            </span>
+            <Kbd variant="inline">⏎</Kbd>
+          </button>
+        </div>
+      )}
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          padding: "8px 10px",
+          borderTop: "1px solid var(--border)",
+          background: "var(--surface-1)",
+        }}
+      >
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 11, color: "var(--text-faint)" }}>
+            <Kbd variant="inline">↑</Kbd>
+            <Kbd variant="inline">↓</Kbd> move
+          </span>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 11, color: "var(--text-faint)" }}>
+            <Kbd variant="inline">→</Kbd> open
+          </span>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 11, color: "var(--text-faint)" }}>
+            <Kbd variant="inline">←</Kbd> back
+          </span>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 4, fontSize: 11, color: "var(--text-faint)" }}>
+            <Kbd variant="inline">esc</Kbd> cancel
+          </span>
+        </div>
+        <Btn
+          variant="primary"
+          onClick={commit}
+          disabled={!onCreateRow && !highlighted && (previewPath === home || !!filter.trim())}
+        >
+          {onCreateRow ? "Create folder" : "Use this folder"}
+        </Btn>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/FormErrorBox.tsx
+++ b/src/components/ui/FormErrorBox.tsx
@@ -9,6 +9,8 @@ export function FormErrorBox({ error }: { error: ReactNode }) {
   if (!error) return null;
   return (
     <div
+      role="alert"
+      aria-live="assertive"
       style={{
         padding: "8px 12px",
         border: "1px solid var(--status-failed)",

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -178,6 +178,7 @@ export function Modal({
           className="mc-modal-footer"
           style={{
             display: "flex",
+            alignItems: "center",
             justifyContent: "flex-end",
             gap: 8,
             padding: "12px 18px",

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -175,6 +175,7 @@ export function Modal({
       <div style={{ padding: 18, overflowY: "auto", flex: 1, ...contentStyle }}>{children}</div>
       {footer && (
         <div
+          className="mc-modal-footer"
           style={{
             display: "flex",
             justifyContent: "flex-end",

--- a/src/components/ui/PickCardGroup.tsx
+++ b/src/components/ui/PickCardGroup.tsx
@@ -1,0 +1,144 @@
+import { useRef, useState, type CSSProperties, type FocusEvent, type KeyboardEvent, type ReactNode } from "react";
+import { Icon } from "~/components/ui/Icon";
+
+export type PickCardOption<V extends string> = {
+  value: V;
+  /** Accessible name; include the disabled reason so AT hears why. */
+  ariaLabel: string;
+  title?: string;
+  disabled?: boolean;
+  /** Card contents (leading glyph + label). The group renders the selected
+      checkmark itself so every picker confirms in the same grammar. */
+  content: (selected: boolean) => ReactNode;
+};
+
+/**
+ * Radiogroup of pick-cards (agent, layout, …) implementing the ARIA radio
+ * pattern the visuals promise: one tab stop, arrow keys move between options.
+ * Arrows land on `aria-disabled` options too — they stay discoverable and
+ * announce their reason — but only enabled options take the selection.
+ */
+export function PickCardGroup<V extends string>({
+  ariaLabel,
+  value,
+  onChange,
+  options,
+  style,
+  deselectable = false,
+}: {
+  ariaLabel: string;
+  value: V | null;
+  onChange: (value: V | null) => void;
+  options: PickCardOption<V>[];
+  style?: CSSProperties;
+  /** When set, clicking (or Space on) the selected option clears it back to
+      null — the selection becomes optional rather than a locked-in radio. */
+  deselectable?: boolean;
+}) {
+  const refs = useRef(new Map<V, HTMLButtonElement>());
+  // While the group holds focus, the tab stop follows the focused option
+  // (which may be disabled); at rest it sits on the selection.
+  const [focusValue, setFocusValue] = useState<V | null>(null);
+
+  const enabledValues = options.filter((o) => !o.disabled).map((o) => o.value);
+  const restingStop =
+    options.some((o) => o.value === value && !o.disabled) ? value : enabledValues[0] ?? options[0]?.value;
+  const tabStop = focusValue ?? restingStop;
+
+  const moveTo = (index: number) => {
+    const target = options[index];
+    if (!target) return;
+    refs.current.get(target.value)?.focus();
+    if (!target.disabled) onChange(target.value);
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const activeIndex = options.findIndex(
+      (o) => refs.current.get(o.value) === document.activeElement,
+    );
+    if (activeIndex < 0) return;
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        e.preventDefault();
+        moveTo((activeIndex + 1) % options.length);
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        e.preventDefault();
+        moveTo((activeIndex - 1 + options.length) % options.length);
+        break;
+      case "Home":
+        e.preventDefault();
+        moveTo(0);
+        break;
+      case "End":
+        e.preventDefault();
+        moveTo(options.length - 1);
+        break;
+    }
+  };
+
+  const onBlur = (e: FocusEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.contains(e.relatedTarget)) setFocusValue(null);
+  };
+
+  return (
+    <div role="radiogroup" aria-label={ariaLabel} style={style} onKeyDown={onKeyDown} onBlur={onBlur}>
+      {options.map((opt) => {
+        const selected = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            ref={(el) => {
+              if (el) refs.current.set(opt.value, el);
+              else refs.current.delete(opt.value);
+            }}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-label={opt.ariaLabel}
+            aria-disabled={opt.disabled || undefined}
+            tabIndex={opt.value === tabStop ? 0 : -1}
+            onFocus={() => setFocusValue(opt.value)}
+            onClick={() =>
+              !opt.disabled && onChange(deselectable && selected ? null : opt.value)
+            }
+            className="mc-pick-card"
+            data-selected={selected}
+            title={opt.title}
+            style={{
+              position: "relative",
+              display: "flex",
+              alignItems: "center",
+              gap: 9,
+              textAlign: "left",
+              padding: "9px 10px",
+              // Selected reads three ways: a faint accent wash in the fill (so
+              // selection shows in hue, not only tone), the soft --accent-border
+              // ring, and the checkmark below. The wash stays dilute so an
+              // agent's own brand-colored glyph still owns the card.
+              background: selected
+                ? "color-mix(in srgb, var(--accent) 9%, var(--surface-2))"
+                : "var(--surface-0)",
+              border: `1px solid ${selected ? "var(--accent-border)" : "var(--border)"}`,
+              borderRadius: 7,
+              cursor: opt.disabled ? "not-allowed" : "pointer",
+              opacity: opt.disabled ? 0.5 : 1,
+            }}
+          >
+            {opt.content(selected)}
+            {selected && (
+              <span
+                aria-hidden
+                style={{ marginLeft: "auto", display: "flex", color: "var(--accent)", flex: "0 0 auto" }}
+              >
+                <Icon name="check" size={12} />
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/TextField.tsx
+++ b/src/components/ui/TextField.tsx
@@ -56,11 +56,11 @@ export function TextField({
         </label>
       )}
       <div
+        className="mc-text-field"
         style={{
           display: "flex",
           alignItems: "center",
           background: "var(--surface-0)",
-          border: "1px solid var(--border)",
           borderRadius: 7,
           overflow: "hidden",
         }}

--- a/src/components/ui/TextField.tsx
+++ b/src/components/ui/TextField.tsx
@@ -60,6 +60,9 @@ export function TextField({
         style={{
           display: "flex",
           alignItems: "center",
+          // Explicit height (not font-derived) so fields line up when placed
+          // in a row with other 38px controls (selects, color triggers).
+          height: 38,
           background: "var(--surface-0)",
           borderRadius: 7,
           overflow: "hidden",
@@ -82,11 +85,12 @@ export function TextField({
           onBlur={onBlur}
           style={{
             flex: 1,
+            height: "100%",
             background: "transparent",
             border: 0,
             outline: 0,
             color: "var(--text)",
-            padding: "9px 12px",
+            padding: "0 12px",
             fontFamily: mono ? "var(--mono)" : "var(--sans)",
             fontSize: 13,
           }}

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -199,10 +199,21 @@ export function ProjectDialog({
   const [confirmingClose, setConfirmingClose] = useState(false);
   const nameRef = useRef<HTMLInputElement>(null);
   const errorRef = useRef<HTMLDivElement>(null);
+  const colorTriggerRef = useRef<HTMLButtonElement>(null);
+  const swatchRefs = useRef<(HTMLButtonElement | null)[]>([]);
   // Snapshot of the seeded form, captured on open, so an accidental Esc /
   // backdrop click on a create form the user has actually touched prompts
   // before discarding — while a pre-filled-but-untouched form closes freely.
   const formSeedRef = useRef<string>("");
+  // When the color menu opens, move focus onto the current swatch so arrow
+  // keys walk the strip immediately (the trigger opens it on ArrowDown).
+  const iconColorRef = useRef(iconColor);
+  iconColorRef.current = iconColor;
+  useEffect(() => {
+    if (!colorMenuOpen) return;
+    const idx = Math.max(0, ICON_COLORS.indexOf(iconColorRef.current));
+    swatchRefs.current[idx]?.focus();
+  }, [colorMenuOpen]);
   const selectedGroup = groupId ? groups.find((group) => group.id === groupId) ?? null : null;
   const normalizedGroupQuery = groupQuery.trim().toLowerCase();
   const exactGroupMatch = normalizedGroupQuery
@@ -649,6 +660,7 @@ export function ProjectDialog({
                 // Close the color menu without also dismissing the whole dialog.
                 e.stopPropagation();
                 setColorMenuOpen(false);
+                colorTriggerRef.current?.focus();
               }
             }}
             onBlur={(e) => {
@@ -657,8 +669,17 @@ export function ProjectDialog({
           >
             <FieldLabel>Color</FieldLabel>
             <button
+              ref={colorTriggerRef}
               type="button"
               onClick={() => setColorMenuOpen((o) => !o)}
+              onKeyDown={(e) => {
+                // Native-select feel: ArrowDown/ArrowUp on the closed trigger
+                // opens the strip (the open-effect then focuses the swatch).
+                if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+                  e.preventDefault();
+                  setColorMenuOpen(true);
+                }
+              }}
               aria-label="Icon color"
               aria-haspopup="listbox"
               aria-expanded={colorMenuOpen}
@@ -692,15 +713,31 @@ export function ProjectDialog({
               <div
                 role="listbox"
                 aria-label="Icon color"
+                onKeyDown={(e) => {
+                  // Roving focus over the vertical column: Down/Right advance,
+                  // Up/Left go back (wrapping), and the selection follows focus
+                  // so the avatar previews each color as the user arrows along.
+                  const count = ICON_COLORS.length;
+                  const idx = Math.max(0, ICON_COLORS.indexOf(iconColor));
+                  let next = -1;
+                  if (e.key === "ArrowDown" || e.key === "ArrowRight") next = (idx + 1) % count;
+                  else if (e.key === "ArrowUp" || e.key === "ArrowLeft") next = (idx - 1 + count) % count;
+                  else if (e.key === "Home") next = 0;
+                  else if (e.key === "End") next = count - 1;
+                  if (next === -1) return;
+                  e.preventDefault();
+                  setIconColor(ICON_COLORS[next]);
+                  swatchRefs.current[next]?.focus();
+                }}
                 style={{
                   position: "absolute",
                   zIndex: 20,
                   top: "calc(100% + 6px)",
-                  // Right-anchored: the trigger sits at the row's right edge,
-                  // so the swatch strip opens leftward into the dialog instead
-                  // of clipping against its edge.
-                  right: 0,
+                  // Centered under the trigger button.
+                  left: "50%",
+                  transform: "translateX(-50%)",
                   display: "flex",
+                  flexDirection: "column",
                   gap: 6,
                   padding: 8,
                   background: "var(--surface-1)",
@@ -709,11 +746,14 @@ export function ProjectDialog({
                   boxShadow: "0 14px 36px rgba(0, 0, 0, 0.32)",
                 }}
               >
-                {ICON_COLORS.map((c) => {
+                {ICON_COLORS.map((c, i) => {
                   const active = iconColor === c;
                   return (
                     <button
                       key={c}
+                      ref={(el) => {
+                        swatchRefs.current[i] = el;
+                      }}
                       type="button"
                       role="option"
                       aria-selected={active}
@@ -721,6 +761,7 @@ export function ProjectDialog({
                       onClick={() => {
                         setIconColor(c);
                         setColorMenuOpen(false);
+                        colorTriggerRef.current?.focus();
                       }}
                       className="mc-color-swatch"
                       style={{

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -5,6 +5,7 @@ import { Btn } from "~/components/ui/Btn";
 import { TextField } from "~/components/ui/TextField";
 import { Icon } from "~/components/ui/Icon";
 import { AgentLogo } from "~/components/ui/AgentLogo";
+import { ProjectIcon } from "~/components/ui/ProjectIcon";
 import { HotkeyTooltip, EscTooltip } from "~/components/ui/Tooltip";
 import { useHotkey } from "~/lib/use-hotkey";
 import { AGENT_META, ICON_COLORS } from "~/lib/design-meta";
@@ -36,23 +37,6 @@ const fieldLabelStyle: CSSProperties = {
 
 function FieldLabel({ children }: { children: ReactNode }) {
   return <label style={fieldLabelStyle}>{children}</label>;
-}
-
-/** Anchors each column of the create form with a quiet titled hairline. */
-function ColumnHeading({ children }: { children: ReactNode }) {
-  return (
-    <div
-      style={{
-        fontSize: 12,
-        fontWeight: 600,
-        color: "var(--text)",
-        paddingBottom: 8,
-        borderBottom: "1px solid var(--border)",
-      }}
-    >
-      {children}
-    </div>
-  );
 }
 
 /** Tiny wireframe that shows what each layout does at a glance. */
@@ -140,6 +124,7 @@ export function ProjectDialog({
     { sourcePath: string; extension: string } | null
   >(null);
   const [uploading, setUploading] = useState(false);
+  const [appearanceOpen, setAppearanceOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const nameRef = useRef<HTMLInputElement>(null);
@@ -188,6 +173,7 @@ export function ProjectDialog({
       setGridView(project?.defaultGridView ?? false);
       setImagePath(project?.imagePath ?? null);
       setPendingImage(null);
+      setAppearanceOpen(false);
       setSubmitting(false);
       setError(null);
     }
@@ -349,6 +335,19 @@ export function ProjectDialog({
   // Enter / Cmd+Enter runs the primary action: "Create & start" for a new
   // project, "Save" when editing (autoStart is ignored on the edit path).
   useHotkey("dialog.submit", () => void submit(!project), { enabled: open });
+
+  // Live identity preview: exactly what the sidebar will render for this
+  // project — auto initials from the name until the user overrides them.
+  const derivedInitials =
+    (name.trim() || path.trim().split(/[\\/]/).filter(Boolean).pop() || "")
+      .slice(0, 2)
+      .toUpperCase() || "AB";
+  const previewInitials = icon || derivedInitials;
+  const appearanceSummary = pendingImage
+    ? pendingImage.sourcePath.split(/[\\/]/).pop() ?? "custom image"
+    : icon
+      ? `Initials ${icon}`
+      : `Auto initials · ${derivedInitials}`;
 
   const nameField = (
     <TextField
@@ -583,13 +582,13 @@ export function ProjectDialog({
 
   const iconField = (
     <div>
-      <FieldLabel>Icon (fallback)</FieldLabel>
+      <FieldLabel>{project ? "Icon (fallback)" : "Initials & color"}</FieldLabel>
       <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
         <input
           value={icon}
           onChange={(e) => setIcon(e.target.value.slice(0, 2).toUpperCase())}
           maxLength={2}
-          placeholder="AB"
+          placeholder={project ? "AB" : derivedInitials}
           aria-label="Icon initials"
           style={{
             width: 56,
@@ -838,6 +837,90 @@ export function ProjectDialog({
     </div>
   );
 
+  const appearanceSection = (
+    <div>
+      <button
+        type="button"
+        aria-expanded={appearanceOpen}
+        aria-controls="project-appearance-fields"
+        onClick={() => setAppearanceOpen((v) => !v)}
+        style={{
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          textAlign: "left",
+          padding: "8px 10px",
+          background: appearanceOpen ? "var(--surface-2)" : "var(--surface-0)",
+          border: "1px solid var(--border)",
+          borderRadius: 8,
+          cursor: "pointer",
+          transition: "background 150ms ease",
+        }}
+      >
+        {pendingImage ? (
+          <div
+            aria-hidden
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 6,
+              border: `1px solid ${iconColor}44`,
+              background: `${iconColor}18`,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: iconColor,
+              flex: "0 0 auto",
+            }}
+          >
+            <Icon name="camera" size={14} />
+          </div>
+        ) : (
+          <ProjectIcon
+            project={{ icon: previewInitials, iconColor, imagePath: null }}
+            size={28}
+          />
+        )}
+        <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text)" }}>
+          Appearance
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: 10.5,
+            color: "var(--text-dim)",
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {appearanceSummary}
+        </span>
+        <Icon
+          name={appearanceOpen ? "chevron-up" : "chevron-down"}
+          size={13}
+          style={{ marginLeft: "auto", color: "var(--text-faint)" }}
+        />
+      </button>
+      {appearanceOpen && (
+        <div
+          id="project-appearance-fields"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
+            padding: "14px 10px 4px",
+          }}
+        >
+          {iconField}
+          {imageField}
+        </div>
+      )}
+    </div>
+  );
+
   const worktreeField = project ? (
     <TextField
       mono
@@ -854,7 +937,7 @@ export function ProjectDialog({
       open={open}
       onClose={onClose}
       title={project ? "Edit project" : "Add project"}
-      width={project ? 520 : 720}
+      width={project ? 520 : 540}
       footer={
         project ? (
           <>
@@ -904,31 +987,13 @@ export function ProjectDialog({
           <FormErrorBox error={error} />
         </div>
       ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "minmax(0, 0.8fr) minmax(0, 1.2fr)",
-              gap: 16,
-              alignItems: "end",
-            }}
-          >
-            {nameField}
-            {dirField}
-          </div>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 22, alignItems: "start" }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-              <ColumnHeading>How you'll work</ColumnHeading>
-              {startWithField}
-              {layoutField}
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-              <ColumnHeading>Appearance &amp; grouping</ColumnHeading>
-              {imageField}
-              {iconField}
-              {groupField}
-            </div>
-          </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+          {nameField}
+          {dirField}
+          {startWithField}
+          {layoutField}
+          {groupField}
+          {appearanceSection}
           <FormErrorBox error={error} />
         </div>
       )}

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { Modal } from "~/components/ui/Modal";
+import { FolderBrowser } from "~/components/ui/FolderBrowser";
 import { FormErrorBox } from "~/components/ui/FormErrorBox";
 import { Btn } from "~/components/ui/Btn";
 import { TextField } from "~/components/ui/TextField";
 import { Icon } from "~/components/ui/Icon";
 import { AgentLogo } from "~/components/ui/AgentLogo";
+import { PickCardGroup } from "~/components/ui/PickCardGroup";
 import { ToggleSwitch } from "~/components/views/SettingsParts";
 import { HotkeyTooltip, EscTooltip } from "~/components/ui/Tooltip";
 import { useHotkey } from "~/lib/use-hotkey";
@@ -36,7 +38,9 @@ const fieldLabelStyle: CSSProperties = {
 };
 
 function FieldLabel({ children }: { children: ReactNode }) {
-  return <label style={fieldLabelStyle}>{children}</label>;
+  // A <span>, not a <label>: nothing here wires htmlFor, and an unassociated
+  // <label> misleads AT. The controls carry their own accessible names.
+  return <span style={fieldLabelStyle}>{children}</span>;
 }
 
 /** Last segment of a filesystem path, ignoring trailing separators. */
@@ -56,7 +60,7 @@ function GroupCard({
   children,
 }: {
   title: string;
-  description: string;
+  description?: string;
   children: ReactNode;
 }) {
   return (
@@ -72,11 +76,13 @@ function GroupCard({
     >
       <div>
         <div style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{title}</div>
-        <div
-          style={{ fontSize: 12, color: "var(--text-dim)", lineHeight: 1.45, marginTop: 3 }}
-        >
-          {description}
-        </div>
+        {description && (
+          <div
+            style={{ fontSize: 12, color: "var(--text-dim)", lineHeight: 1.45, marginTop: 3 }}
+          >
+            {description}
+          </div>
+        )}
       </div>
       {children}
     </section>
@@ -101,7 +107,7 @@ function LayoutGlyph({ variant, active }: { variant: "list" | "grid"; active: bo
     return (
       <div style={{ ...frame, display: "flex", flexDirection: "column", gap: 2.5 }}>
         {[0, 1, 2].map((i) => (
-          <div key={i} style={{ height: 4, borderRadius: 1.5, background: cell, opacity: active ? 1 : 0.6 }} />
+          <div key={i} style={{ height: 4, borderRadius: 1.5, background: cell }} />
         ))}
       </div>
     );
@@ -117,7 +123,7 @@ function LayoutGlyph({ variant, active }: { variant: "list" | "grid"; active: bo
       }}
     >
       {[0, 1, 2, 3].map((i) => (
-        <div key={i} style={{ borderRadius: 1.5, background: cell, opacity: active ? 1 : 0.6 }} />
+        <div key={i} style={{ borderRadius: 1.5, background: cell }} />
       ))}
     </div>
   );
@@ -151,20 +157,32 @@ export function ProjectDialog({
     rememberAgentSettings?: boolean;
     defaultGridView?: boolean;
     autoStart?: boolean;
+    pinned?: boolean;
   }) => Promise<void> | void;
   onCreateGroup?: (name: string) => Promise<Group> | Group;
 }) {
   const [name, setName] = useState("");
   const [path, setPath] = useState("");
+  // The inline folder browser live-syncs the name to the highlighted folder
+  // only until the user types a name of their own (clearing it re-enables).
+  const [nameTouched, setNameTouched] = useState(false);
+  const [folderBrowserOpen, setFolderBrowserOpen] = useState(false);
+  // Filter box gets focus when the browser is the opening step (create flow)
+  // or was opened via Browse…; the edit flow keeps focus on the name field.
+  const [folderBrowserAutoFocus, setFolderBrowserAutoFocus] = useState(false);
+  // Committed path+name snapshot so Esc in the browser reverts the preview.
+  const folderSnapshotRef = useRef<{ path: string; name: string } | null>(null);
   const [groupId, setGroupId] = useState<string>("");
   const [groupQuery, setGroupQuery] = useState("");
   const [groupTypeaheadOpen, setGroupTypeaheadOpen] = useState(false);
   const [groupActiveIndex, setGroupActiveIndex] = useState(-1);
   const [creatingGroup, setCreatingGroup] = useState(false);
   const [icon, setIcon] = useState("");
-  const [iconColor, setIconColor] = useState("#ff5a1f");
+  const [iconColor, setIconColor] = useState<string>(ICON_COLORS[0]);
   const [worktreeSetupCommand, setWorktreeSetupCommand] = useState("");
-  const [agent, setAgent] = useState<TaskAgent>("claude-code");
+  // Optional at create time: null means "just create the project", a selection
+  // means "create it and start a session with that agent".
+  const [agent, setAgent] = useState<TaskAgent | null>(null);
   const [gridView, setGridView] = useState(false);
   const [colorMenuOpen, setColorMenuOpen] = useState(false);
   const [imagePath, setImagePath] = useState<string | null>(null);
@@ -177,7 +195,7 @@ export function ProjectDialog({
   const [uploading, setUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [autoStart, setAutoStart] = useState(true);
+  const [pinned, setPinned] = useState(true);
   const [confirmingClose, setConfirmingClose] = useState(false);
   const nameRef = useRef<HTMLInputElement>(null);
   const errorRef = useRef<HTMLDivElement>(null);
@@ -218,9 +236,15 @@ export function ProjectDialog({
         ? groups.find((group) => group.id === project.groupId)?.name ?? ""
         : "";
       const seededIcon = project?.icon || "";
-      const seededIconColor = project?.iconColor || "#ff5a1f";
-      nameRef.current?.focus();
-      nameRef.current?.select();
+      const seededIconColor = project?.iconColor || ICON_COLORS[0];
+      const startInBrowser = !project && !!getElectron();
+      // Create flow starts in the folder browser (picking the directory IS the
+      // first step; the name auto-fills from it, and committing a folder moves
+      // focus to the name field). Editing keeps the old focus-the-name start.
+      if (!startInBrowser) {
+        nameRef.current?.focus();
+        nameRef.current?.select();
+      }
       setName(seededName);
       setPath(seededPath);
       setGroupId(project?.groupId || "");
@@ -235,10 +259,19 @@ export function ProjectDialog({
       setImagePath(project?.imagePath ?? null);
       setPendingImage(null);
       setColorMenuOpen(false);
-      setAutoStart(true);
+      setAgent(null);
+      setPinned(true);
       setConfirmingClose(false);
       setSubmitting(false);
       setError(null);
+      // Seeded names track the path, so browsing may keep overwriting them;
+      // an existing project's name is the user's and must never be touched.
+      setNameTouched(!!project);
+      // Create flow opens straight into the in-app browser (the whole point:
+      // no OS dialog); editing keeps it collapsed behind Browse….
+      setFolderBrowserOpen(startInBrowser);
+      setFolderBrowserAutoFocus(startInBrowser);
+      folderSnapshotRef.current = { path: seededPath, name: seededName };
       formSeedRef.current = JSON.stringify({
         name: seededName,
         path: seededPath,
@@ -248,23 +281,17 @@ export function ProjectDialog({
         hasImage: !!project?.imagePath,
       });
     }
-    // Agent is seeded in the effect below once agentOptions has settled.
   }, [initialPath, open, project?.id]);
 
-  // Seed the agent selection to the first launchable option when the dialog
-  // opens, and re-home it if the current pick turns out to be unavailable.
+  // If the selected agent turns out to be unavailable (its CLI probe resolves
+  // to missing after the pick), drop back to "no agent" rather than starting a
+  // session that can't launch. Optional-by-default means null is a valid rest.
   useEffect(() => {
     if (!open || project) return;
-    const firstLaunchable =
-      agentOptions.find((a) => agentCanLaunch(cliAvailability, a.id))?.id ??
-      agentOptions[0]?.id ??
-      "claude-code";
     setAgent((current) =>
-      agentOptions.some((a) => a.id === current) && agentCanLaunch(cliAvailability, current)
-        ? current
-        : firstLaunchable,
+      current && agentCanLaunch(cliAvailability, current) ? current : null,
     );
-  }, [open, project, agentOptions, cliAvailability]);
+  }, [open, project, cliAvailability]);
 
   // Surface save errors even when the form has scrolled: bring the error box
   // into view (FormErrorBox is role="alert", so it also announces to AT).
@@ -315,17 +342,43 @@ export function ProjectDialog({
     setPendingImage(null);
   };
 
-  const browse = async () => {
-    const electron = getElectron();
-    if (!electron) return;
-    const result = await electron.browseFolder();
-    if (result) {
-      setPath(result);
-      if (!name.trim()) {
-        const base = basename(result);
-        if (base) setName(base);
-      }
+  // In-app folder browsing replaces the OS dialog: the highlight live-previews
+  // into the path field and (until the user types their own) the name field.
+  const previewFolder = (p: string) => {
+    setPath(p);
+    if (!nameTouched) {
+      const base = basename(p);
+      if (base) setName(base);
     }
+  };
+
+  const commitFolder = (p: string) => {
+    previewFolder(p);
+    folderSnapshotRef.current = { path: p, name: nameTouched ? name : basename(p) };
+    setFolderBrowserOpen(false);
+    // Same directory grant an OS-dialog pick records; fire-and-forget.
+    void getElectron()?.grantFolder(p);
+    nameRef.current?.focus();
+    nameRef.current?.select();
+  };
+
+  const cancelFolderBrowse = () => {
+    const snapshot = folderSnapshotRef.current;
+    if (snapshot) {
+      setPath(snapshot.path);
+      if (!nameTouched) setName(snapshot.name);
+    }
+    setFolderBrowserOpen(false);
+  };
+
+  const toggleFolderBrowser = () => {
+    if (folderBrowserOpen) {
+      cancelFolderBrowse();
+      return;
+    }
+    folderSnapshotRef.current = { path, name };
+    setFolderBrowserAutoFocus(true);
+    setFolderBrowserOpen(true);
   };
 
   const selectGroup = (group: Group) => {
@@ -379,11 +432,19 @@ export function ProjectDialog({
     return groupId || null;
   };
 
-  const submit = async (autoStart: boolean) => {
+  // A picked agent is the opt-in to launch a session; no pick just creates the
+  // project. Drives the primary button's label and the create payload alike.
+  const willStartSession = !project && agent !== null;
+
+  const submit = async () => {
     if (submitting) return;
     setError(null);
     setSubmitting(true);
     try {
+      // The final path may have been live-previewed (or hand-typed) without
+      // passing through commitFolder — record its grant here so every saved
+      // path is granted, not just explicitly committed picks. Idempotent.
+      void getElectron()?.grantFolder(path.trim());
       const effectiveGroupId = await resolveGroupIdForSave();
       const effectiveName = name.trim() || basename(path.trim());
       await onSave({
@@ -397,9 +458,10 @@ export function ProjectDialog({
           ? { worktreeSetupCommand: worktreeSetupCommand.trim() || null }
           : {
               savedAgent: agent,
-              rememberAgentSettings: true,
+              rememberAgentSettings: agent !== null,
               defaultGridView: gridView,
-              autoStart,
+              autoStart: willStartSession,
+              pinned,
             }),
       });
     } catch (e: any) {
@@ -410,18 +472,18 @@ export function ProjectDialog({
   };
 
   // Enter / Cmd+Enter runs the primary action: Save when editing; for a new
-  // project it honors the "Start a session now" toggle and the same path gate
+  // project it honors the agent pick (willStartSession) and the same path gate
   // as the button, so the keyboard path can't bypass what the button enforces.
   useHotkey(
     "dialog.submit",
     () => {
       if (confirmingClose) return;
       if (project) {
-        void submit(false);
+        void submit();
         return;
       }
       if (!path.trim()) return;
-      void submit(autoStart);
+      void submit();
     },
     { enabled: open },
   );
@@ -430,7 +492,6 @@ export function ProjectDialog({
   // project — auto initials from the name until the user overrides them.
   const derivedInitials =
     (name.trim() || basename(path.trim())).slice(0, 2).toUpperCase() || "AB";
-  const selectedAgentLabel = AGENT_REGISTRY[agent]?.label ?? "your coding agent";
   const currentFormKey = JSON.stringify({
     name,
     path,
@@ -540,7 +601,12 @@ export function ProjectDialog({
         <TextField
           label="Name (optional)"
           value={name}
-          onChange={setName}
+          onChange={(v) => {
+            setName(v);
+            // A typed name opts out of folder-name auto-sync; clearing the
+            // field hands naming back to the browser highlight.
+            setNameTouched(v.trim().length > 0);
+          }}
           inputRef={nameRef}
           placeholder={basename(path.trim()) || "defaults to folder name"}
         />
@@ -697,130 +763,138 @@ export function ProjectDialog({
       <FieldLabel>
         Working directory <span style={{ color: "var(--accent)" }}>*</span>
       </FieldLabel>
-      <div style={{ display: "flex", gap: 8 }}>
-        <div style={{ flex: 1 }}>
-          <TextField
-            mono
-            required
-            ariaLabel="Working directory (required)"
-            value={path}
-            onChange={setPath}
-            placeholder="/Users/me/dev/my-project"
-          />
+      {/* While the browser is open it IS the working-directory control —
+          breadcrumbs + highlight show the path, so the input row would just
+          duplicate state (and invite edits the browser ignores). */}
+      {!folderBrowserOpen && (
+        <div style={{ display: "flex", gap: 8 }}>
+          <div style={{ flex: 1 }}>
+            <TextField
+              mono
+              required
+              ariaLabel="Working directory (required)"
+              value={path}
+              onChange={setPath}
+              placeholder="/Users/me/dev/my-project"
+            />
+          </div>
+          {!!getElectron() && (
+            <Btn variant="solid" icon="folder" onClick={toggleFolderBrowser}>
+              Browse…
+            </Btn>
+          )}
         </div>
-        <Btn variant="solid" icon="folder" onClick={browse}>
-          Browse…
-        </Btn>
-      </div>
+      )}
+      {folderBrowserOpen && (
+        <FolderBrowser
+          initialPath={path.trim() || null}
+          autoFocus={folderBrowserAutoFocus}
+          onPreview={previewFolder}
+          onCommit={commitFolder}
+          onCancel={cancelFolderBrowse}
+        />
+      )}
     </div>
   );
 
   const startWithField = (
     <div>
       <FieldLabel>Start with</FieldLabel>
-      <div
-        role="radiogroup"
-        aria-label="Default coding agent"
+      <PickCardGroup
+        // Accessible name starts with the visible label so "Start with" is
+        // speakable (WCAG label-in-name).
+        ariaLabel="Start with — coding agent for the first session (optional)"
+        value={agent}
+        onChange={setAgent}
+        deselectable
         style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}
-      >
-        {agentOptions.map((a) => {
+        options={agentOptions.map((a) => {
           const meta = AGENT_META[a.id];
-          const selected = agent === a.id;
           const availability = availabilityFor(cliAvailability, a.id);
           const cliMissing = availability.status === "missing";
           const cliOutdated = availability.status === "outdated";
-          const disabled = !cliOutdated && !agentCanLaunch(cliAvailability, a.id);
+          // In Electron an `unknown` status only exists for the beat before the
+          // probe kicks off — treat it as still checking, never as broken.
+          const cliChecking =
+            !cliMissing &&
+            !cliOutdated &&
+            !!getElectron() &&
+            (availability.status === "checking" || availability.status === "unknown");
+          const disabled =
+            submitting || (!cliOutdated && !agentCanLaunch(cliAvailability, a.id));
+          // Reason lives in the name (not just `title`) so keyboard/AT users
+          // hear why it's unavailable; `aria-disabled` keeps it focusable.
           const statusReason = cliMissing
-            ? `${a.command} was not found on PATH`
+            ? `${a.command} not found on PATH — install it to enable`
             : cliOutdated
               ? `${a.command} must be updated before launching`
-              : null;
-          return (
-            <button
-              key={a.id}
-              type="button"
-              role="radio"
-              aria-checked={selected}
-              // Reason lives in the name (not just `title`) so keyboard/AT users
-              // hear why it's unavailable; `aria-disabled` keeps it focusable.
-              aria-label={disabled && statusReason ? `${a.label} — ${statusReason}` : a.label}
-              aria-disabled={disabled || undefined}
-              onClick={() => !disabled && setAgent(a.id)}
-              className="mc-pick-card"
-              title={statusReason ?? undefined}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 9,
-                textAlign: "left",
-                padding: "9px 10px",
-                background: selected ? "var(--surface-2)" : "var(--surface-0)",
-                border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
-                borderRadius: 7,
-                cursor: disabled ? "not-allowed" : "pointer",
-                opacity: disabled ? 0.5 : 1,
-              }}
-            >
-              <div
-                key={selected ? "on" : "off"}
-                className={selected ? "mc-pick-pop" : undefined}
-                style={{
-                  width: 26,
-                  height: 26,
-                  borderRadius: 6,
-                  background: `${meta.color}22`,
-                  border: `1px solid ${meta.color}44`,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  color: meta.color,
-                  flex: "0 0 auto",
-                }}
-              >
-                <AgentLogo agent={a.id} size={17} title={a.label} />
-              </div>
-              <span
-                style={{
-                  minWidth: 0,
-                  fontSize: 12,
-                  fontWeight: 600,
-                  color: "var(--text)",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {a.label}
-              </span>
-              {(cliMissing || cliOutdated) && (
-                <span
-                  aria-hidden
-                  title={cliMissing ? "CLI not found on PATH" : "Update required"}
+              : cliChecking
+                ? `checking ${a.command} availability…`
+                : null;
+          return {
+            value: a.id,
+            ariaLabel: disabled && statusReason ? `${a.label} — ${statusReason}` : a.label,
+            title: statusReason ?? undefined,
+            disabled,
+            content: (selected: boolean) => (
+              <>
+                <div
+                  key={selected ? "on" : "off"}
+                  className={selected ? "mc-pick-pop" : undefined}
                   style={{
-                    marginLeft: "auto",
-                    width: 6,
-                    height: 6,
-                    borderRadius: "50%",
-                    background: "var(--status-failed)",
+                    width: 26,
+                    height: 26,
+                    borderRadius: 6,
+                    background: `${meta.color}22`,
+                    border: `1px solid ${meta.color}44`,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    color: meta.color,
                     flex: "0 0 auto",
                   }}
-                />
-              )}
-            </button>
-          );
+                >
+                  <AgentLogo agent={a.id} size={17} />
+                </div>
+                <span
+                  style={{
+                    minWidth: 0,
+                    fontSize: 12,
+                    fontWeight: 600,
+                    color: "var(--text)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {a.label}
+                </span>
+                {(cliMissing || cliOutdated || cliChecking) && (
+                  <span
+                    aria-hidden
+                    className={cliChecking ? "mc-availability-checking" : undefined}
+                    style={{
+                      marginLeft: "auto",
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      // Severity-tiered: missing = failed (can't launch at all),
+                      // outdated = warning (launchable, but update needed),
+                      // checking = faint pulse (probe still running).
+                      background: cliChecking
+                        ? "var(--text-faint)"
+                        : cliMissing
+                          ? "var(--status-failed)"
+                          : "var(--status-warning, var(--accent))",
+                      flex: "0 0 auto",
+                    }}
+                  />
+                )}
+              </>
+            ),
+          };
         })}
-      </div>
-      <div
-        style={{
-          fontFamily: "var(--mono)",
-          fontSize: 10.5,
-          color: "var(--text-faint)",
-          marginTop: 7,
-          lineHeight: 1.4,
-        }}
-      >
-        The default for new sessions — switch agents anytime.
-      </div>
+      />
     </div>
   );
 
@@ -830,39 +904,22 @@ export function ProjectDialog({
   const layoutField = (
     <div>
       <FieldLabel>Layout</FieldLabel>
-      <div
-        role="radiogroup"
-        aria-label="Default layout"
+      <PickCardGroup
+        ariaLabel="Layout — default session layout"
+        value={gridView ? "grid" : "list"}
+        onChange={(v) => setGridView(v === "grid")}
         style={{ display: "grid", gap: 8 }}
-      >
-        {(
+        options={(
           [
-            { value: false, label: "List", variant: "list" as const },
-            { value: true, label: "Grid", variant: "grid" as const },
+            { label: "List", variant: "list" as const },
+            { label: "Grid", variant: "grid" as const },
           ]
-        ).map((opt) => {
-          const selected = gridView === opt.value;
-          return (
-            <button
-              key={opt.label}
-              type="button"
-              role="radio"
-              aria-checked={selected}
-              aria-label={`${opt.label} layout`}
-              onClick={() => setGridView(opt.value)}
-              className="mc-pick-card"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 9,
-                textAlign: "left",
-                padding: "9px 10px",
-                background: selected ? "var(--surface-2)" : "var(--surface-0)",
-                border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
-                borderRadius: 7,
-                cursor: "pointer",
-              }}
-            >
+        ).map((opt) => ({
+          value: opt.variant,
+          ariaLabel: `${opt.label} layout`,
+          disabled: submitting,
+          content: (selected: boolean) => (
+            <>
               <span
                 key={selected ? "on" : "off"}
                 className={selected ? "mc-pick-pop" : undefined}
@@ -873,10 +930,10 @@ export function ProjectDialog({
               <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text)" }}>
                 {opt.label}
               </span>
-            </button>
-          );
-        })}
-      </div>
+            </>
+          ),
+        }))}
+      />
     </div>
   );
 
@@ -1142,7 +1199,7 @@ export function ProjectDialog({
       open={open}
       onClose={requestClose}
       title={project ? "Edit project" : "Add project"}
-      width={project ? 520 : 540}
+      width={project ? 600 : 620}
       footer={
         project ? (
           <>
@@ -1152,7 +1209,7 @@ export function ProjectDialog({
               </Btn>
             </EscTooltip>
             <HotkeyTooltip action="dialog.submit">
-              <Btn variant="primary" onClick={() => void submit(false)} disabled={submitting}>
+              <Btn variant="primary" onClick={() => void submit()} disabled={submitting}>
                 Save
               </Btn>
             </HotkeyTooltip>
@@ -1193,21 +1250,21 @@ export function ProjectDialog({
                 Add a working directory to create.
               </span>
             ) : (
-              // Compact footer toggle: sits next to the button it modifies
-              // ("Create & start session" ⇄ "Create project").
+              // Compact footer toggle: pinning is independent of whether a
+              // session starts — that's driven by the agent pick above.
               <div
                 style={{ marginRight: "auto", display: "flex", alignItems: "center", gap: 8 }}
-                title={`Launches ${selectedAgentLabel} in this project as soon as it's created.`}
+                title="Keep this project pinned to the top of your sidebar."
               >
                 <ToggleSwitch
-                  checked={autoStart}
-                  onChange={setAutoStart}
-                  label="Start a session now"
-                  labelledBy="project-autostart-label"
+                  checked={pinned}
+                  onChange={setPinned}
+                  label="Pin project"
+                  labelledBy="project-pin-label"
                 />
                 <span
-                  id="project-autostart-label"
-                  onClick={() => setAutoStart(!autoStart)}
+                  id="project-pin-label"
+                  onClick={() => setPinned(!pinned)}
                   style={{
                     fontFamily: "var(--mono)",
                     fontSize: 11.5,
@@ -1216,7 +1273,7 @@ export function ProjectDialog({
                     userSelect: "none",
                   }}
                 >
-                  Start a session now
+                  Pin project
                 </span>
               </div>
             )}
@@ -1228,11 +1285,11 @@ export function ProjectDialog({
             <HotkeyTooltip action="dialog.submit">
               <Btn
                 variant="primary"
-                icon={autoStart ? "terminal" : undefined}
-                onClick={() => void submit(autoStart)}
+                icon={willStartSession ? "terminal" : undefined}
+                onClick={() => void submit()}
                 disabled={submitting || !path.trim()}
               >
-                {autoStart ? "Create & start session" : "Create project"}
+                {willStartSession ? "Create & start session" : "Create project"}
               </Btn>
             </HotkeyTooltip>
           </>
@@ -1251,18 +1308,12 @@ export function ProjectDialog({
         </div>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-          <GroupCard
-            title="Project"
-            description="Where it lives on disk and how it shows up in your sidebar."
-          >
+          <GroupCard title="Project">
             {identityRow}
             {dirField}
             {groupField}
           </GroupCard>
-          <GroupCard
-            title="Sessions"
-            description="Defaults for the coding agents you'll run in this project."
-          >
+          <GroupCard title="Sessions">
             {/* Agent picker and layout side-by-side — layout is the lighter
                 choice, so it sits as a slim column with a rule between them. */}
             <div style={{ display: "flex", gap: 14, alignItems: "stretch" }}>

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -1,14 +1,97 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { Modal } from "~/components/ui/Modal";
 import { FormErrorBox } from "~/components/ui/FormErrorBox";
 import { Btn } from "~/components/ui/Btn";
 import { TextField } from "~/components/ui/TextField";
 import { Icon } from "~/components/ui/Icon";
+import { AgentLogo } from "~/components/ui/AgentLogo";
 import { HotkeyTooltip, EscTooltip } from "~/components/ui/Tooltip";
 import { useHotkey } from "~/lib/use-hotkey";
-import { ICON_COLORS } from "~/lib/design-meta";
+import { AGENT_META, ICON_COLORS } from "~/lib/design-meta";
+import {
+  agentCanLaunch,
+  availabilityFor,
+  useCliAvailability,
+} from "~/lib/cli-availability";
 import { getElectron } from "~/lib/electron";
+import { useSettings } from "~/queries";
+import { AGENT_REGISTRY } from "~/shared/agents";
+import {
+  DEFAULT_AGENT_LAUNCHER_CONFIG,
+  visibleLauncherAgents,
+} from "~/shared/agent-launcher-config";
+import type { TaskAgent } from "~/shared/domain";
 import type { Group, Project } from "~/db/schema";
+
+const fieldLabelStyle: CSSProperties = {
+  fontFamily: "var(--mono)",
+  fontSize: 10.5,
+  fontWeight: 500,
+  color: "var(--text-dim)",
+  letterSpacing: "0.05em",
+  textTransform: "uppercase",
+  display: "block",
+  marginBottom: 6,
+};
+
+function FieldLabel({ children }: { children: ReactNode }) {
+  return <label style={fieldLabelStyle}>{children}</label>;
+}
+
+/** Anchors each column of the create form with a quiet titled hairline. */
+function ColumnHeading({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        fontSize: 12,
+        fontWeight: 600,
+        color: "var(--text)",
+        paddingBottom: 8,
+        borderBottom: "1px solid var(--border)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Tiny wireframe that shows what each layout does at a glance. */
+function LayoutGlyph({ variant, active }: { variant: "list" | "grid"; active: boolean }) {
+  const cell = active ? "var(--accent)" : "var(--text-faint)";
+  const frame: CSSProperties = {
+    width: 34,
+    height: 24,
+    borderRadius: 4,
+    border: "1px solid var(--border)",
+    background: "var(--surface-0)",
+    padding: 4,
+    flex: "0 0 auto",
+  };
+  if (variant === "list") {
+    return (
+      <div style={{ ...frame, display: "flex", flexDirection: "column", gap: 2.5 }}>
+        {[0, 1, 2].map((i) => (
+          <div key={i} style={{ height: 4, borderRadius: 1.5, background: cell, opacity: active ? 1 : 0.6 }} />
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div
+      style={{
+        ...frame,
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr",
+        gridTemplateRows: "1fr 1fr",
+        gap: 2.5,
+      }}
+    >
+      {[0, 1, 2, 3].map((i) => (
+        <div key={i} style={{ borderRadius: 1.5, background: cell, opacity: active ? 1 : 0.6 }} />
+      ))}
+    </div>
+  );
+}
 
 export function ProjectDialog({
   open,
@@ -33,6 +116,11 @@ export function ProjectDialog({
     imagePath?: string | null;
     pendingImage?: { sourcePath: string; extension: string } | null;
     worktreeSetupCommand?: string | null;
+    // Create-only onboarding fields (undefined when editing an existing project).
+    savedAgent?: TaskAgent | null;
+    rememberAgentSettings?: boolean;
+    defaultGridView?: boolean;
+    autoStart?: boolean;
   }) => Promise<void> | void;
   onCreateGroup?: (name: string) => Promise<Group> | Group;
 }) {
@@ -45,11 +133,14 @@ export function ProjectDialog({
   const [icon, setIcon] = useState("");
   const [iconColor, setIconColor] = useState("#ff5a1f");
   const [worktreeSetupCommand, setWorktreeSetupCommand] = useState("");
+  const [agent, setAgent] = useState<TaskAgent>("claude-code");
+  const [gridView, setGridView] = useState(false);
   const [imagePath, setImagePath] = useState<string | null>(null);
   const [pendingImage, setPendingImage] = useState<
     { sourcePath: string; extension: string } | null
   >(null);
   const [uploading, setUploading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const nameRef = useRef<HTMLInputElement>(null);
   const selectedGroup = groupId ? groups.find((group) => group.id === groupId) ?? null : null;
@@ -62,6 +153,19 @@ export function ProjectDialog({
     : groups;
   const canCreateGroup =
     !!onCreateGroup && !!groupQuery.trim() && !exactGroupMatch;
+
+  const cliAvailability = useCliAvailability();
+  const { data: settings } = useSettings();
+  // Order + visibility mirror the New-session picker (Settings → Providers), so
+  // the agent chosen here reads as the same set the user launches with later.
+  const launcherConfig = settings?.agentLauncherConfig ?? DEFAULT_AGENT_LAUNCHER_CONFIG;
+  const agentOptions = useMemo(
+    () =>
+      visibleLauncherAgents(launcherConfig)
+        .filter((id) => AGENT_REGISTRY[id].uiVisible)
+        .map((id) => ({ id, ...AGENT_REGISTRY[id] })),
+    [launcherConfig],
+  );
 
   useEffect(() => {
     if (open) {
@@ -81,11 +185,29 @@ export function ProjectDialog({
       setIcon(project?.icon || "");
       setIconColor(project?.iconColor || "#ff5a1f");
       setWorktreeSetupCommand(project?.worktreeSetupCommand || "");
+      setGridView(project?.defaultGridView ?? false);
       setImagePath(project?.imagePath ?? null);
       setPendingImage(null);
+      setSubmitting(false);
       setError(null);
     }
+    // Agent is seeded in the effect below once agentOptions has settled.
   }, [initialPath, open, project?.id]);
+
+  // Seed the agent selection to the first launchable option when the dialog
+  // opens, and re-home it if the current pick turns out to be unavailable.
+  useEffect(() => {
+    if (!open || project) return;
+    const firstLaunchable =
+      agentOptions.find((a) => agentCanLaunch(cliAvailability, a.id))?.id ??
+      agentOptions[0]?.id ??
+      "claude-code";
+    setAgent((current) =>
+      agentOptions.some((a) => a.id === current) && agentCanLaunch(cliAvailability, current)
+        ? current
+        : firstLaunchable,
+    );
+  }, [open, project, agentOptions, cliAvailability]);
 
   useEffect(() => {
     if (!open || !selectedGroup || groupQuery.trim()) return;
@@ -193,8 +315,10 @@ export function ProjectDialog({
     return groupId || null;
   };
 
-  const submit = async () => {
+  const submit = async (autoStart: boolean) => {
+    if (submitting) return;
     setError(null);
+    setSubmitting(true);
     try {
       const effectiveGroupId = await resolveGroupIdForSave();
       const effectiveName =
@@ -206,429 +330,608 @@ export function ProjectDialog({
         iconColor,
         groupId: effectiveGroupId,
         ...(project ? { imagePath } : { pendingImage }),
-        ...(project ? { worktreeSetupCommand: worktreeSetupCommand.trim() || null } : {}),
+        ...(project
+          ? { worktreeSetupCommand: worktreeSetupCommand.trim() || null }
+          : {
+              savedAgent: agent,
+              rememberAgentSettings: true,
+              defaultGridView: gridView,
+              autoStart,
+            }),
       });
     } catch (e: any) {
       setError(e?.message || "Save failed");
+    } finally {
+      setSubmitting(false);
     }
   };
 
-  useHotkey("dialog.submit", () => void submit(), { enabled: open });
+  // Enter / Cmd+Enter runs the primary action: "Create & start" for a new
+  // project, "Save" when editing (autoStart is ignored on the edit path).
+  useHotkey("dialog.submit", () => void submit(!project), { enabled: open });
+
+  const nameField = (
+    <TextField
+      label="Name (optional)"
+      value={name}
+      onChange={setName}
+      inputRef={nameRef}
+      placeholder={path.trim().split(/[\\/]/).filter(Boolean).pop() || "defaults to folder name"}
+    />
+  );
+
+  const dirField = (
+    <div>
+      <FieldLabel>Working directory</FieldLabel>
+      <div style={{ display: "flex", gap: 8 }}>
+        <div style={{ flex: 1 }}>
+          <TextField
+            mono
+            value={path}
+            onChange={setPath}
+            placeholder="/Users/me/dev/my-project"
+          />
+        </div>
+        <Btn variant="solid" icon="folder" onClick={browse}>
+          Browse…
+        </Btn>
+      </div>
+    </div>
+  );
+
+  const startWithField = (
+    <div>
+      <FieldLabel>Start with</FieldLabel>
+      <div
+        role="radiogroup"
+        aria-label="Default coding agent"
+        style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}
+      >
+        {agentOptions.map((a) => {
+          const meta = AGENT_META[a.id];
+          const selected = agent === a.id;
+          const availability = availabilityFor(cliAvailability, a.id);
+          const cliMissing = availability.status === "missing";
+          const cliOutdated = availability.status === "outdated";
+          const disabled = !cliOutdated && !agentCanLaunch(cliAvailability, a.id);
+          return (
+            <button
+              key={a.id}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-label={a.label}
+              disabled={disabled}
+              onClick={() => !disabled && setAgent(a.id)}
+              title={
+                cliMissing
+                  ? `${a.command} was not found on PATH`
+                  : cliOutdated
+                    ? `${a.command} must be updated before launching`
+                    : undefined
+              }
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 9,
+                textAlign: "left",
+                padding: "9px 10px",
+                background: selected ? "var(--surface-2)" : "var(--surface-0)",
+                border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
+                borderRadius: 8,
+                boxShadow: selected ? "0 0 0 1px var(--accent)" : "none",
+                cursor: disabled ? "not-allowed" : "pointer",
+                opacity: disabled ? 0.5 : 1,
+                transition: "border-color 150ms ease, background 150ms ease",
+              }}
+            >
+              <div
+                style={{
+                  width: 26,
+                  height: 26,
+                  borderRadius: 6,
+                  background: `${meta.color}22`,
+                  border: `1px solid ${meta.color}44`,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: meta.color,
+                  flex: "0 0 auto",
+                }}
+              >
+                <AgentLogo agent={a.id} size={17} title={a.label} />
+              </div>
+              <span
+                style={{
+                  minWidth: 0,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: "var(--text)",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {a.label}
+              </span>
+              {(cliMissing || cliOutdated) && (
+                <span
+                  aria-hidden
+                  title={cliMissing ? "CLI not found on PATH" : "Update required"}
+                  style={{
+                    marginLeft: "auto",
+                    width: 6,
+                    height: 6,
+                    borderRadius: "50%",
+                    background: "var(--status-failed)",
+                    flex: "0 0 auto",
+                  }}
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 10.5,
+          color: "var(--text-faint)",
+          marginTop: 7,
+          lineHeight: 1.4,
+        }}
+      >
+        Launches your sessions — change anytime.
+      </div>
+    </div>
+  );
+
+  const layoutField = (
+    <div>
+      <FieldLabel>Layout</FieldLabel>
+      <div
+        role="radiogroup"
+        aria-label="Default layout"
+        style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}
+      >
+        {(
+          [
+            { value: false, label: "List", desc: "One at a time", variant: "list" as const },
+            { value: true, label: "Grid", desc: "All at once", variant: "grid" as const },
+          ]
+        ).map((opt) => {
+          const selected = gridView === opt.value;
+          return (
+            <button
+              key={opt.label}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-label={`${opt.label} layout`}
+              onClick={() => setGridView(opt.value)}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                textAlign: "left",
+                padding: "9px 10px",
+                background: selected ? "var(--surface-2)" : "var(--surface-0)",
+                border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
+                borderRadius: 8,
+                boxShadow: selected ? "0 0 0 1px var(--accent)" : "none",
+                cursor: "pointer",
+                transition: "border-color 150ms ease, background 150ms ease",
+              }}
+            >
+              <LayoutGlyph variant={opt.variant} active={selected} />
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)" }}>
+                  {opt.label}
+                </div>
+                <div
+                  style={{
+                    fontFamily: "var(--mono)",
+                    fontSize: 10,
+                    color: "var(--text-dim)",
+                    marginTop: 2,
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  {opt.desc}
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  const imageField = (
+    <div>
+      <FieldLabel>Custom image</FieldLabel>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <Btn variant="solid" icon="folder" onClick={chooseImage} disabled={uploading}>
+          {uploading
+            ? "Uploading…"
+            : imagePath || pendingImage
+              ? "Replace image…"
+              : "Choose image…"}
+        </Btn>
+        {(imagePath || pendingImage) && (
+          <Btn variant="ghost" onClick={removeImage}>
+            Remove
+          </Btn>
+        )}
+        {pendingImage && (
+          <span
+            style={{ fontFamily: "var(--mono)", fontSize: 11, color: "var(--text-dim)" }}
+          >
+            {pendingImage.sourcePath.split(/[\\/]/).pop()} — uploads on save
+          </span>
+        )}
+        <span
+          style={{ fontFamily: "var(--mono)", fontSize: 10.5, color: "var(--text-faint)" }}
+        >
+          PNG / JPG / WebP / GIF, ≤ 5MB
+        </span>
+      </div>
+    </div>
+  );
+
+  const iconField = (
+    <div>
+      <FieldLabel>Icon (fallback)</FieldLabel>
+      <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+        <input
+          value={icon}
+          onChange={(e) => setIcon(e.target.value.slice(0, 2).toUpperCase())}
+          maxLength={2}
+          placeholder="AB"
+          aria-label="Icon initials"
+          style={{
+            width: 56,
+            textAlign: "center",
+            background: "var(--surface-0)",
+            border: "1px solid var(--border)",
+            borderRadius: 7,
+            outline: 0,
+            color: "var(--text)",
+            padding: "9px 8px",
+            fontFamily: "var(--mono)",
+            fontSize: 14,
+            fontWeight: 600,
+          }}
+        />
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {ICON_COLORS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              aria-label={`Icon color ${c}`}
+              aria-pressed={iconColor === c}
+              onClick={() => setIconColor(c)}
+              style={{
+                width: 24,
+                height: 24,
+                borderRadius: 6,
+                background: c,
+                border: iconColor === c ? "2px solid var(--text)" : "2px solid transparent",
+                cursor: "pointer",
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+
+  const groupField = (
+    <div>
+      <FieldLabel>Group</FieldLabel>
+      <div style={{ position: "relative" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            background: "var(--surface-0)",
+            border: `1px solid ${groupTypeaheadOpen ? "var(--accent)" : "var(--border)"}`,
+            borderRadius: 7,
+            padding: "0 8px 0 12px",
+            minHeight: 38,
+          }}
+        >
+          {selectedGroup && (
+            <span
+              aria-hidden
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                background: selectedGroup.color,
+                flex: "0 0 auto",
+              }}
+            />
+          )}
+          <input
+            value={groupQuery}
+            onFocus={() => setGroupTypeaheadOpen(true)}
+            onBlur={() => {
+              window.setTimeout(() => setGroupTypeaheadOpen(false), 100);
+            }}
+            onChange={(e) => {
+              const next = e.target.value;
+              setGroupQuery(next);
+              setGroupTypeaheadOpen(true);
+              if (!next.trim()) setGroupId("");
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void commitGroupQuery();
+              } else if (e.key === "Escape") {
+                setGroupTypeaheadOpen(false);
+              }
+            }}
+            role="combobox"
+            aria-expanded={groupTypeaheadOpen}
+            aria-controls="project-group-options"
+            aria-label="Project group"
+            placeholder="Ungrouped or group name"
+            style={{
+              flex: 1,
+              minWidth: 0,
+              background: "transparent",
+              border: 0,
+              outline: 0,
+              color: "var(--text)",
+              padding: "9px 0",
+              fontFamily: "var(--mono)",
+              fontSize: 12.5,
+            }}
+          />
+          {(groupQuery || groupId) && (
+            <button
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={clearGroup}
+              aria-label="Clear group"
+              title="Clear group"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 24,
+                height: 24,
+                border: 0,
+                background: "transparent",
+                color: "var(--text-faint)",
+                cursor: "pointer",
+                padding: 0,
+              }}
+            >
+              <Icon name="x" size={12} />
+            </button>
+          )}
+        </div>
+        {groupTypeaheadOpen && (
+          <div
+            id="project-group-options"
+            role="listbox"
+            style={{
+              position: "absolute",
+              zIndex: 20,
+              left: 0,
+              right: 0,
+              top: "calc(100% + 6px)",
+              maxHeight: 220,
+              overflow: "auto",
+              background: "var(--surface-1)",
+              border: "1px solid var(--border)",
+              borderRadius: 8,
+              boxShadow: "0 14px 36px rgba(0, 0, 0, 0.32)",
+              padding: 6,
+            }}
+          >
+            <button
+              type="button"
+              role="option"
+              aria-selected={groupId === ""}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={clearGroup}
+              style={{
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                minHeight: 32,
+                border: 0,
+                borderRadius: 6,
+                background: groupId === "" ? "var(--accent-dim)" : "transparent",
+                color: groupId === "" ? "var(--accent-ink)" : "var(--text-dim)",
+                cursor: "pointer",
+                padding: "7px 9px",
+                textAlign: "left",
+                fontFamily: "var(--mono)",
+                fontSize: 11.5,
+              }}
+            >
+              Ungrouped
+            </button>
+            {filteredGroups.map((group) => (
+              <button
+                key={group.id}
+                type="button"
+                role="option"
+                aria-selected={groupId === group.id}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => selectGroup(group)}
+                style={{
+                  width: "100%",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  minHeight: 32,
+                  border: 0,
+                  borderRadius: 6,
+                  background: groupId === group.id ? "var(--accent-dim)" : "transparent",
+                  color: groupId === group.id ? "var(--accent-ink)" : "var(--text)",
+                  cursor: "pointer",
+                  padding: "7px 9px",
+                  textAlign: "left",
+                  fontFamily: "var(--mono)",
+                  fontSize: 11.5,
+                }}
+              >
+                <span
+                  aria-hidden
+                  style={{ width: 8, height: 8, borderRadius: "50%", background: group.color }}
+                />
+                <span
+                  style={{
+                    minWidth: 0,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {group.name}
+                </span>
+              </button>
+            ))}
+            {canCreateGroup && (
+              <button
+                type="button"
+                role="option"
+                aria-selected={false}
+                disabled={creatingGroup}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => void commitGroupQuery()}
+                style={{
+                  width: "100%",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  minHeight: 32,
+                  border: 0,
+                  borderRadius: 6,
+                  background: "transparent",
+                  color: "var(--accent-ink)",
+                  cursor: creatingGroup ? "default" : "pointer",
+                  opacity: creatingGroup ? 0.65 : 1,
+                  padding: "7px 9px",
+                  textAlign: "left",
+                  fontFamily: "var(--mono)",
+                  fontSize: 11.5,
+                }}
+              >
+                <Icon name="plus" size={12} />
+                {creatingGroup ? "Creating..." : `Create "${groupQuery.trim()}"`}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  const worktreeField = project ? (
+    <TextField
+      mono
+      label="New worktree setup command"
+      value={worktreeSetupCommand}
+      onChange={(value) => setWorktreeSetupCommand(value.slice(0, 500))}
+      placeholder="pnpm i"
+      hint="Optional. Runs once inside each newly created worktree."
+    />
+  ) : null;
 
   return (
     <Modal
       open={open}
       onClose={onClose}
       title={project ? "Edit project" : "Add project"}
-      width={520}
+      width={project ? 520 : 720}
       footer={
-        <>
-          <EscTooltip label="Cancel">
-            <Btn variant="ghost" onClick={onClose}>
-              Cancel
+        project ? (
+          <>
+            <EscTooltip label="Cancel">
+              <Btn variant="ghost" onClick={onClose}>
+                Cancel
+              </Btn>
+            </EscTooltip>
+            <HotkeyTooltip action="dialog.submit">
+              <Btn variant="primary" onClick={() => void submit(false)} disabled={submitting}>
+                Save
+              </Btn>
+            </HotkeyTooltip>
+          </>
+        ) : (
+          <>
+            <EscTooltip label="Cancel">
+              <Btn variant="ghost" onClick={onClose}>
+                Cancel
+              </Btn>
+            </EscTooltip>
+            <Btn variant="solid" onClick={() => void submit(false)} disabled={submitting}>
+              Create only
             </Btn>
-          </EscTooltip>
-          <HotkeyTooltip action="dialog.submit">
-            <Btn
-              variant="primary"
-              onClick={submit}
-              style={{
-                height: 36,
-                ["--mc-btn-height" as any]: "36px",
-                ["--mc-btn-padding-x" as any]: "18px",
-                ["--mc-btn-frame-border" as any]: "14px",
-                minWidth: 80,
-              }}
-            >
-              {project ? "Save" : "Add project"}
-            </Btn>
-          </HotkeyTooltip>
-        </>
+            <HotkeyTooltip action="dialog.submit">
+              <Btn
+                variant="primary"
+                icon="terminal"
+                onClick={() => void submit(true)}
+                disabled={submitting || !path.trim()}
+              >
+                Create &amp; start session
+              </Btn>
+            </HotkeyTooltip>
+          </>
+        )
       }
     >
-      <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
-        <TextField
-          label="Name (optional — defaults to folder name)"
-          value={name}
-          onChange={setName}
-          inputRef={nameRef}
-          placeholder={path.trim().split(/[\\/]/).filter(Boolean).pop() || "my-project"}
-        />
-
-        <div>
-          <label
+      {project ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          {nameField}
+          {dirField}
+          {imageField}
+          {iconField}
+          {groupField}
+          {worktreeField}
+          <FormErrorBox error={error} />
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <div
             style={{
-              fontFamily: "var(--mono)",
-              fontSize: 10.5,
-              fontWeight: 500,
-              color: "var(--text-dim)",
-              letterSpacing: "0.05em",
-              textTransform: "uppercase",
-              display: "block",
-              marginBottom: 6,
+              display: "grid",
+              gridTemplateColumns: "minmax(0, 0.8fr) minmax(0, 1.2fr)",
+              gap: 16,
+              alignItems: "end",
             }}
           >
-            Working directory
-          </label>
-          <div style={{ display: "flex", gap: 8 }}>
-            <div style={{ flex: 1 }}>
-              <TextField
-                mono
-                value={path}
-                onChange={setPath}
-                placeholder="/Users/me/dev/my-project"
-              />
+            {nameField}
+            {dirField}
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 22, alignItems: "start" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+              <ColumnHeading>How you'll work</ColumnHeading>
+              {startWithField}
+              {layoutField}
             </div>
-            <Btn variant="solid" icon="folder" onClick={browse}>
-              Browse…
-            </Btn>
-          </div>
-        </div>
-
-        <div>
-          <label
-            style={{
-              fontFamily: "var(--mono)",
-              fontSize: 10.5,
-              fontWeight: 500,
-              color: "var(--text-dim)",
-              letterSpacing: "0.05em",
-              textTransform: "uppercase",
-              display: "block",
-              marginBottom: 6,
-            }}
-          >
-            Custom image
-          </label>
-          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-            <Btn variant="solid" icon="folder" onClick={chooseImage} disabled={uploading}>
-              {uploading
-                ? "Uploading…"
-                : imagePath || pendingImage
-                  ? "Replace image…"
-                  : "Choose image…"}
-            </Btn>
-            {(imagePath || pendingImage) && (
-              <Btn variant="ghost" onClick={removeImage}>
-                Remove
-              </Btn>
-            )}
-            {pendingImage && (
-              <span
-                style={{
-                  fontFamily: "var(--mono)",
-                  fontSize: 11,
-                  color: "var(--text-dim)",
-                }}
-              >
-                {pendingImage.sourcePath.split(/[\\/]/).pop()} — uploads on save
-              </span>
-            )}
-            <span
-              style={{
-                fontFamily: "var(--mono)",
-                fontSize: 11,
-                color: "var(--text-faint)",
-              }}
-            >
-              PNG / JPG / WebP / GIF, ≤ 5MB
-            </span>
-          </div>
-        </div>
-
-        <div>
-          <label
-            style={{
-              fontFamily: "var(--mono)",
-              fontSize: 10.5,
-              fontWeight: 500,
-              color: "var(--text-dim)",
-              letterSpacing: "0.05em",
-              textTransform: "uppercase",
-              display: "block",
-              marginBottom: 6,
-            }}
-          >
-            Icon (fallback)
-          </label>
-          <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
-            <input
-              value={icon}
-              onChange={(e) => setIcon(e.target.value.slice(0, 2).toUpperCase())}
-              maxLength={2}
-              placeholder="AB"
-              style={{
-                width: 60,
-                textAlign: "center",
-                background: "var(--surface-0)",
-                border: "1px solid var(--border)",
-                borderRadius: 7,
-                outline: 0,
-                color: "var(--text)",
-                padding: "9px 8px",
-                fontFamily: "var(--mono)",
-                fontSize: 14,
-                fontWeight: 600,
-              }}
-            />
-            <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-              {ICON_COLORS.map((c) => (
-                <button
-                  key={c}
-                  onClick={() => setIconColor(c)}
-                  style={{
-                    width: 24,
-                    height: 24,
-                    borderRadius: 6,
-                    background: c,
-                    border: iconColor === c ? "2px solid var(--text)" : "2px solid transparent",
-                    cursor: "pointer",
-                  }}
-                />
-              ))}
+            <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+              <ColumnHeading>Appearance &amp; grouping</ColumnHeading>
+              {imageField}
+              {iconField}
+              {groupField}
             </div>
           </div>
+          <FormErrorBox error={error} />
         </div>
-
-        <div>
-          <label
-            style={{
-              fontFamily: "var(--mono)",
-              fontSize: 10.5,
-              fontWeight: 500,
-              color: "var(--text-dim)",
-              letterSpacing: "0.05em",
-              textTransform: "uppercase",
-              display: "block",
-              marginBottom: 6,
-            }}
-          >
-            Group
-          </label>
-          <div style={{ position: "relative" }}>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                background: "var(--surface-0)",
-                border: `1px solid ${groupTypeaheadOpen ? "var(--accent)" : "var(--border)"}`,
-                borderRadius: 7,
-                padding: "0 8px 0 12px",
-                minHeight: 38,
-              }}
-            >
-              {selectedGroup && (
-                <span
-                  aria-hidden
-                  style={{
-                    width: 8,
-                    height: 8,
-                    borderRadius: "50%",
-                    background: selectedGroup.color,
-                    flex: "0 0 auto",
-                  }}
-                />
-              )}
-              <input
-                value={groupQuery}
-                onFocus={() => setGroupTypeaheadOpen(true)}
-                onBlur={() => {
-                  window.setTimeout(() => setGroupTypeaheadOpen(false), 100);
-                }}
-                onChange={(e) => {
-                  const next = e.target.value;
-                  setGroupQuery(next);
-                  setGroupTypeaheadOpen(true);
-                  if (!next.trim()) setGroupId("");
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    void commitGroupQuery();
-                  } else if (e.key === "Escape") {
-                    setGroupTypeaheadOpen(false);
-                  }
-                }}
-                role="combobox"
-                aria-expanded={groupTypeaheadOpen}
-                aria-controls="project-group-options"
-                aria-label="Project group"
-                placeholder="Ungrouped or group name"
-                style={{
-                  flex: 1,
-                  minWidth: 0,
-                  background: "transparent",
-                  border: 0,
-                  outline: 0,
-                  color: "var(--text)",
-                  padding: "9px 0",
-                  fontFamily: "var(--mono)",
-                  fontSize: 12.5,
-                }}
-              />
-              {(groupQuery || groupId) && (
-                <button
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={clearGroup}
-                  aria-label="Clear group"
-                  title="Clear group"
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    width: 24,
-                    height: 24,
-                    border: 0,
-                    background: "transparent",
-                    color: "var(--text-faint)",
-                    cursor: "pointer",
-                    padding: 0,
-                  }}
-                >
-                  <Icon name="x" size={12} />
-                </button>
-              )}
-            </div>
-            {groupTypeaheadOpen && (
-              <div
-                id="project-group-options"
-                role="listbox"
-                style={{
-                  position: "absolute",
-                  zIndex: 20,
-                  left: 0,
-                  right: 0,
-                  top: "calc(100% + 6px)",
-                  maxHeight: 220,
-                  overflow: "auto",
-                  background: "var(--surface-1)",
-                  border: "1px solid var(--border)",
-                  borderRadius: 8,
-                  boxShadow: "0 14px 36px rgba(0, 0, 0, 0.32)",
-                  padding: 6,
-                }}
-              >
-                <button
-                  type="button"
-                  role="option"
-                  aria-selected={groupId === ""}
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={clearGroup}
-                  style={{
-                    width: "100%",
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 8,
-                    minHeight: 32,
-                    border: 0,
-                    borderRadius: 6,
-                    background: groupId === "" ? "var(--accent-dim)" : "transparent",
-                    color: groupId === "" ? "var(--accent-ink)" : "var(--text-dim)",
-                    cursor: "pointer",
-                    padding: "7px 9px",
-                    textAlign: "left",
-                    fontFamily: "var(--mono)",
-                    fontSize: 11.5,
-                  }}
-                >
-                  Ungrouped
-                </button>
-                {filteredGroups.map((group) => (
-                  <button
-                    key={group.id}
-                    type="button"
-                    role="option"
-                    aria-selected={groupId === group.id}
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => selectGroup(group)}
-                    style={{
-                      width: "100%",
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 8,
-                      minHeight: 32,
-                      border: 0,
-                      borderRadius: 6,
-                      background: groupId === group.id ? "var(--accent-dim)" : "transparent",
-                      color: groupId === group.id ? "var(--accent-ink)" : "var(--text)",
-                      cursor: "pointer",
-                      padding: "7px 9px",
-                      textAlign: "left",
-                      fontFamily: "var(--mono)",
-                      fontSize: 11.5,
-                    }}
-                  >
-                    <span
-                      aria-hidden
-                      style={{
-                        width: 8,
-                        height: 8,
-                        borderRadius: "50%",
-                        background: group.color,
-                      }}
-                    />
-                    <span
-                      style={{
-                        minWidth: 0,
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      {group.name}
-                    </span>
-                  </button>
-                ))}
-                {canCreateGroup && (
-                  <button
-                    type="button"
-                    role="option"
-                    aria-selected={false}
-                    disabled={creatingGroup}
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => void commitGroupQuery()}
-                    style={{
-                      width: "100%",
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 8,
-                      minHeight: 32,
-                      border: 0,
-                      borderRadius: 6,
-                      background: "transparent",
-                      color: "var(--accent-ink)",
-                      cursor: creatingGroup ? "default" : "pointer",
-                      opacity: creatingGroup ? 0.65 : 1,
-                      padding: "7px 9px",
-                      textAlign: "left",
-                      fontFamily: "var(--mono)",
-                      fontSize: 11.5,
-                    }}
-                  >
-                    <Icon name="plus" size={12} />
-                    {creatingGroup ? "Creating..." : `Create "${groupQuery.trim()}"`}
-                  </button>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-
-        {project && (
-          <TextField
-            mono
-            label="New worktree setup command"
-            value={worktreeSetupCommand}
-            onChange={(value) => setWorktreeSetupCommand(value.slice(0, 500))}
-            placeholder="pnpm i"
-            hint="Optional. Runs once inside each newly created worktree."
-          />
-        )}
-
-        <FormErrorBox error={error} />
-      </div>
+      )}
     </Modal>
   );
 }

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -6,7 +6,7 @@ import { TextField } from "~/components/ui/TextField";
 import { Icon } from "~/components/ui/Icon";
 import { AgentLogo } from "~/components/ui/AgentLogo";
 import { ProjectIcon } from "~/components/ui/ProjectIcon";
-import { SettingsSection, ToggleRow } from "~/components/views/SettingsParts";
+import { ToggleRow } from "~/components/views/SettingsParts";
 import { HotkeyTooltip, EscTooltip } from "~/components/ui/Tooltip";
 import { useHotkey } from "~/lib/use-hotkey";
 import { AGENT_META, ICON_COLORS } from "~/lib/design-meta";
@@ -43,6 +43,45 @@ function FieldLabel({ children }: { children: ReactNode }) {
 /** Last segment of a filesystem path, ignoring trailing separators. */
 function basename(p: string): string {
   return p.split(/[\\/]/).filter(Boolean).pop() || "";
+}
+
+/**
+ * A titled group in the dialog — same title/description vocabulary as the
+ * Settings pages' SettingCard, but outlined (transparent fill) rather than
+ * filled, so the already-bordered controls inside recede instead of reading
+ * as nested cards.
+ */
+function GroupCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: 10,
+        padding: 16,
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+      }}
+    >
+      <div>
+        <div style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{title}</div>
+        <div
+          style={{ fontSize: 12, color: "var(--text-dim)", lineHeight: 1.45, marginTop: 3 }}
+        >
+          {description}
+        </div>
+      </div>
+      {children}
+    </section>
+  );
 }
 
 /** Tiny wireframe that shows what each layout does at a glance. */
@@ -131,7 +170,6 @@ export function ProjectDialog({
     { sourcePath: string; extension: string } | null
   >(null);
   const [uploading, setUploading] = useState(false);
-  const [appearanceOpen, setAppearanceOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [autoStart, setAutoStart] = useState(true);
@@ -191,7 +229,6 @@ export function ProjectDialog({
       setGridView(project?.defaultGridView ?? false);
       setImagePath(project?.imagePath ?? null);
       setPendingImage(null);
-      setAppearanceOpen(false);
       setAutoStart(true);
       setConfirmingClose(false);
       setSubmitting(false);
@@ -387,11 +424,6 @@ export function ProjectDialog({
   const derivedInitials =
     (name.trim() || basename(path.trim())).slice(0, 2).toUpperCase() || "AB";
   const previewInitials = icon || derivedInitials;
-  const appearanceSummary = pendingImage
-    ? basename(pendingImage.sourcePath) || "custom image"
-    : icon
-      ? `Initials ${icon}`
-      : `Auto initials · ${derivedInitials}`;
 
   const selectedAgentLabel = AGENT_REGISTRY[agent]?.label ?? "your coding agent";
   const currentFormKey = JSON.stringify({
@@ -604,6 +636,10 @@ export function ProjectDialog({
                 border: 0,
                 borderRadius: 5,
                 background: selected ? "var(--surface-2)" : "transparent",
+                // Single accent edge = selected, the same signal the agent
+                // cards use — one selection language, and a non-color cue so
+                // it doesn't rely on the glyph hue alone.
+                boxShadow: selected ? "0 0 0 1px var(--accent)" : "none",
                 color: selected ? "var(--text)" : "var(--text-dim)",
                 cursor: "pointer",
               }}
@@ -659,6 +695,18 @@ export function ProjectDialog({
     <div>
       <FieldLabel>{project ? "Icon (fallback)" : "Initials & color"}</FieldLabel>
       <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+        {!project && (
+          <span
+            key={`${previewInitials}-${iconColor}`}
+            className="mc-identity-pop"
+            style={{ display: "inline-flex", flex: "0 0 auto" }}
+          >
+            <ProjectIcon
+              project={{ icon: previewInitials, iconColor, imagePath: null }}
+              size={34}
+            />
+          </span>
+        )}
         <input
           value={icon}
           onChange={(e) => setIcon(e.target.value.slice(0, 2).toUpperCase())}
@@ -968,96 +1016,6 @@ export function ProjectDialog({
     </div>
   );
 
-  const appearanceSection = (
-    <div>
-      <button
-        type="button"
-        aria-expanded={appearanceOpen}
-        aria-controls="project-appearance-fields"
-        onClick={() => setAppearanceOpen((v) => !v)}
-        style={{
-          width: "100%",
-          display: "flex",
-          alignItems: "center",
-          gap: 10,
-          textAlign: "left",
-          padding: "8px 10px",
-          background: appearanceOpen ? "var(--surface-2)" : "var(--surface-0)",
-          border: "1px solid var(--border)",
-          borderRadius: 7,
-          cursor: "pointer",
-          transition: "background 150ms ease",
-        }}
-      >
-        {pendingImage ? (
-          <div
-            aria-hidden
-            style={{
-              width: 28,
-              height: 28,
-              borderRadius: 6,
-              border: `1px solid ${iconColor}44`,
-              background: `${iconColor}18`,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              color: iconColor,
-              flex: "0 0 auto",
-            }}
-          >
-            <Icon name="camera" size={14} />
-          </div>
-        ) : (
-          <span
-            key={`${previewInitials}-${iconColor}`}
-            className="mc-identity-pop"
-            style={{ display: "inline-flex", flex: "0 0 auto" }}
-          >
-            <ProjectIcon
-              project={{ icon: previewInitials, iconColor, imagePath: null }}
-              size={28}
-            />
-          </span>
-        )}
-        <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text)" }}>
-          Appearance
-        </span>
-        <span
-          style={{
-            fontFamily: "var(--mono)",
-            fontSize: 10.5,
-            color: "var(--text-dim)",
-            minWidth: 0,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {appearanceSummary}
-        </span>
-        <Icon
-          name={appearanceOpen ? "chevron-up" : "chevron-down"}
-          size={13}
-          style={{ marginLeft: "auto", color: "var(--text-faint)" }}
-        />
-      </button>
-      {appearanceOpen && (
-        <div
-          id="project-appearance-fields"
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: 14,
-            padding: "14px 10px 4px",
-          }}
-        >
-          {iconField}
-          {imageField}
-        </div>
-      )}
-    </div>
-  );
-
   const worktreeField = project ? (
     <TextField
       mono
@@ -1157,12 +1115,15 @@ export function ProjectDialog({
           </div>
         </div>
       ) : (
-        <div style={{ display: "flex", flexDirection: "column" }}>
-          <SettingsSection title="Project">
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <GroupCard title="Project" description="Where it lives on disk and what it's called.">
             {dirField}
             {nameField}
-          </SettingsSection>
-          <SettingsSection title="Sessions">
+          </GroupCard>
+          <GroupCard
+            title="Sessions"
+            description="Defaults for the coding agents you'll run in this project."
+          >
             {startWithField}
             {layoutField}
             <ToggleRow
@@ -1172,11 +1133,12 @@ export function ProjectDialog({
               onChange={setAutoStart}
               label="Start a session now"
             />
-          </SettingsSection>
-          <SettingsSection title="Organize">
+          </GroupCard>
+          <GroupCard title="Organize" description="How this project appears in your sidebar.">
             {groupField}
-            {appearanceSection}
-          </SettingsSection>
+            {iconField}
+            {imageField}
+          </GroupCard>
           <div ref={errorRef}>
             <FormErrorBox error={error} />
           </div>

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -6,7 +6,7 @@ import { TextField } from "~/components/ui/TextField";
 import { Icon } from "~/components/ui/Icon";
 import { AgentLogo } from "~/components/ui/AgentLogo";
 import { ProjectIcon } from "~/components/ui/ProjectIcon";
-import { ToggleRow } from "~/components/views/SettingsParts";
+import { SettingsSection, ToggleRow } from "~/components/views/SettingsParts";
 import { HotkeyTooltip, EscTooltip } from "~/components/ui/Tooltip";
 import { useHotkey } from "~/lib/use-hotkey";
 import { AGENT_META, ICON_COLORS } from "~/lib/design-meta";
@@ -493,7 +493,6 @@ export function ProjectDialog({
                 background: selected ? "var(--surface-2)" : "var(--surface-0)",
                 border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
                 borderRadius: 7,
-                boxShadow: selected ? "0 0 0 1px var(--accent)" : "none",
                 cursor: disabled ? "not-allowed" : "pointer",
                 opacity: disabled ? 0.5 : 1,
               }}
@@ -605,7 +604,6 @@ export function ProjectDialog({
                 border: 0,
                 borderRadius: 5,
                 background: selected ? "var(--surface-2)" : "transparent",
-                boxShadow: selected ? "0 0 0 1px var(--accent) inset" : "none",
                 color: selected ? "var(--text)" : "var(--text-dim)",
                 cursor: "pointer",
               }}
@@ -1159,20 +1157,26 @@ export function ProjectDialog({
           </div>
         </div>
       ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
-          {dirField}
-          {nameField}
-          {startWithField}
-          {layoutField}
-          {groupField}
-          {appearanceSection}
-          <ToggleRow
-            title="Start a session now"
-            description={`Launches ${selectedAgentLabel} in this project as soon as it's created.`}
-            checked={autoStart}
-            onChange={setAutoStart}
-            label="Start a session now"
-          />
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <SettingsSection title="Project">
+            {dirField}
+            {nameField}
+          </SettingsSection>
+          <SettingsSection title="Sessions">
+            {startWithField}
+            {layoutField}
+            <ToggleRow
+              title="Start a session now"
+              description={`Launches ${selectedAgentLabel} in this project as soon as it's created.`}
+              checked={autoStart}
+              onChange={setAutoStart}
+              label="Start a session now"
+            />
+          </SettingsSection>
+          <SettingsSection title="Organize">
+            {groupField}
+            {appearanceSection}
+          </SettingsSection>
           <div ref={errorRef}>
             <FormErrorBox error={error} />
           </div>

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -1117,6 +1117,18 @@ export function ProjectDialog({
           </div>
         ) : (
           <>
+            {!path.trim() && (
+              <span
+                style={{
+                  marginRight: "auto",
+                  fontFamily: "var(--mono)",
+                  fontSize: 11,
+                  color: "var(--text-faint)",
+                }}
+              >
+                Add a working directory to create.
+              </span>
+            )}
             <EscTooltip label="Cancel">
               <Btn variant="ghost" onClick={requestClose}>
                 Cancel

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -430,12 +430,15 @@ export function ProjectDialog({
 
   const dirField = (
     <div>
-      <FieldLabel>Working directory</FieldLabel>
+      <FieldLabel>
+        Working directory <span style={{ color: "var(--accent)" }}>*</span>
+      </FieldLabel>
       <div style={{ display: "flex", gap: 8 }}>
         <div style={{ flex: 1 }}>
           <TextField
             mono
-            ariaLabel="Working directory"
+            required
+            ariaLabel="Working directory (required)"
             value={path}
             onChange={setPath}
             placeholder="/Users/me/dev/my-project"
@@ -489,7 +492,7 @@ export function ProjectDialog({
                 padding: "9px 10px",
                 background: selected ? "var(--surface-2)" : "var(--surface-0)",
                 border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
-                borderRadius: 8,
+                borderRadius: 7,
                 boxShadow: selected ? "0 0 0 1px var(--accent)" : "none",
                 cursor: disabled ? "not-allowed" : "pointer",
                 opacity: disabled ? 0.5 : 1,
@@ -558,18 +561,28 @@ export function ProjectDialog({
     </div>
   );
 
+  // A compact segmented control, not a second card grid: layout is a trivial,
+  // reversible per-session choice, so it should read lighter than the agent
+  // picker above it. The glyph still shows what each option does.
   const layoutField = (
     <div>
       <FieldLabel>Layout</FieldLabel>
       <div
         role="radiogroup"
         aria-label="Default layout"
-        style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}
+        style={{
+          display: "flex",
+          gap: 4,
+          padding: 3,
+          background: "var(--surface-0)",
+          border: "1px solid var(--border)",
+          borderRadius: 7,
+        }}
       >
         {(
           [
-            { value: false, label: "List", desc: "One at a time", variant: "list" as const },
-            { value: true, label: "Grid", desc: "All at once", variant: "grid" as const },
+            { value: false, label: "List", variant: "list" as const },
+            { value: true, label: "Grid", variant: "grid" as const },
           ]
         ).map((opt) => {
           const selected = gridView === opt.value;
@@ -581,17 +594,19 @@ export function ProjectDialog({
               aria-checked={selected}
               aria-label={`${opt.label} layout`}
               onClick={() => setGridView(opt.value)}
-              className="mc-pick-card"
+              className="mc-segment"
               style={{
+                flex: 1,
                 display: "flex",
                 alignItems: "center",
-                gap: 10,
-                textAlign: "left",
-                padding: "9px 10px",
-                background: selected ? "var(--surface-2)" : "var(--surface-0)",
-                border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
-                borderRadius: 8,
-                boxShadow: selected ? "0 0 0 1px var(--accent)" : "none",
+                justifyContent: "center",
+                gap: 9,
+                padding: "8px 10px",
+                border: 0,
+                borderRadius: 5,
+                background: selected ? "var(--surface-2)" : "transparent",
+                boxShadow: selected ? "0 0 0 1px var(--accent) inset" : "none",
+                color: selected ? "var(--text)" : "var(--text-dim)",
                 cursor: "pointer",
               }}
             >
@@ -602,24 +617,7 @@ export function ProjectDialog({
               >
                 <LayoutGlyph variant={opt.variant} active={selected} />
               </span>
-              <div style={{ minWidth: 0 }}>
-                <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)" }}>
-                  {opt.label}
-                </div>
-                <div
-                  style={{
-                    fontFamily: "var(--mono)",
-                    fontSize: 10,
-                    color: "var(--text-dim)",
-                    marginTop: 2,
-                    whiteSpace: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                  }}
-                >
-                  {opt.desc}
-                </div>
-              </div>
+              <span style={{ fontSize: 12, fontWeight: 600 }}>{opt.label}</span>
             </button>
           );
         })}
@@ -988,7 +986,7 @@ export function ProjectDialog({
           padding: "8px 10px",
           background: appearanceOpen ? "var(--surface-2)" : "var(--surface-0)",
           border: "1px solid var(--border)",
-          borderRadius: 8,
+          borderRadius: 7,
           cursor: "pointer",
           transition: "background 150ms ease",
         }}
@@ -1162,8 +1160,8 @@ export function ProjectDialog({
         </div>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
-          {nameField}
           {dirField}
+          {nameField}
           {startWithField}
           {layoutField}
           {groupField}

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -40,6 +40,11 @@ function FieldLabel({ children }: { children: ReactNode }) {
   return <label style={fieldLabelStyle}>{children}</label>;
 }
 
+/** Last segment of a filesystem path, ignoring trailing separators. */
+function basename(p: string): string {
+  return p.split(/[\\/]/).filter(Boolean).pop() || "";
+}
+
 /** Tiny wireframe that shows what each layout does at a glance. */
 function LayoutGlyph({ variant, active }: { variant: "list" | "grid"; active: boolean }) {
   const cell = active ? "var(--accent)" : "var(--text-faint)";
@@ -163,7 +168,7 @@ export function ProjectDialog({
 
   useEffect(() => {
     if (open) {
-      const initialName = initialPath.split(/[\\/]/).filter(Boolean).pop() || "";
+      const initialName = basename(initialPath);
       const seededName = project?.name || (!project ? initialName : "");
       const seededPath = project?.path || (!project ? initialPath : "");
       const seededGroupQuery = project?.groupId
@@ -273,8 +278,8 @@ export function ProjectDialog({
     if (result) {
       setPath(result);
       if (!name.trim()) {
-        const basename = result.split(/[\\/]/).filter(Boolean).pop() || "";
-        if (basename) setName(basename);
+        const base = basename(result);
+        if (base) setName(base);
       }
     }
   };
@@ -336,8 +341,7 @@ export function ProjectDialog({
     setSubmitting(true);
     try {
       const effectiveGroupId = await resolveGroupIdForSave();
-      const effectiveName =
-        name.trim() || (path.trim().split(/[\\/]/).filter(Boolean).pop() ?? "");
+      const effectiveName = name.trim() || basename(path.trim());
       await onSave({
         name: name.trim() || undefined,
         path,
@@ -381,12 +385,10 @@ export function ProjectDialog({
   // Live identity preview: exactly what the sidebar will render for this
   // project — auto initials from the name until the user overrides them.
   const derivedInitials =
-    (name.trim() || path.trim().split(/[\\/]/).filter(Boolean).pop() || "")
-      .slice(0, 2)
-      .toUpperCase() || "AB";
+    (name.trim() || basename(path.trim())).slice(0, 2).toUpperCase() || "AB";
   const previewInitials = icon || derivedInitials;
   const appearanceSummary = pendingImage
-    ? pendingImage.sourcePath.split(/[\\/]/).pop() ?? "custom image"
+    ? basename(pendingImage.sourcePath) || "custom image"
     : icon
       ? `Initials ${icon}`
       : `Auto initials · ${derivedInitials}`;
@@ -422,7 +424,7 @@ export function ProjectDialog({
       value={name}
       onChange={setName}
       inputRef={nameRef}
-      placeholder={path.trim().split(/[\\/]/).filter(Boolean).pop() || "defaults to folder name"}
+      placeholder={basename(path.trim()) || "defaults to folder name"}
     />
   );
 
@@ -551,7 +553,7 @@ export function ProjectDialog({
           lineHeight: 1.4,
         }}
       >
-        Launches your sessions — change anytime.
+        The default for new sessions — switch agents anytime.
       </div>
     </div>
   );
@@ -645,7 +647,7 @@ export function ProjectDialog({
           <span
             style={{ fontFamily: "var(--mono)", fontSize: 11, color: "var(--text-dim)" }}
           >
-            {pendingImage.sourcePath.split(/[\\/]/).pop()} — uploads on save
+            {basename(pendingImage.sourcePath)} — uploads on save
           </span>
         )}
         <span

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -5,7 +5,6 @@ import { Btn } from "~/components/ui/Btn";
 import { TextField } from "~/components/ui/TextField";
 import { Icon } from "~/components/ui/Icon";
 import { AgentLogo } from "~/components/ui/AgentLogo";
-import { ProjectIcon } from "~/components/ui/ProjectIcon";
 import { ToggleRow } from "~/components/views/SettingsParts";
 import { HotkeyTooltip, EscTooltip } from "~/components/ui/Tooltip";
 import { useHotkey } from "~/lib/use-hotkey";
@@ -423,8 +422,6 @@ export function ProjectDialog({
   // project — auto initials from the name until the user overrides them.
   const derivedInitials =
     (name.trim() || basename(path.trim())).slice(0, 2).toUpperCase() || "AB";
-  const previewInitials = icon || derivedInitials;
-
   const selectedAgentLabel = AGENT_REGISTRY[agent]?.label ?? "your coding agent";
   const currentFormKey = JSON.stringify({
     name,
@@ -694,19 +691,7 @@ export function ProjectDialog({
   const iconField = (
     <div>
       <FieldLabel>{project ? "Icon (fallback)" : "Initials & color"}</FieldLabel>
-      <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
-        {!project && (
-          <span
-            key={`${previewInitials}-${iconColor}`}
-            className="mc-identity-pop"
-            style={{ display: "inline-flex", flex: "0 0 auto" }}
-          >
-            <ProjectIcon
-              project={{ icon: previewInitials, iconColor, imagePath: null }}
-              size={34}
-            />
-          </span>
-        )}
+      <div style={{ display: "flex", gap: 10, alignItems: "stretch" }}>
         <input
           value={icon}
           onChange={(e) => setIcon(e.target.value.slice(0, 2).toUpperCase())}
@@ -716,6 +701,7 @@ export function ProjectDialog({
           className="mc-initials-input"
           style={{
             width: 56,
+            flex: "0 0 auto",
             textAlign: "center",
             background: "var(--surface-0)",
             borderRadius: 7,
@@ -726,7 +712,7 @@ export function ProjectDialog({
             fontWeight: 600,
           }}
         />
-        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+        <div style={{ flex: 1, minWidth: 0, display: "flex", gap: 6 }}>
           {ICON_COLORS.map((c) => {
             const active = iconColor === c;
             return (
@@ -738,8 +724,8 @@ export function ProjectDialog({
                 onClick={() => setIconColor(c)}
                 className="mc-color-swatch"
                 style={{
-                  width: 24,
-                  height: 24,
+                  flex: 1,
+                  minWidth: 0,
                   borderRadius: 6,
                   background: c,
                   border: active ? "2px solid var(--text)" : "2px solid transparent",

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -166,8 +166,12 @@ export function ProjectDialog({
   const [gridView, setGridView] = useState(false);
   const [imagePath, setImagePath] = useState<string | null>(null);
   const [pendingImage, setPendingImage] = useState<
-    { sourcePath: string; extension: string } | null
+    { sourcePath: string; extension: string; previewDataUrl: string } | null
   >(null);
+  // Bumped on each in-dialog image replace so the app:// preview URL can't
+  // serve a stale cached copy (the filename stays `<projectId>.<ext>`).
+  const [imageVersion, setImageVersion] = useState(0);
+  const [colorMenuOpen, setColorMenuOpen] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -228,6 +232,7 @@ export function ProjectDialog({
       setGridView(project?.defaultGridView ?? false);
       setImagePath(project?.imagePath ?? null);
       setPendingImage(null);
+      setColorMenuOpen(false);
       setAutoStart(true);
       setConfirmingClose(false);
       setSubmitting(false);
@@ -297,6 +302,7 @@ export function ProjectDialog({
         return;
       }
       setImagePath(result.filename);
+      setImageVersion((v) => v + 1);
     } finally {
       setUploading(false);
     }
@@ -447,14 +453,220 @@ export function ProjectDialog({
     onClose();
   };
 
-  const nameField = (
-    <TextField
-      label="Name (optional)"
-      value={name}
-      onChange={setName}
-      inputRef={nameRef}
-      placeholder={basename(path.trim()) || "defaults to folder name"}
-    />
+  const hasImage = !!pendingImage || !!imagePath;
+  const previewSrc =
+    pendingImage?.previewDataUrl ??
+    (imagePath
+      ? `app://project-image/${imagePath}?v=${project?.updatedAt ?? 0}-${imageVersion}`
+      : null);
+
+  // One row of identity: the avatar tile IS the live sidebar preview and the
+  // image-upload button in one — initials, color, and name sit beside it, so
+  // every input that shapes the tile is within reach of it.
+  const identityRow = (
+    <div style={{ display: "flex", gap: 10, alignItems: "flex-end" }}>
+      <div style={{ position: "relative", flex: "0 0 auto" }}>
+        <button
+          type="button"
+          onClick={chooseImage}
+          disabled={uploading}
+          aria-label={hasImage ? "Replace project image" : "Add project image"}
+          title="PNG, JPG, WebP or GIF — up to 5MB"
+          className="mc-avatar-tile"
+          style={{
+            position: "relative",
+            width: 58,
+            height: 58,
+            borderRadius: 12,
+            padding: 0,
+            overflow: "hidden",
+            border: `1px solid ${previewSrc ? "var(--border)" : `${iconColor}44`}`,
+            background: previewSrc
+              ? "var(--surface-0)"
+              : `linear-gradient(135deg, ${iconColor}22, ${iconColor}08)`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: uploading ? "wait" : "pointer",
+          }}
+        >
+          {previewSrc ? (
+            <img
+              src={previewSrc}
+              alt=""
+              style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            />
+          ) : (
+            <span
+              key={`${icon || derivedInitials}-${iconColor}`}
+              className="mc-identity-pop"
+              style={{
+                fontFamily: "var(--mono)",
+                fontSize: 20,
+                fontWeight: 600,
+                color: iconColor,
+                letterSpacing: "-0.02em",
+              }}
+            >
+              {icon || derivedInitials}
+            </span>
+          )}
+          <span aria-hidden className="mc-avatar-tile-overlay">
+            <Icon name="camera" size={15} />
+          </span>
+        </button>
+        {hasImage && !uploading && (
+          <button
+            type="button"
+            onClick={removeImage}
+            aria-label="Remove image"
+            title="Remove image"
+            className="mc-avatar-remove"
+          >
+            <Icon name="x" size={10} />
+          </button>
+        )}
+      </div>
+      <div style={{ flex: "0 0 auto" }}>
+        <FieldLabel>Initials</FieldLabel>
+        <input
+          value={icon}
+          onChange={(e) => setIcon(e.target.value.slice(0, 2).toUpperCase())}
+          maxLength={2}
+          placeholder={project ? "AB" : derivedInitials}
+          aria-label="Icon initials (used when no image is set)"
+          className="mc-initials-input"
+          style={{
+            width: 52,
+            textAlign: "center",
+            background: "var(--surface-0)",
+            borderRadius: 7,
+            color: "var(--text)",
+            padding: "9px 8px",
+            fontFamily: "var(--mono)",
+            fontSize: 14,
+            fontWeight: 600,
+          }}
+        />
+      </div>
+      <div
+        style={{ flex: "0 0 auto", position: "relative" }}
+        onKeyDown={(e) => {
+          if (e.key === "Escape" && colorMenuOpen) {
+            // Close the color menu without also dismissing the whole dialog.
+            e.stopPropagation();
+            setColorMenuOpen(false);
+          }
+        }}
+        onBlur={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget as Node)) setColorMenuOpen(false);
+        }}
+      >
+        <FieldLabel>Color</FieldLabel>
+        <button
+          type="button"
+          onClick={() => setColorMenuOpen((o) => !o)}
+          aria-label="Icon color"
+          aria-haspopup="listbox"
+          aria-expanded={colorMenuOpen}
+          className="mc-color-trigger"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            height: 38,
+            padding: "0 8px 0 9px",
+            background: "var(--surface-0)",
+            border: `1px solid ${colorMenuOpen ? "var(--accent)" : "var(--border)"}`,
+            borderRadius: 7,
+            cursor: "pointer",
+            color: "var(--text-dim)",
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              width: 18,
+              height: 18,
+              borderRadius: 5,
+              background: iconColor,
+              flex: "0 0 auto",
+            }}
+          />
+          <Icon name="chevron-down" size={12} />
+        </button>
+        {colorMenuOpen && (
+          <div
+            role="listbox"
+            aria-label="Icon color"
+            style={{
+              position: "absolute",
+              zIndex: 20,
+              top: "calc(100% + 6px)",
+              left: 0,
+              display: "flex",
+              gap: 6,
+              padding: 8,
+              background: "var(--surface-1)",
+              border: "1px solid var(--border)",
+              borderRadius: 8,
+              boxShadow: "0 14px 36px rgba(0, 0, 0, 0.32)",
+            }}
+          >
+            {ICON_COLORS.map((c) => {
+              const active = iconColor === c;
+              return (
+                <button
+                  key={c}
+                  type="button"
+                  role="option"
+                  aria-selected={active}
+                  aria-label={`Icon color ${c}`}
+                  onClick={() => {
+                    setIconColor(c);
+                    setColorMenuOpen(false);
+                  }}
+                  className="mc-color-swatch"
+                  style={{
+                    width: 24,
+                    height: 24,
+                    flex: "0 0 auto",
+                    borderRadius: 6,
+                    background: c,
+                    border: active ? "2px solid var(--text)" : "2px solid transparent",
+                    boxShadow: active ? `0 0 0 2px ${c}` : "none",
+                    cursor: "pointer",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    color: "#fff",
+                    padding: 0,
+                  }}
+                >
+                  {active && (
+                    <span
+                      aria-hidden
+                      style={{ display: "flex", filter: "drop-shadow(0 1px 1px rgba(0, 0, 0, 0.45))" }}
+                    >
+                      <Icon name="check" size={12} />
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <TextField
+          label="Name (optional)"
+          value={name}
+          onChange={setName}
+          inputRef={nameRef}
+          placeholder={basename(path.trim()) || "defaults to folder name"}
+        />
+      </div>
+    </div>
   );
 
   const dirField = (
@@ -652,108 +864,6 @@ export function ProjectDialog({
             </button>
           );
         })}
-      </div>
-    </div>
-  );
-
-  const imageField = (
-    <div>
-      <FieldLabel>Custom image</FieldLabel>
-      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-        <Btn variant="solid" icon="folder" onClick={chooseImage} disabled={uploading}>
-          {uploading
-            ? "Uploading…"
-            : imagePath || pendingImage
-              ? "Replace image…"
-              : "Choose image…"}
-        </Btn>
-        {(imagePath || pendingImage) && (
-          <Btn variant="ghost" onClick={removeImage}>
-            Remove
-          </Btn>
-        )}
-        {pendingImage && (
-          <span
-            style={{ fontFamily: "var(--mono)", fontSize: 11, color: "var(--text-dim)" }}
-          >
-            {basename(pendingImage.sourcePath)} — uploads on save
-          </span>
-        )}
-        <span
-          style={{ fontFamily: "var(--mono)", fontSize: 10.5, color: "var(--text-faint)" }}
-        >
-          PNG / JPG / WebP / GIF, ≤ 5MB
-        </span>
-      </div>
-    </div>
-  );
-
-  const iconField = (
-    <div>
-      <FieldLabel>{project ? "Icon (fallback)" : "Initials & color"}</FieldLabel>
-      <div style={{ display: "flex", gap: 10, alignItems: "stretch" }}>
-        <input
-          value={icon}
-          onChange={(e) => setIcon(e.target.value.slice(0, 2).toUpperCase())}
-          maxLength={2}
-          placeholder={project ? "AB" : derivedInitials}
-          aria-label="Icon initials"
-          className="mc-initials-input"
-          style={{
-            width: 56,
-            flex: "0 0 auto",
-            textAlign: "center",
-            background: "var(--surface-0)",
-            borderRadius: 7,
-            color: "var(--text)",
-            padding: "9px 8px",
-            fontFamily: "var(--mono)",
-            fontSize: 14,
-            fontWeight: 600,
-          }}
-        />
-        <div style={{ flex: 1, minWidth: 0, display: "flex", gap: 6 }}>
-          {ICON_COLORS.map((c) => {
-            const active = iconColor === c;
-            return (
-              <button
-                key={c}
-                type="button"
-                aria-label={`Icon color ${c}`}
-                aria-pressed={active}
-                onClick={() => setIconColor(c)}
-                className="mc-color-swatch"
-                style={{
-                  flex: 1,
-                  minWidth: 0,
-                  borderRadius: 6,
-                  background: c,
-                  border: active ? "2px solid var(--text)" : "2px solid transparent",
-                  boxShadow: active ? `0 0 0 2px ${c}` : "none",
-                  cursor: "pointer",
-                }}
-              >
-                <span
-                  key={active ? "on" : "off"}
-                  aria-hidden
-                  className={active ? "mc-pick-pop" : undefined}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    width: "100%",
-                    height: "100%",
-                    opacity: active ? 1 : 0,
-                    color: "#fff",
-                    filter: "drop-shadow(0 1px 1px rgba(0, 0, 0, 0.45))",
-                  }}
-                >
-                  <Icon name="check" size={13} />
-                </span>
-              </button>
-            );
-          })}
-        </div>
       </div>
     </div>
   );
@@ -1090,10 +1200,8 @@ export function ProjectDialog({
     >
       {project ? (
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-          {nameField}
+          {identityRow}
           {dirField}
-          {imageField}
-          {iconField}
           {groupField}
           {worktreeField}
           <div ref={errorRef}>
@@ -1102,9 +1210,13 @@ export function ProjectDialog({
         </div>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-          <GroupCard title="Project" description="Where it lives on disk and what it's called.">
+          <GroupCard
+            title="Project"
+            description="Where it lives on disk and how it shows up in your sidebar."
+          >
+            {identityRow}
             {dirField}
-            {nameField}
+            {groupField}
           </GroupCard>
           <GroupCard
             title="Sessions"
@@ -1119,11 +1231,6 @@ export function ProjectDialog({
               onChange={setAutoStart}
               label="Start a session now"
             />
-          </GroupCard>
-          <GroupCard title="Organize" description="How this project appears in your sidebar.">
-            {groupField}
-            {iconField}
-            {imageField}
           </GroupCard>
           <div ref={errorRef}>
             <FormErrorBox error={error} />

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -5,7 +5,7 @@ import { Btn } from "~/components/ui/Btn";
 import { TextField } from "~/components/ui/TextField";
 import { Icon } from "~/components/ui/Icon";
 import { AgentLogo } from "~/components/ui/AgentLogo";
-import { ToggleRow } from "~/components/views/SettingsParts";
+import { ToggleSwitch } from "~/components/views/SettingsParts";
 import { HotkeyTooltip, EscTooltip } from "~/components/ui/Tooltip";
 import { useHotkey } from "~/lib/use-hotkey";
 import { AGENT_META, ICON_COLORS } from "~/lib/design-meta";
@@ -88,7 +88,9 @@ function LayoutGlyph({ variant, active }: { variant: "list" | "grid"; active: bo
   const cell = active ? "var(--accent)" : "var(--text-faint)";
   const frame: CSSProperties = {
     width: 34,
-    height: 24,
+    // 26 tall to match the agent cards' icon tile, so the List/Grid cards
+    // beside the agent grid land on exactly the same row heights.
+    height: 26,
     borderRadius: 4,
     border: "1px solid var(--border)",
     background: "var(--surface-0)",
@@ -164,6 +166,7 @@ export function ProjectDialog({
   const [worktreeSetupCommand, setWorktreeSetupCommand] = useState("");
   const [agent, setAgent] = useState<TaskAgent>("claude-code");
   const [gridView, setGridView] = useState(false);
+  const [colorMenuOpen, setColorMenuOpen] = useState(false);
   const [imagePath, setImagePath] = useState<string | null>(null);
   const [pendingImage, setPendingImage] = useState<
     { sourcePath: string; extension: string; previewDataUrl: string } | null
@@ -171,7 +174,6 @@ export function ProjectDialog({
   // Bumped on each in-dialog image replace so the app:// preview URL can't
   // serve a stale cached copy (the filename stays `<projectId>.<ext>`).
   const [imageVersion, setImageVersion] = useState(0);
-  const [colorMenuOpen, setColorMenuOpen] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -461,8 +463,8 @@ export function ProjectDialog({
       : null);
 
   // One row of identity: the avatar tile IS the live sidebar preview and the
-  // image-upload button in one — initials, color, and name sit beside it, so
-  // every input that shapes the tile is within reach of it.
+  // image-upload button in one. Initials + color are its no-image fallback and
+  // only render while no image is set; name always sits at the end.
   const identityRow = (
     <div style={{ display: "flex", gap: 10, alignItems: "flex-end" }}>
       <div style={{ position: "relative", flex: "0 0 auto" }}>
@@ -515,6 +517,13 @@ export function ProjectDialog({
             <Icon name="camera" size={15} />
           </span>
         </button>
+        {/* At rest the tile looks like a static preview — this always-visible
+            corner badge is what says "click to add/replace an image". */}
+        {!uploading && (
+          <span aria-hidden className="mc-avatar-upload-badge">
+            <Icon name="camera" size={10} />
+          </span>
+        )}
         {hasImage && !uploading && (
           <button
             type="button"
@@ -527,136 +536,6 @@ export function ProjectDialog({
           </button>
         )}
       </div>
-      <div style={{ flex: "0 0 auto" }}>
-        <FieldLabel>Initials</FieldLabel>
-        <input
-          value={icon}
-          onChange={(e) => setIcon(e.target.value.slice(0, 2).toUpperCase())}
-          maxLength={2}
-          placeholder={project ? "AB" : derivedInitials}
-          aria-label="Icon initials (used when no image is set)"
-          className="mc-initials-input"
-          style={{
-            width: 52,
-            textAlign: "center",
-            background: "var(--surface-0)",
-            borderRadius: 7,
-            color: "var(--text)",
-            padding: "9px 8px",
-            fontFamily: "var(--mono)",
-            fontSize: 14,
-            fontWeight: 600,
-          }}
-        />
-      </div>
-      <div
-        style={{ flex: "0 0 auto", position: "relative" }}
-        onKeyDown={(e) => {
-          if (e.key === "Escape" && colorMenuOpen) {
-            // Close the color menu without also dismissing the whole dialog.
-            e.stopPropagation();
-            setColorMenuOpen(false);
-          }
-        }}
-        onBlur={(e) => {
-          if (!e.currentTarget.contains(e.relatedTarget as Node)) setColorMenuOpen(false);
-        }}
-      >
-        <FieldLabel>Color</FieldLabel>
-        <button
-          type="button"
-          onClick={() => setColorMenuOpen((o) => !o)}
-          aria-label="Icon color"
-          aria-haspopup="listbox"
-          aria-expanded={colorMenuOpen}
-          className="mc-color-trigger"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-            height: 38,
-            padding: "0 8px 0 9px",
-            background: "var(--surface-0)",
-            border: `1px solid ${colorMenuOpen ? "var(--accent)" : "var(--border)"}`,
-            borderRadius: 7,
-            cursor: "pointer",
-            color: "var(--text-dim)",
-          }}
-        >
-          <span
-            aria-hidden
-            style={{
-              width: 18,
-              height: 18,
-              borderRadius: 5,
-              background: iconColor,
-              flex: "0 0 auto",
-            }}
-          />
-          <Icon name="chevron-down" size={12} />
-        </button>
-        {colorMenuOpen && (
-          <div
-            role="listbox"
-            aria-label="Icon color"
-            style={{
-              position: "absolute",
-              zIndex: 20,
-              top: "calc(100% + 6px)",
-              left: 0,
-              display: "flex",
-              gap: 6,
-              padding: 8,
-              background: "var(--surface-1)",
-              border: "1px solid var(--border)",
-              borderRadius: 8,
-              boxShadow: "0 14px 36px rgba(0, 0, 0, 0.32)",
-            }}
-          >
-            {ICON_COLORS.map((c) => {
-              const active = iconColor === c;
-              return (
-                <button
-                  key={c}
-                  type="button"
-                  role="option"
-                  aria-selected={active}
-                  aria-label={`Icon color ${c}`}
-                  onClick={() => {
-                    setIconColor(c);
-                    setColorMenuOpen(false);
-                  }}
-                  className="mc-color-swatch"
-                  style={{
-                    width: 24,
-                    height: 24,
-                    flex: "0 0 auto",
-                    borderRadius: 6,
-                    background: c,
-                    border: active ? "2px solid var(--text)" : "2px solid transparent",
-                    boxShadow: active ? `0 0 0 2px ${c}` : "none",
-                    cursor: "pointer",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    color: "#fff",
-                    padding: 0,
-                  }}
-                >
-                  {active && (
-                    <span
-                      aria-hidden
-                      style={{ display: "flex", filter: "drop-shadow(0 1px 1px rgba(0, 0, 0, 0.45))" }}
-                    >
-                      <Icon name="check" size={12} />
-                    </span>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-        )}
-      </div>
       <div style={{ flex: 1, minWidth: 0 }}>
         <TextField
           label="Name (optional)"
@@ -666,6 +545,150 @@ export function ProjectDialog({
           placeholder={basename(path.trim()) || "defaults to folder name"}
         />
       </div>
+      {/* Initials and color only shape the tile when no image covers it, so
+          an uploaded image collapses them away — removing the image (×) brings
+          them back with whatever the user had set. */}
+      {!hasImage && (
+        <div
+          className="mc-identity-fallback"
+          style={{ display: "flex", gap: 10, alignItems: "flex-end", flex: "0 0 auto" }}
+        >
+          <div style={{ flex: "0 0 auto" }}>
+            <FieldLabel>Initials</FieldLabel>
+            <input
+              value={icon}
+              onChange={(e) => setIcon(e.target.value.slice(0, 2).toUpperCase())}
+              maxLength={2}
+              placeholder={project ? "AB" : derivedInitials}
+              aria-label="Icon initials (used when no image is set)"
+              className="mc-initials-input"
+              style={{
+                width: 52,
+                height: 38,
+                textAlign: "center",
+                background: "var(--surface-0)",
+                borderRadius: 7,
+                color: "var(--text)",
+                padding: "0 8px",
+                fontFamily: "var(--mono)",
+                fontSize: 14,
+                fontWeight: 600,
+              }}
+            />
+          </div>
+          <div
+            style={{ flex: "0 0 auto", position: "relative" }}
+            onKeyDown={(e) => {
+              if (e.key === "Escape" && colorMenuOpen) {
+                // Close the color menu without also dismissing the whole dialog.
+                e.stopPropagation();
+                setColorMenuOpen(false);
+              }
+            }}
+            onBlur={(e) => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) setColorMenuOpen(false);
+            }}
+          >
+            <FieldLabel>Color</FieldLabel>
+            <button
+              type="button"
+              onClick={() => setColorMenuOpen((o) => !o)}
+              aria-label="Icon color"
+              aria-haspopup="listbox"
+              aria-expanded={colorMenuOpen}
+              className="mc-color-trigger"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                height: 38,
+                padding: "0 8px 0 9px",
+                background: "var(--surface-0)",
+                border: `1px solid ${colorMenuOpen ? "var(--accent)" : "var(--border)"}`,
+                borderRadius: 7,
+                cursor: "pointer",
+                color: "var(--text-dim)",
+              }}
+            >
+              <span
+                aria-hidden
+                style={{
+                  width: 18,
+                  height: 18,
+                  borderRadius: 5,
+                  background: iconColor,
+                  flex: "0 0 auto",
+                }}
+              />
+              <Icon name="chevron-down" size={12} />
+            </button>
+            {colorMenuOpen && (
+              <div
+                role="listbox"
+                aria-label="Icon color"
+                style={{
+                  position: "absolute",
+                  zIndex: 20,
+                  top: "calc(100% + 6px)",
+                  // Right-anchored: the trigger sits at the row's right edge,
+                  // so the swatch strip opens leftward into the dialog instead
+                  // of clipping against its edge.
+                  right: 0,
+                  display: "flex",
+                  gap: 6,
+                  padding: 8,
+                  background: "var(--surface-1)",
+                  border: "1px solid var(--border)",
+                  borderRadius: 8,
+                  boxShadow: "0 14px 36px rgba(0, 0, 0, 0.32)",
+                }}
+              >
+                {ICON_COLORS.map((c) => {
+                  const active = iconColor === c;
+                  return (
+                    <button
+                      key={c}
+                      type="button"
+                      role="option"
+                      aria-selected={active}
+                      aria-label={`Icon color ${c}`}
+                      onClick={() => {
+                        setIconColor(c);
+                        setColorMenuOpen(false);
+                      }}
+                      className="mc-color-swatch"
+                      style={{
+                        width: 24,
+                        height: 24,
+                        flex: "0 0 auto",
+                        borderRadius: 6,
+                        background: c,
+                        border: active ? "2px solid var(--text)" : "2px solid transparent",
+                        boxShadow: active ? `0 0 0 2px ${c}` : "none",
+                        cursor: "pointer",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        color: "#fff",
+                        padding: 0,
+                      }}
+                    >
+                      {active && (
+                        <span
+                          aria-hidden
+                          style={{ display: "flex", filter: "drop-shadow(0 1px 1px rgba(0, 0, 0, 0.45))" }}
+                        >
+                          <Icon name="check" size={12} />
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 
@@ -801,23 +824,16 @@ export function ProjectDialog({
     </div>
   );
 
-  // A compact segmented control, not a second card grid: layout is a trivial,
-  // reversible per-session choice, so it should read lighter than the agent
-  // picker above it. The glyph still shows what each option does.
+  // Same card anatomy and spacing as the agent picker beside it — one row of
+  // options in the whole section, one selection language. List sits on the
+  // agents' first row, Grid on their second.
   const layoutField = (
     <div>
       <FieldLabel>Layout</FieldLabel>
       <div
         role="radiogroup"
         aria-label="Default layout"
-        style={{
-          display: "flex",
-          gap: 4,
-          padding: 3,
-          background: "var(--surface-0)",
-          border: "1px solid var(--border)",
-          borderRadius: 7,
-        }}
+        style={{ display: "grid", gap: 8 }}
       >
         {(
           [
@@ -834,22 +850,16 @@ export function ProjectDialog({
               aria-checked={selected}
               aria-label={`${opt.label} layout`}
               onClick={() => setGridView(opt.value)}
-              className="mc-segment"
+              className="mc-pick-card"
               style={{
-                flex: 1,
                 display: "flex",
                 alignItems: "center",
-                justifyContent: "center",
                 gap: 9,
-                padding: "8px 10px",
-                border: 0,
-                borderRadius: 5,
-                background: selected ? "var(--surface-2)" : "transparent",
-                // Single accent edge = selected, the same signal the agent
-                // cards use — one selection language, and a non-color cue so
-                // it doesn't rely on the glyph hue alone.
-                boxShadow: selected ? "0 0 0 1px var(--accent)" : "none",
-                color: selected ? "var(--text)" : "var(--text-dim)",
+                textAlign: "left",
+                padding: "9px 10px",
+                background: selected ? "var(--surface-2)" : "var(--surface-0)",
+                border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
+                borderRadius: 7,
                 cursor: "pointer",
               }}
             >
@@ -860,7 +870,9 @@ export function ProjectDialog({
               >
                 <LayoutGlyph variant={opt.variant} active={selected} />
               </span>
-              <span style={{ fontSize: 12, fontWeight: 600 }}>{opt.label}</span>
+              <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text)" }}>
+                {opt.label}
+              </span>
             </button>
           );
         })}
@@ -902,7 +914,9 @@ export function ProjectDialog({
             border: `1px solid ${groupTypeaheadOpen ? "var(--accent)" : "var(--border)"}`,
             borderRadius: 7,
             padding: "0 8px 0 12px",
-            minHeight: 38,
+            // Exact (not min) so the inline color swatches beside it can
+            // match this row's height 1:1.
+            height: 38,
           }}
         >
           {selectedGroup && (
@@ -1167,7 +1181,7 @@ export function ProjectDialog({
           </div>
         ) : (
           <>
-            {!path.trim() && (
+            {!path.trim() ? (
               <span
                 style={{
                   marginRight: "auto",
@@ -1178,6 +1192,33 @@ export function ProjectDialog({
               >
                 Add a working directory to create.
               </span>
+            ) : (
+              // Compact footer toggle: sits next to the button it modifies
+              // ("Create & start session" ⇄ "Create project").
+              <div
+                style={{ marginRight: "auto", display: "flex", alignItems: "center", gap: 8 }}
+                title={`Launches ${selectedAgentLabel} in this project as soon as it's created.`}
+              >
+                <ToggleSwitch
+                  checked={autoStart}
+                  onChange={setAutoStart}
+                  label="Start a session now"
+                  labelledBy="project-autostart-label"
+                />
+                <span
+                  id="project-autostart-label"
+                  onClick={() => setAutoStart(!autoStart)}
+                  style={{
+                    fontFamily: "var(--mono)",
+                    fontSize: 11.5,
+                    color: "var(--text-dim)",
+                    cursor: "pointer",
+                    userSelect: "none",
+                  }}
+                >
+                  Start a session now
+                </span>
+              </div>
             )}
             <EscTooltip label="Cancel">
               <Btn variant="ghost" onClick={requestClose}>
@@ -1222,15 +1263,13 @@ export function ProjectDialog({
             title="Sessions"
             description="Defaults for the coding agents you'll run in this project."
           >
-            {startWithField}
-            {layoutField}
-            <ToggleRow
-              title="Start a session now"
-              description={`Launches ${selectedAgentLabel} in this project as soon as it's created.`}
-              checked={autoStart}
-              onChange={setAutoStart}
-              label="Start a session now"
-            />
+            {/* Agent picker and layout side-by-side — layout is the lighter
+                choice, so it sits as a slim column with a rule between them. */}
+            <div style={{ display: "flex", gap: 14, alignItems: "stretch" }}>
+              <div style={{ flex: 1, minWidth: 0 }}>{startWithField}</div>
+              <div aria-hidden style={{ width: 1, alignSelf: "stretch", background: "var(--border)" }} />
+              <div style={{ flex: "0 0 128px" }}>{layoutField}</div>
+            </div>
           </GroupCard>
           <div ref={errorRef}>
             <FormErrorBox error={error} />

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -6,6 +6,7 @@ import { TextField } from "~/components/ui/TextField";
 import { Icon } from "~/components/ui/Icon";
 import { AgentLogo } from "~/components/ui/AgentLogo";
 import { ProjectIcon } from "~/components/ui/ProjectIcon";
+import { ToggleRow } from "~/components/views/SettingsParts";
 import { HotkeyTooltip, EscTooltip } from "~/components/ui/Tooltip";
 import { useHotkey } from "~/lib/use-hotkey";
 import { AGENT_META, ICON_COLORS } from "~/lib/design-meta";
@@ -128,7 +129,14 @@ export function ProjectDialog({
   const [appearanceOpen, setAppearanceOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [autoStart, setAutoStart] = useState(true);
+  const [confirmingClose, setConfirmingClose] = useState(false);
   const nameRef = useRef<HTMLInputElement>(null);
+  const errorRef = useRef<HTMLDivElement>(null);
+  // Snapshot of the seeded form, captured on open, so an accidental Esc /
+  // backdrop click on a create form the user has actually touched prompts
+  // before discarding — while a pre-filled-but-untouched form closes freely.
+  const formSeedRef = useRef<string>("");
   const selectedGroup = groupId ? groups.find((group) => group.id === groupId) ?? null : null;
   const normalizedGroupQuery = groupQuery.trim().toLowerCase();
   const exactGroupMatch = normalizedGroupQuery
@@ -156,28 +164,41 @@ export function ProjectDialog({
   useEffect(() => {
     if (open) {
       const initialName = initialPath.split(/[\\/]/).filter(Boolean).pop() || "";
+      const seededName = project?.name || (!project ? initialName : "");
+      const seededPath = project?.path || (!project ? initialPath : "");
+      const seededGroupQuery = project?.groupId
+        ? groups.find((group) => group.id === project.groupId)?.name ?? ""
+        : "";
+      const seededIcon = project?.icon || "";
+      const seededIconColor = project?.iconColor || "#ff5a1f";
       nameRef.current?.focus();
       nameRef.current?.select();
-      setName(project?.name || (!project ? initialName : ""));
-      setPath(project?.path || (!project ? initialPath : ""));
+      setName(seededName);
+      setPath(seededPath);
       setGroupId(project?.groupId || "");
-      setGroupQuery(
-        project?.groupId
-          ? groups.find((group) => group.id === project.groupId)?.name ?? ""
-          : "",
-      );
+      setGroupQuery(seededGroupQuery);
       setGroupTypeaheadOpen(false);
       setGroupActiveIndex(-1);
       setCreatingGroup(false);
-      setIcon(project?.icon || "");
-      setIconColor(project?.iconColor || "#ff5a1f");
+      setIcon(seededIcon);
+      setIconColor(seededIconColor);
       setWorktreeSetupCommand(project?.worktreeSetupCommand || "");
       setGridView(project?.defaultGridView ?? false);
       setImagePath(project?.imagePath ?? null);
       setPendingImage(null);
       setAppearanceOpen(false);
+      setAutoStart(true);
+      setConfirmingClose(false);
       setSubmitting(false);
       setError(null);
+      formSeedRef.current = JSON.stringify({
+        name: seededName,
+        path: seededPath,
+        groupQuery: seededGroupQuery,
+        icon: seededIcon,
+        iconColor: seededIconColor,
+        hasImage: !!project?.imagePath,
+      });
     }
     // Agent is seeded in the effect below once agentOptions has settled.
   }, [initialPath, open, project?.id]);
@@ -196,6 +217,12 @@ export function ProjectDialog({
         : firstLaunchable,
     );
   }, [open, project, agentOptions, cliAvailability]);
+
+  // Surface save errors even when the form has scrolled: bring the error box
+  // into view (FormErrorBox is role="alert", so it also announces to AT).
+  useEffect(() => {
+    if (error) errorRef.current?.scrollIntoView({ block: "nearest" });
+  }, [error]);
 
   useEffect(() => {
     if (!open || !selectedGroup || groupQuery.trim()) return;
@@ -334,9 +361,22 @@ export function ProjectDialog({
     }
   };
 
-  // Enter / Cmd+Enter runs the primary action: "Create & start" for a new
-  // project, "Save" when editing (autoStart is ignored on the edit path).
-  useHotkey("dialog.submit", () => void submit(!project), { enabled: open });
+  // Enter / Cmd+Enter runs the primary action: Save when editing; for a new
+  // project it honors the "Start a session now" toggle and the same path gate
+  // as the button, so the keyboard path can't bypass what the button enforces.
+  useHotkey(
+    "dialog.submit",
+    () => {
+      if (confirmingClose) return;
+      if (project) {
+        void submit(false);
+        return;
+      }
+      if (!path.trim()) return;
+      void submit(autoStart);
+    },
+    { enabled: open },
+  );
 
   // Live identity preview: exactly what the sidebar will render for this
   // project — auto initials from the name until the user overrides them.
@@ -350,6 +390,31 @@ export function ProjectDialog({
     : icon
       ? `Initials ${icon}`
       : `Auto initials · ${derivedInitials}`;
+
+  const selectedAgentLabel = AGENT_REGISTRY[agent]?.label ?? "your coding agent";
+  const currentFormKey = JSON.stringify({
+    name,
+    path,
+    groupQuery,
+    icon,
+    iconColor,
+    hasImage: !!pendingImage || !!imagePath,
+  });
+  const isDirty = !project && currentFormKey !== formSeedRef.current;
+  // Esc / backdrop / Cancel route through here so a touched create form
+  // confirms before discarding; a second Esc (or "Keep editing") backs out.
+  const requestClose = () => {
+    if (submitting) return;
+    if (confirmingClose) {
+      setConfirmingClose(false);
+      return;
+    }
+    if (isDirty) {
+      setConfirmingClose(true);
+      return;
+    }
+    onClose();
+  };
 
   const nameField = (
     <TextField
@@ -1009,7 +1074,7 @@ export function ProjectDialog({
   return (
     <Modal
       open={open}
-      onClose={onClose}
+      onClose={requestClose}
       title={project ? "Edit project" : "Add project"}
       width={project ? 520 : 540}
       footer={
@@ -1026,24 +1091,43 @@ export function ProjectDialog({
               </Btn>
             </HotkeyTooltip>
           </>
+        ) : confirmingClose ? (
+          <div
+            style={{
+              display: "flex",
+              flex: 1,
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 12,
+            }}
+          >
+            <span style={{ fontFamily: "var(--mono)", fontSize: 11.5, color: "var(--text-dim)" }}>
+              Discard this project? Your changes will be lost.
+            </span>
+            <div style={{ display: "flex", gap: 8 }}>
+              <Btn variant="ghost" onClick={() => setConfirmingClose(false)}>
+                Keep editing
+              </Btn>
+              <Btn variant="danger" onClick={onClose}>
+                Discard
+              </Btn>
+            </div>
+          </div>
         ) : (
           <>
             <EscTooltip label="Cancel">
-              <Btn variant="ghost" onClick={onClose}>
+              <Btn variant="ghost" onClick={requestClose}>
                 Cancel
               </Btn>
             </EscTooltip>
-            <Btn variant="solid" onClick={() => void submit(false)} disabled={submitting}>
-              Create only
-            </Btn>
             <HotkeyTooltip action="dialog.submit">
               <Btn
                 variant="primary"
-                icon="terminal"
-                onClick={() => void submit(true)}
+                icon={autoStart ? "terminal" : undefined}
+                onClick={() => void submit(autoStart)}
                 disabled={submitting || !path.trim()}
               >
-                Create &amp; start session
+                {autoStart ? "Create & start session" : "Create project"}
               </Btn>
             </HotkeyTooltip>
           </>
@@ -1058,7 +1142,9 @@ export function ProjectDialog({
           {iconField}
           {groupField}
           {worktreeField}
-          <FormErrorBox error={error} />
+          <div ref={errorRef}>
+            <FormErrorBox error={error} />
+          </div>
         </div>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
@@ -1068,7 +1154,16 @@ export function ProjectDialog({
           {layoutField}
           {groupField}
           {appearanceSection}
-          <FormErrorBox error={error} />
+          <ToggleRow
+            title="Start a session now"
+            description={`Launches ${selectedAgentLabel} in this project as soon as it's created.`}
+            checked={autoStart}
+            onChange={setAutoStart}
+            label="Start a session now"
+          />
+          <div ref={errorRef}>
+            <FormErrorBox error={error} />
+          </div>
         </div>
       )}
     </Modal>

--- a/src/components/views/ProjectDialog.tsx
+++ b/src/components/views/ProjectDialog.tsx
@@ -113,6 +113,7 @@ export function ProjectDialog({
   const [groupId, setGroupId] = useState<string>("");
   const [groupQuery, setGroupQuery] = useState("");
   const [groupTypeaheadOpen, setGroupTypeaheadOpen] = useState(false);
+  const [groupActiveIndex, setGroupActiveIndex] = useState(-1);
   const [creatingGroup, setCreatingGroup] = useState(false);
   const [icon, setIcon] = useState("");
   const [iconColor, setIconColor] = useState("#ff5a1f");
@@ -166,6 +167,7 @@ export function ProjectDialog({
           : "",
       );
       setGroupTypeaheadOpen(false);
+      setGroupActiveIndex(-1);
       setCreatingGroup(false);
       setIcon(project?.icon || "");
       setIconColor(project?.iconColor || "#ff5a1f");
@@ -366,6 +368,7 @@ export function ProjectDialog({
         <div style={{ flex: 1 }}>
           <TextField
             mono
+            ariaLabel="Working directory"
             value={path}
             onChange={setPath}
             placeholder="/Users/me/dev/my-project"
@@ -393,22 +396,24 @@ export function ProjectDialog({
           const cliMissing = availability.status === "missing";
           const cliOutdated = availability.status === "outdated";
           const disabled = !cliOutdated && !agentCanLaunch(cliAvailability, a.id);
+          const statusReason = cliMissing
+            ? `${a.command} was not found on PATH`
+            : cliOutdated
+              ? `${a.command} must be updated before launching`
+              : null;
           return (
             <button
               key={a.id}
               type="button"
               role="radio"
               aria-checked={selected}
-              aria-label={a.label}
-              disabled={disabled}
+              // Reason lives in the name (not just `title`) so keyboard/AT users
+              // hear why it's unavailable; `aria-disabled` keeps it focusable.
+              aria-label={disabled && statusReason ? `${a.label} — ${statusReason}` : a.label}
+              aria-disabled={disabled || undefined}
               onClick={() => !disabled && setAgent(a.id)}
-              title={
-                cliMissing
-                  ? `${a.command} was not found on PATH`
-                  : cliOutdated
-                    ? `${a.command} must be updated before launching`
-                    : undefined
-              }
+              className="mc-pick-card"
+              title={statusReason ?? undefined}
               style={{
                 display: "flex",
                 alignItems: "center",
@@ -421,10 +426,11 @@ export function ProjectDialog({
                 boxShadow: selected ? "0 0 0 1px var(--accent)" : "none",
                 cursor: disabled ? "not-allowed" : "pointer",
                 opacity: disabled ? 0.5 : 1,
-                transition: "border-color 150ms ease, background 150ms ease",
               }}
             >
               <div
+                key={selected ? "on" : "off"}
+                className={selected ? "mc-pick-pop" : undefined}
                 style={{
                   width: 26,
                   height: 26,
@@ -508,6 +514,7 @@ export function ProjectDialog({
               aria-checked={selected}
               aria-label={`${opt.label} layout`}
               onClick={() => setGridView(opt.value)}
+              className="mc-pick-card"
               style={{
                 display: "flex",
                 alignItems: "center",
@@ -519,10 +526,15 @@ export function ProjectDialog({
                 borderRadius: 8,
                 boxShadow: selected ? "0 0 0 1px var(--accent)" : "none",
                 cursor: "pointer",
-                transition: "border-color 150ms ease, background 150ms ease",
               }}
             >
-              <LayoutGlyph variant={opt.variant} active={selected} />
+              <span
+                key={selected ? "on" : "off"}
+                className={selected ? "mc-pick-pop" : undefined}
+                style={{ display: "inline-flex", flex: "0 0 auto" }}
+              >
+                <LayoutGlyph variant={opt.variant} active={selected} />
+              </span>
               <div style={{ minWidth: 0 }}>
                 <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)" }}>
                   {opt.label}
@@ -590,13 +602,12 @@ export function ProjectDialog({
           maxLength={2}
           placeholder={project ? "AB" : derivedInitials}
           aria-label="Icon initials"
+          className="mc-initials-input"
           style={{
             width: 56,
             textAlign: "center",
             background: "var(--surface-0)",
-            border: "1px solid var(--border)",
             borderRadius: 7,
-            outline: 0,
             color: "var(--text)",
             padding: "9px 8px",
             fontFamily: "var(--mono)",
@@ -605,27 +616,71 @@ export function ProjectDialog({
           }}
         />
         <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-          {ICON_COLORS.map((c) => (
-            <button
-              key={c}
-              type="button"
-              aria-label={`Icon color ${c}`}
-              aria-pressed={iconColor === c}
-              onClick={() => setIconColor(c)}
-              style={{
-                width: 24,
-                height: 24,
-                borderRadius: 6,
-                background: c,
-                border: iconColor === c ? "2px solid var(--text)" : "2px solid transparent",
-                cursor: "pointer",
-              }}
-            />
-          ))}
+          {ICON_COLORS.map((c) => {
+            const active = iconColor === c;
+            return (
+              <button
+                key={c}
+                type="button"
+                aria-label={`Icon color ${c}`}
+                aria-pressed={active}
+                onClick={() => setIconColor(c)}
+                className="mc-color-swatch"
+                style={{
+                  width: 24,
+                  height: 24,
+                  borderRadius: 6,
+                  background: c,
+                  border: active ? "2px solid var(--text)" : "2px solid transparent",
+                  boxShadow: active ? `0 0 0 2px ${c}` : "none",
+                  cursor: "pointer",
+                }}
+              >
+                <span
+                  key={active ? "on" : "off"}
+                  aria-hidden
+                  className={active ? "mc-pick-pop" : undefined}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    width: "100%",
+                    height: "100%",
+                    opacity: active ? 1 : 0,
+                    color: "#fff",
+                    filter: "drop-shadow(0 1px 1px rgba(0, 0, 0, 0.45))",
+                  }}
+                >
+                  <Icon name="check" size={13} />
+                </span>
+              </button>
+            );
+          })}
         </div>
       </div>
     </div>
   );
+
+  // Flat, ordered descriptor for the combobox listbox so the keyboard handler
+  // and the rendered options share one source of truth (ids + indices align).
+  type GroupOption =
+    | { id: string; kind: "ungrouped" }
+    | { id: string; kind: "group"; group: Group }
+    | { id: string; kind: "create" };
+  const groupOptions: GroupOption[] = [
+    { id: "grp-opt-ungrouped", kind: "ungrouped" },
+    ...filteredGroups.map(
+      (group): GroupOption => ({ id: `grp-opt-${group.id}`, kind: "group", group }),
+    ),
+    ...(canCreateGroup ? [{ id: "grp-opt-create", kind: "create" } as GroupOption] : []),
+  ];
+  const activeGroupOption =
+    groupTypeaheadOpen && groupActiveIndex >= 0 ? groupOptions[groupActiveIndex] : undefined;
+  const selectGroupOption = (opt: GroupOption) => {
+    if (opt.kind === "ungrouped") clearGroup();
+    else if (opt.kind === "group") selectGroup(opt.group);
+    else void commitGroupQuery();
+  };
 
   const groupField = (
     <div>
@@ -657,7 +712,10 @@ export function ProjectDialog({
           )}
           <input
             value={groupQuery}
-            onFocus={() => setGroupTypeaheadOpen(true)}
+            onFocus={() => {
+              setGroupTypeaheadOpen(true);
+              setGroupActiveIndex(-1);
+            }}
             onBlur={() => {
               window.setTimeout(() => setGroupTypeaheadOpen(false), 100);
             }}
@@ -665,19 +723,36 @@ export function ProjectDialog({
               const next = e.target.value;
               setGroupQuery(next);
               setGroupTypeaheadOpen(true);
+              setGroupActiveIndex(-1);
               if (!next.trim()) setGroupId("");
             }}
             onKeyDown={(e) => {
-              if (e.key === "Enter") {
+              if (e.key === "ArrowDown") {
                 e.preventDefault();
-                void commitGroupQuery();
+                setGroupTypeaheadOpen(true);
+                setGroupActiveIndex((i) => (i + 1 >= groupOptions.length ? 0 : i + 1));
+              } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setGroupTypeaheadOpen(true);
+                setGroupActiveIndex((i) => (i <= 0 ? groupOptions.length - 1 : i - 1));
+              } else if (e.key === "Enter") {
+                e.preventDefault();
+                if (activeGroupOption) selectGroupOption(activeGroupOption);
+                else void commitGroupQuery();
               } else if (e.key === "Escape") {
-                setGroupTypeaheadOpen(false);
+                if (groupTypeaheadOpen) {
+                  // Close the list without also dismissing the whole dialog.
+                  e.stopPropagation();
+                  setGroupTypeaheadOpen(false);
+                  setGroupActiveIndex(-1);
+                }
               }
             }}
             role="combobox"
             aria-expanded={groupTypeaheadOpen}
             aria-controls="project-group-options"
+            aria-autocomplete="list"
+            aria-activedescendant={activeGroupOption?.id}
             aria-label="Project group"
             placeholder="Ungrouped or group name"
             style={{
@@ -716,6 +791,13 @@ export function ProjectDialog({
             </button>
           )}
         </div>
+        <span className="sr-only" role="status" aria-live="polite">
+          {groupTypeaheadOpen
+            ? `${filteredGroups.length} group${filteredGroups.length === 1 ? "" : "s"} available${
+                canCreateGroup ? `. Press Enter to create "${groupQuery.trim()}".` : "."
+              }`
+            : ""}
+        </span>
         {groupTypeaheadOpen && (
           <div
             id="project-group-options"
@@ -735,102 +817,88 @@ export function ProjectDialog({
               padding: 6,
             }}
           >
-            <button
-              type="button"
-              role="option"
-              aria-selected={groupId === ""}
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={clearGroup}
-              style={{
-                width: "100%",
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                minHeight: 32,
-                border: 0,
-                borderRadius: 6,
-                background: groupId === "" ? "var(--accent-dim)" : "transparent",
-                color: groupId === "" ? "var(--accent-ink)" : "var(--text-dim)",
-                cursor: "pointer",
-                padding: "7px 9px",
-                textAlign: "left",
-                fontFamily: "var(--mono)",
-                fontSize: 11.5,
-              }}
-            >
-              Ungrouped
-            </button>
-            {filteredGroups.map((group) => (
-              <button
-                key={group.id}
-                type="button"
-                role="option"
-                aria-selected={groupId === group.id}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => selectGroup(group)}
-                style={{
-                  width: "100%",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 8,
-                  minHeight: 32,
-                  border: 0,
-                  borderRadius: 6,
-                  background: groupId === group.id ? "var(--accent-dim)" : "transparent",
-                  color: groupId === group.id ? "var(--accent-ink)" : "var(--text)",
-                  cursor: "pointer",
-                  padding: "7px 9px",
-                  textAlign: "left",
-                  fontFamily: "var(--mono)",
-                  fontSize: 11.5,
-                }}
-              >
-                <span
-                  aria-hidden
-                  style={{ width: 8, height: 8, borderRadius: "50%", background: group.color }}
-                />
-                <span
+            {groupOptions.map((opt, index) => {
+              const isActive = index === groupActiveIndex;
+              const isChosen =
+                opt.kind === "ungrouped"
+                  ? groupId === ""
+                  : opt.kind === "group"
+                    ? groupId === opt.group.id
+                    : false;
+              const isCreate = opt.kind === "create";
+              const label =
+                opt.kind === "ungrouped"
+                  ? "Ungrouped"
+                  : opt.kind === "group"
+                    ? opt.group.name
+                    : creatingGroup
+                      ? "Creating..."
+                      : `Create "${groupQuery.trim()}"`;
+              return (
+                <button
+                  key={opt.id}
+                  id={opt.id}
+                  type="button"
+                  role="option"
+                  aria-selected={isActive}
+                  disabled={isCreate && creatingGroup}
+                  className={isActive ? "mc-combo-option-active" : undefined}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onMouseEnter={() => setGroupActiveIndex(index)}
+                  onClick={() => selectGroupOption(opt)}
                   style={{
-                    minWidth: 0,
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
+                    width: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    minHeight: 32,
+                    border: 0,
+                    borderRadius: 6,
+                    background: isChosen
+                      ? "var(--accent-dim)"
+                      : isActive
+                        ? "var(--surface-2)"
+                        : "transparent",
+                    color:
+                      isCreate || isChosen
+                        ? "var(--accent-ink)"
+                        : opt.kind === "ungrouped"
+                          ? "var(--text-dim)"
+                          : "var(--text)",
+                    cursor: isCreate && creatingGroup ? "default" : "pointer",
+                    opacity: isCreate && creatingGroup ? 0.65 : 1,
+                    padding: "7px 9px",
+                    textAlign: "left",
+                    fontFamily: "var(--mono)",
+                    fontSize: 11.5,
                   }}
                 >
-                  {group.name}
-                </span>
-              </button>
-            ))}
-            {canCreateGroup && (
-              <button
-                type="button"
-                role="option"
-                aria-selected={false}
-                disabled={creatingGroup}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => void commitGroupQuery()}
-                style={{
-                  width: "100%",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 8,
-                  minHeight: 32,
-                  border: 0,
-                  borderRadius: 6,
-                  background: "transparent",
-                  color: "var(--accent-ink)",
-                  cursor: creatingGroup ? "default" : "pointer",
-                  opacity: creatingGroup ? 0.65 : 1,
-                  padding: "7px 9px",
-                  textAlign: "left",
-                  fontFamily: "var(--mono)",
-                  fontSize: 11.5,
-                }}
-              >
-                <Icon name="plus" size={12} />
-                {creatingGroup ? "Creating..." : `Create "${groupQuery.trim()}"`}
-              </button>
-            )}
+                  {opt.kind === "group" && (
+                    <span
+                      aria-hidden
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        background: opt.group.color,
+                        flex: "0 0 auto",
+                      }}
+                    />
+                  )}
+                  {isCreate && <Icon name="plus" size={12} />}
+                  <span
+                    style={{
+                      minWidth: 0,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {label}
+                  </span>
+                </button>
+              );
+            })}
           </div>
         )}
       </div>
@@ -877,10 +945,16 @@ export function ProjectDialog({
             <Icon name="camera" size={14} />
           </div>
         ) : (
-          <ProjectIcon
-            project={{ icon: previewInitials, iconColor, imagePath: null }}
-            size={28}
-          />
+          <span
+            key={`${previewInitials}-${iconColor}`}
+            className="mc-identity-pop"
+            style={{ display: "inline-flex", flex: "0 0 auto" }}
+          >
+            <ProjectIcon
+              project={{ icon: previewInitials, iconColor, imagePath: null }}
+              size={28}
+            />
+          </span>
         )}
         <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text)" }}>
           Appearance

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -402,6 +402,7 @@ function ensureSchema(sqlite: Database.Database) {
       saved_agent TEXT,
       saved_skip_permissions INTEGER NOT NULL DEFAULT 0,
       saved_bare_session INTEGER NOT NULL DEFAULT 0,
+      default_grid_view INTEGER NOT NULL DEFAULT 0,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );

--- a/src/db/migrations/0023_project_default_grid_view.sql
+++ b/src/db/migrations/0023_project_default_grid_view.sql
@@ -1,0 +1,5 @@
+-- Per-project default layout chosen at create time: 1 = grid (all sessions
+-- tiled), 0 = list (sessions stacked in a column). The in-session grid/list
+-- toggle still overrides this at runtime; this only decides how the project
+-- first opens.
+ALTER TABLE projects ADD COLUMN default_grid_view INTEGER NOT NULL DEFAULT 0;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -102,6 +102,12 @@ export const projects = sqliteTable(
     savedBareSession: integer("saved_bare_session", { mode: "boolean" })
       .notNull()
       .default(false),
+    // Which layout this project opens in: true = grid (all sessions tiled),
+    // false = list (sessions stacked in a column). Chosen at create time; the
+    // in-session toggle still lets the user switch on the fly.
+    defaultGridView: integer("default_grid_view", { mode: "boolean" })
+      .notNull()
+      .default(false),
     createdAt: integer("created_at").notNull(),
     updatedAt: integer("updated_at").notNull(),
   },

--- a/src/lib/__tests__/shell-query-cache.test.ts
+++ b/src/lib/__tests__/shell-query-cache.test.ts
@@ -52,6 +52,7 @@ function makeProject(overrides: Partial<ProjectWithCounts> = {}): ProjectWithCou
     savedAgent: null,
     savedSkipPermissions: false,
     savedBareSession: false,
+    defaultGridView: false,
     createdAt: 1,
     updatedAt: 1,
     taskCounts: {

--- a/src/lib/__tests__/sort-projects.test.ts
+++ b/src/lib/__tests__/sort-projects.test.ts
@@ -34,6 +34,7 @@ function makeProject(
     savedAgent: null,
     savedSkipPermissions: false,
     savedBareSession: false,
+    defaultGridView: false,
     createdAt: 1_000,
     updatedAt: 1_000,
     taskCounts: {

--- a/src/lib/__tests__/worktree-live-activity.test.ts
+++ b/src/lib/__tests__/worktree-live-activity.test.ts
@@ -32,6 +32,7 @@ function makeScopedProject(
     savedAgent: null,
     savedSkipPermissions: false,
     savedBareSession: false,
+    defaultGridView: false,
     createdAt: 1_000,
     updatedAt: 1_000,
     activeWorktreeId: null,

--- a/src/lib/add-project-store.tsx
+++ b/src/lib/add-project-store.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "@tanstack/react-router";
 import { ProjectDialog } from "~/components/views/ProjectDialog";
 import { api } from "~/lib/api";
 import { getElectron } from "~/lib/electron";
+import { markProjectOnboardIntent } from "~/lib/project-onboard-intent";
 import { useHotkey, isEditableTarget } from "~/lib/use-hotkey";
 import {
   groupsQueryOptions,
@@ -89,7 +90,7 @@ export function AddProjectProvider({ children }: { children: React.ReactNode }) 
         onClose={close}
         onCreateGroup={createGroupForSelection}
         onSave={async (data) => {
-          const { pendingImage, imagePath: _ignore, ...createBody } = data;
+          const { pendingImage, imagePath: _ignore, autoStart, ...createBody } = data;
           const { project: created } = await api.createProject(createBody);
           if (pendingImage) {
             const electron = (await import("~/lib/electron")).getElectron();
@@ -102,13 +103,18 @@ export function AddProjectProvider({ children }: { children: React.ReactNode }) 
               await api.updateProject(created.id, { imagePath: result.filename });
             }
           }
+          // Hand the project page a one-shot intent: open in the chosen layout
+          // and, if requested, launch the chosen agent so the user lands in a
+          // live session instead of an empty page.
+          markProjectOnboardIntent(created.id, {
+            autoStart: !!autoStart,
+            gridView: !!created.defaultGridView,
+          });
           close();
           void queryClient.invalidateQueries({ queryKey: queryKeys.projects });
-          // If the user is already viewing a project detail page, switch to the
-          // project they just opened so it becomes the selected/active one.
-          if (router.state.location.pathname.startsWith("/projects/")) {
-            void router.navigate({ to: "/projects/$id", params: { id: created.id } });
-          }
+          // Always land the user on the project they just created — the previous
+          // "stay on the dashboard" behavior is what left new projects stranded.
+          void router.navigate({ to: "/projects/$id", params: { id: created.id } });
         }}
       />
     </AddProjectContext.Provider>

--- a/src/lib/add-project-store.tsx
+++ b/src/lib/add-project-store.tsx
@@ -1,9 +1,8 @@
-import { createContext, useCallback, useContext, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { ProjectDialog } from "~/components/views/ProjectDialog";
 import { api } from "~/lib/api";
-import { getElectron } from "~/lib/electron";
 import { markProjectOnboardIntent } from "~/lib/project-onboard-intent";
 import { useHotkey, isEditableTarget } from "~/lib/use-hotkey";
 import {
@@ -24,35 +23,16 @@ const AddProjectContext = createContext<Ctx | null>(null);
 export function AddProjectProvider({ children }: { children: React.ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
   const [initialPath, setInitialPath] = useState("");
-  const browsingRef = useRef(false);
   const queryClient = useQueryClient();
   const router = useRouter();
   const { data: groups = [] } = useGroups();
 
+  // Straight into the dialog — the working-directory field hosts an inline
+  // folder browser, so the flow no longer detours through the OS dialog.
   const open = useCallback(() => {
-    if (browsingRef.current) return;
-    const electron = getElectron();
-    if (!electron) {
-      setInitialPath("");
-      void queryClient.ensureQueryData(groupsQueryOptions());
-      setIsOpen(true);
-      return;
-    }
-
-    browsingRef.current = true;
-    void (async () => {
-      try {
-        const pickedPath = await electron.browseFolder();
-        if (!pickedPath) return;
-        void queryClient.ensureQueryData(groupsQueryOptions());
-        setInitialPath(pickedPath);
-        setIsOpen(true);
-      } catch (error) {
-        console.error("[projects] failed to browse for project folder:", error);
-      } finally {
-        browsingRef.current = false;
-      }
-    })();
+    setInitialPath("");
+    void queryClient.ensureQueryData(groupsQueryOptions());
+    setIsOpen(true);
   }, [queryClient]);
   const close = useCallback(() => {
     setIsOpen(false);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -345,6 +345,9 @@ export const api = {
     iconColor?: string;
     groupId?: string | null;
     sandboxId?: string | null;
+    savedAgent?: Project["savedAgent"] | null;
+    rememberAgentSettings?: boolean;
+    defaultGridView?: boolean;
   }) =>
     req<{ project: Project }>("/api/projects", {
       method: "POST",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -348,6 +348,7 @@ export const api = {
     savedAgent?: Project["savedAgent"] | null;
     rememberAgentSettings?: boolean;
     defaultGridView?: boolean;
+    pinned?: boolean;
   }) =>
     req<{ project: Project }>("/api/projects", {
       method: "POST",

--- a/src/lib/project-onboard-intent.ts
+++ b/src/lib/project-onboard-intent.ts
@@ -1,0 +1,25 @@
+// Hands a one-shot "just created, get me working" intent from the Add-project
+// flow (add-project-store) to the project page (projects.$id) across a
+// router.navigate. A module-level map — rather than a route search param —
+// keeps the URL clean and avoids threading a search schema through the route.
+// The intent is consumed exactly once, on the project page's first render for
+// that id, then discarded so navigating back never re-triggers a launch.
+
+export type ProjectOnboardIntent = {
+  /** Launch the project's saved agent as soon as the working directory is ready. */
+  autoStart: boolean;
+  /** Open the project in the layout chosen at create time (true = grid). */
+  gridView: boolean;
+};
+
+const pending = new Map<string, ProjectOnboardIntent>();
+
+export function markProjectOnboardIntent(id: string, intent: ProjectOnboardIntent): void {
+  pending.set(id, intent);
+}
+
+export function consumeProjectOnboardIntent(id: string): ProjectOnboardIntent | null {
+  const intent = pending.get(id) ?? null;
+  if (intent) pending.delete(id);
+  return intent;
+}

--- a/src/routes/projects.$id.tsx
+++ b/src/routes/projects.$id.tsx
@@ -38,6 +38,7 @@ import { GridLayoutButton } from "~/components/views/GridLayoutButton";
 import { SessionGrid } from "~/components/views/SessionGrid";
 import { archiveOpenSession, invalidateSessionQueries } from "~/lib/archive-session";
 import { enterFocusSession } from "~/lib/focus-session";
+import { consumeProjectOnboardIntent, type ProjectOnboardIntent } from "~/lib/project-onboard-intent";
 import { ScriptArgsModal } from "~/components/views/ScriptArgsModal";
 import { WorktreeSetupCommandDialog } from "~/components/views/WorktreeSetupCommandDialog";
 import { NewAgentButton } from "~/components/views/NewAgentButton";
@@ -1702,6 +1703,30 @@ function ProjectPage() {
   }, [project, projectPathReady, showNewAgent, showEdit, startWithSaved]);
 
   useHotkey("agent.new", onNewAgentPrimary, { ignoreEditable: true });
+
+  // Create-then-start onboarding: the Add-project flow hands off a one-shot
+  // intent (see project-onboard-intent). On first render for the new project we
+  // consume it, apply the chosen layout immediately, and — once the working
+  // directory is ready — launch the saved agent so the user lands in a live
+  // session instead of a dead empty page.
+  const onboardConsumedForRef = useRef<string | null>(null);
+  const onboardIntentRef = useRef<ProjectOnboardIntent | null>(null);
+  const onboardStartedRef = useRef(false);
+  useEffect(() => {
+    if (onboardConsumedForRef.current === id) return;
+    onboardConsumedForRef.current = id;
+    onboardStartedRef.current = false;
+    const intent = consumeProjectOnboardIntent(id);
+    onboardIntentRef.current = intent;
+    if (intent) terminals.setGridView(intent.gridView);
+  }, [id, terminals]);
+  useEffect(() => {
+    const intent = onboardIntentRef.current;
+    if (!intent?.autoStart || onboardStartedRef.current) return;
+    if (!project || !projectPathReady) return;
+    onboardStartedRef.current = true;
+    onNewAgentPrimary();
+  }, [project, projectPathReady, onNewAgentPrimary]);
 
   // New-row variant of agent.new: the session lands in a fresh grid row at the
   // bottom instead of beside the active one. Grid-only — rows don't exist

--- a/src/server/__tests__/projects-custom-scripts-api.test.ts
+++ b/src/server/__tests__/projects-custom-scripts-api.test.ts
@@ -48,6 +48,7 @@ function makeProject(): string {
     savedAgent: null,
     savedSkipPermissions: false,
     savedBareSession: false,
+    defaultGridView: false,
     createdAt: now,
     updatedAt: now,
   });

--- a/src/server/__tests__/sandboxes-api.test.ts
+++ b/src/server/__tests__/sandboxes-api.test.ts
@@ -82,6 +82,7 @@ function makeProject(id: string, sandboxId: string | null) {
     savedAgent: null,
     savedSkipPermissions: false,
     savedBareSession: false,
+    defaultGridView: false,
     createdAt: now,
     updatedAt: now,
   });

--- a/src/server/controllers/projects.controller.ts
+++ b/src/server/controllers/projects.controller.ts
@@ -55,6 +55,7 @@ const createProjectBody = z.object({
   savedAgent: z.enum(TASK_AGENTS).nullable().optional(),
   rememberAgentSettings: z.boolean().optional(),
   defaultGridView: z.boolean().optional(),
+  pinned: z.boolean().optional(),
 });
 
 const updateProjectBody = z

--- a/src/server/controllers/projects.controller.ts
+++ b/src/server/controllers/projects.controller.ts
@@ -51,6 +51,10 @@ const createProjectBody = z.object({
   iconColor: z.string().optional(),
   groupId: z.string().nullable().optional(),
   sandboxId: z.string().nullable().optional(),
+  // Create-time onboarding: default agent + layout for the new project.
+  savedAgent: z.enum(TASK_AGENTS).nullable().optional(),
+  rememberAgentSettings: z.boolean().optional(),
+  defaultGridView: z.boolean().optional(),
 });
 
 const updateProjectBody = z

--- a/src/server/services/projects.ts
+++ b/src/server/services/projects.ts
@@ -304,6 +304,8 @@ export function createProject(input: {
   rememberAgentSettings?: boolean;
   /** Layout the project first opens in: true = grid, false = list. */
   defaultGridView?: boolean;
+  /** Pin the project to the top of the sidebar the moment it's created. */
+  pinned?: boolean;
 }): Project {
   const localPath = validateWorkingDirectory(input.path ?? "");
 
@@ -326,8 +328,8 @@ export function createProject(input: {
     groupId: input.groupId ?? null,
     // Inherits the scope the project was created in (Local when null/undefined).
     sandboxId: input.sandboxId ?? null,
-    pinned: false,
-    pinnedOrder: null,
+    pinned: !!input.pinned,
+    pinnedOrder: input.pinned ? nextPinnedOrder(findAllProjects()) : null,
     branch,
     launchCommands: null,
     customScripts: null,

--- a/src/server/services/projects.ts
+++ b/src/server/services/projects.ts
@@ -298,6 +298,12 @@ export function createProject(input: {
   groupId?: string | null;
   /** Scope to create the project in: a sandbox id, or null/undefined = Local. */
   sandboxId?: string | null;
+  /** Default agent to launch for this project's sessions (create-time onboarding). */
+  savedAgent?: Project["savedAgent"] | null;
+  /** When true, "New session" launches savedAgent directly instead of prompting. */
+  rememberAgentSettings?: boolean;
+  /** Layout the project first opens in: true = grid, false = list. */
+  defaultGridView?: boolean;
 }): Project {
   const localPath = validateWorkingDirectory(input.path ?? "");
 
@@ -306,6 +312,10 @@ export function createProject(input: {
   const now = Date.now();
   const id = newId("p");
   const branch = detectBranch(localPath);
+  // Only remember an agent when one was actually chosen at create time — a bare
+  // "remember" with no agent would make "New session" a no-op.
+  const savedAgent = input.savedAgent ?? null;
+  const rememberAgentSettings = !!input.rememberAgentSettings && !!savedAgent;
   const row = {
     id,
     name,
@@ -323,10 +333,11 @@ export function createProject(input: {
     customScripts: null,
     launchUrl: null,
     worktreeSetupCommand: null,
-    rememberAgentSettings: false,
-    savedAgent: null,
+    rememberAgentSettings,
+    savedAgent,
     savedSkipPermissions: false,
     savedBareSession: false,
+    defaultGridView: !!input.defaultGridView,
     createdAt: now,
     updatedAt: now,
   };

--- a/src/shared/electron-contract.ts
+++ b/src/shared/electron-contract.ts
@@ -332,7 +332,9 @@ export type ElectronBridge = {
     readImage: (path: string) => Promise<{ dataUrl: string } | { error: string }>;
   };
   pickImage: () => Promise<
-    { sourcePath: string; extension: string } | { error: string } | null
+    | { sourcePath: string; extension: string; previewDataUrl: string }
+    | { error: string }
+    | null
   >;
   saveProjectImage: (opts: {
     projectId: string;

--- a/src/shared/electron-contract.ts
+++ b/src/shared/electron-contract.ts
@@ -296,6 +296,28 @@ export type FocusModeStateBridge = {
   alwaysOnTop: boolean;
 };
 
+export type FolderEntry = {
+  name: string;
+  /** Visible (non-hidden) subfolder count — 0 renders as a leaf. */
+  childCount: number;
+};
+
+export type ListFoldersResult =
+  | {
+      ok: true;
+      /** Resolved absolute path of the listed directory. */
+      path: string;
+      /** null when `path` is the filesystem root. */
+      parent: string | null;
+      home: string;
+      /** Shortcut chips: home plus standard dirs that exist on this machine. */
+      roots: Array<{ label: string; path: string }>;
+      entries: FolderEntry[];
+      /** True when the listing was capped and some folders are not shown. */
+      truncated: boolean;
+    }
+  | { ok: false; error: string };
+
 export type ElectronBridge = {
   /** The host OS, straight from the main process (authoritative, unlike navigator.platform). */
   platform: NodeJS.Platform;
@@ -311,6 +333,15 @@ export type ElectronBridge = {
   };
   getPathForFile: (file: File) => string;
   browseFolder: () => Promise<string | null>;
+  /** In-app folder browser: subdirectories of `dir` (null → home). */
+  listFolders: (dir: string | null) => Promise<ListFoldersResult>;
+  /** Record a directory grant for a folder committed via the in-app browser. */
+  grantFolder: (dir: string) => Promise<{ ok: boolean }>;
+  /** Create a single new folder inside `parent` (in-app browser's ＋ row). */
+  createFolder: (
+    parent: string,
+    name: string,
+  ) => Promise<{ ok: true; path: string } | { ok: false; error: string }>;
   openPath: (path: string) => Promise<{ ok: true } | { ok: false; error: string }>;
   openExternal: (url: string) => Promise<{ ok: true } | { ok: false; error: string }>;
   clipboard: {

--- a/src/styles.css
+++ b/src/styles.css
@@ -686,6 +686,15 @@ select,
   filter: saturate(0.75);
 }
 
+/* A gated primary/frame must read as inert: strip the accent glow (the base
+   filter above it) and desaturate so a disabled CTA never looks clickable. */
+.mc-btn-primary:disabled,
+.mc-btn-primary[aria-disabled="true"],
+.mc-btn-frame:disabled,
+.mc-btn-frame[aria-disabled="true"] {
+  filter: grayscale(0.65);
+}
+
 .mc-input-frame {
   position: relative;
   isolation: isolate;
@@ -1572,6 +1581,15 @@ html[data-window-idle] .mc-pet * {
 }
 .mc-pick-card:not(:disabled):active {
   transform: translateY(0) scale(0.99);
+}
+/* Pick-cards and swatches carry their border/shadow inline (driven by the
+   selected state), which would beat a box-shadow focus rule — so use an
+   outline for a keyboard-focus ring that can't be overridden, matching the
+   accent ring the inputs get on focus. */
+.mc-pick-card:focus-visible,
+.mc-color-swatch:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 /* One-shot settle when a card's leading glyph becomes the selected one.
    Re-fires by remount (React keys the node on selected state). */

--- a/src/styles.css
+++ b/src/styles.css
@@ -1591,6 +1591,17 @@ html[data-window-idle] .mc-pet * {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+/* Segmented control (Layout: List | Grid) — lighter than a card grid. */
+.mc-segment {
+  transition:
+    background 150ms ease,
+    color 150ms ease,
+    box-shadow 150ms ease;
+}
+.mc-segment:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 /* One-shot settle when a card's leading glyph becomes the selected one.
    Re-fires by remount (React keys the node on selected state). */
 .mc-pick-pop {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1555,6 +1555,104 @@ html[data-window-idle] .mc-pet * {
     transform: none;
   }
 }
+/* ── Add-project dialog: selections register physically ───────────────────
+   Creating a project is where it gets its tools and identity. Each pick —
+   agent, layout, color — acknowledges in the same grammar as the theme
+   picker: hover lift, press settle, a small pop the moment the choice lands.
+   Choosing should feel deliberate, never like filling a form. */
+.mc-pick-card {
+  transition:
+    transform 150ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 150ms ease,
+    background 150ms ease,
+    box-shadow 150ms ease;
+}
+.mc-pick-card:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+.mc-pick-card:not(:disabled):active {
+  transform: translateY(0) scale(0.99);
+}
+/* One-shot settle when a card's leading glyph becomes the selected one.
+   Re-fires by remount (React keys the node on selected state). */
+.mc-pick-pop {
+  animation: mc-pick-pop 0.26s cubic-bezier(0.16, 1, 0.3, 1) backwards;
+}
+@keyframes mc-pick-pop {
+  0% {
+    transform: scale(0.72);
+  }
+  55% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+.mc-color-swatch {
+  transition:
+    transform 150ms cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 150ms ease;
+}
+.mc-color-swatch:hover {
+  transform: translateY(-1px) scale(1.06);
+}
+.mc-color-swatch:active {
+  transform: translateY(0) scale(0.94);
+}
+/* The live identity tile pops each time its initials or color change — the
+   project taking shape as you type, not a static preview. */
+.mc-identity-pop {
+  animation: mc-pick-pop 0.3s cubic-bezier(0.16, 1, 0.3, 1) backwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mc-pick-card:not(:disabled):hover,
+  .mc-pick-card:not(:disabled):active,
+  .mc-color-swatch:hover,
+  .mc-color-swatch:active {
+    transform: none;
+  }
+  .mc-pick-pop,
+  .mc-identity-pop {
+    animation: none;
+  }
+}
+/* ── Form inputs: visible keyboard focus ───────────────────────────────────
+   TextField and the bare initials input hardcode `outline: 0`; without a
+   replacement, keyboard focus was invisible on the app's most common control.
+   The container owns the border here (not inline) so :focus can turn it accent
+   and add a ring — an inline border would otherwise win over any CSS rule. */
+.mc-text-field {
+  border: 1px solid var(--border);
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+.mc-text-field:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+.mc-initials-input {
+  outline: none;
+  border: 1px solid var(--border);
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+.mc-initials-input:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+/* Group combobox option under keyboard (aria-activedescendant) highlight. */
+.mc-combo-option-active {
+  box-shadow: 0 0 0 1px var(--accent) inset;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mc-text-field,
+  .mc-initials-input {
+    transition: none;
+  }
+}
 /* Newly captured screenshot card entering the bottom-right stack: slides in
    from past the screen edge. `backwards` fill (not `forwards`) so the
    animation releases its opacity/transform once done — the card hides itself

--- a/src/styles.css
+++ b/src/styles.css
@@ -1571,16 +1571,33 @@ html[data-window-idle] .mc-pet * {
    Choosing should feel deliberate, never like filling a form. */
 .mc-pick-card {
   transition:
-    transform 150ms cubic-bezier(0.16, 1, 0.3, 1),
     border-color 150ms ease,
-    background 150ms ease,
-    box-shadow 150ms ease;
+    background 150ms ease;
 }
-.mc-pick-card:not(:disabled):hover {
-  transform: translateY(-1px);
+/* No shadow, no lift: hover just fades a translucent tint over the card (warm
+   when selected, neutral otherwise) and press darkens it a touch. The tint is
+   a pointer-inert overlay under the text (z-index:-1), so nothing floats off
+   the surface and the text never rasterizes to that "pixelated" shimmer. */
+.mc-pick-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background: rgba(255, 255, 255, 0.04);
+  opacity: 0;
+  transition: opacity 150ms ease;
+  pointer-events: none;
 }
-.mc-pick-card:not(:disabled):active {
-  transform: translateY(0) scale(0.99);
+.mc-pick-card[data-selected="true"]::before {
+  background: rgba(255, 90, 31, 0.07);
+}
+.mc-pick-card:not(:disabled):hover::before {
+  opacity: 1;
+}
+.mc-pick-card:not(:disabled):active::before {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.12);
 }
 /* Pick-cards and swatches carry their border/shadow inline (driven by the
    selected state), which would beat a box-shadow focus rule — so use an
@@ -1588,17 +1605,6 @@ html[data-window-idle] .mc-pet * {
    accent ring the inputs get on focus. */
 .mc-pick-card:focus-visible,
 .mc-color-swatch:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-/* Segmented control (Layout: List | Grid) — lighter than a card grid. */
-.mc-segment {
-  transition:
-    background 150ms ease,
-    color 150ms ease,
-    box-shadow 150ms ease;
-}
-.mc-segment:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
@@ -1616,6 +1622,20 @@ html[data-window-idle] .mc-pet * {
   }
   100% {
     transform: scale(1);
+  }
+}
+/* Availability probe still running — the agent tile's status dot breathes
+   instead of alarming, so "checking" never reads as "broken". */
+.mc-availability-checking {
+  animation: mc-availability-pulse 1.2s ease-in-out infinite;
+}
+@keyframes mc-availability-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 0.9;
   }
 }
 .mc-color-swatch {
@@ -1735,7 +1755,8 @@ html[data-window-idle] .mc-pet * {
   }
   .mc-pick-pop,
   .mc-identity-pop,
-  .mc-identity-fallback {
+  .mc-identity-fallback,
+  .mc-availability-checking {
     animation: none;
   }
 }
@@ -3273,6 +3294,29 @@ body[data-card-glow] .cursor-glow {
   background: transparent;
   border-color: transparent;
   color: var(--status-failed);
+}
+
+/* Modal footers are decision points, not chrome: a borderless-tonal ghost or
+   danger reads as plain text there, so a confirm dialog (ghost "Cancel" +
+   danger "Discard") shows no buttons at all on flat. Give footer buttons a
+   resting hairline + fill so both choices read as buttons; toolbar/menu ghost
+   and danger stay borderless. */
+[data-minimal="true"] .mc-modal-footer .mc-btn-ghost {
+  background: var(--surface-1);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+[data-minimal="true"] .mc-modal-footer .mc-btn-danger {
+  background: color-mix(in srgb, var(--status-failed) 12%, transparent);
+  border-color: color-mix(in srgb, var(--status-failed) 42%, transparent);
+  color: var(--status-failed);
+}
+[data-minimal="true"] .mc-modal-footer .mc-btn-ghost:hover {
+  background: var(--surface-2);
+}
+[data-minimal="true"] .mc-modal-footer .mc-btn-danger:hover {
+  background: color-mix(in srgb, var(--status-failed) 20%, transparent);
+  border-color: color-mix(in srgb, var(--status-failed) 58%, transparent);
 }
 
 /* Hover */

--- a/src/styles.css
+++ b/src/styles.css
@@ -1634,6 +1634,21 @@ html[data-window-idle] .mc-pet * {
 .mc-identity-pop {
   animation: mc-pick-pop 0.3s cubic-bezier(0.16, 1, 0.3, 1) backwards;
 }
+/* Initials + color are the tile's no-image fallback settings; they mount and
+   unmount with the image state, easing in so the row doesn't snap. */
+.mc-identity-fallback {
+  animation: mc-identity-fallback-in 0.22s cubic-bezier(0.16, 1, 0.3, 1) backwards;
+}
+@keyframes mc-identity-fallback-in {
+  0% {
+    opacity: 0;
+    transform: translateX(-6px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
 /* Project-dialog avatar tile: the identity preview doubles as the image
    upload button — hover/focus reveals a camera scrim over it. */
 .mc-avatar-tile {
@@ -1659,6 +1674,31 @@ html[data-window-idle] .mc-pet * {
 .mc-color-trigger:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+/* Always-visible camera badge on the tile's bottom corner — the resting-state
+   affordance that the tile accepts an image (the hover scrim alone is
+   undiscoverable). Non-interactive: clicks fall through to the tile button. */
+.mc-avatar-upload-badge {
+  position: absolute;
+  bottom: -5px;
+  right: -5px;
+  z-index: 1;
+  width: 19px;
+  height: 19px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  pointer-events: none;
+  transition: color 150ms ease, border-color 150ms ease;
+}
+.mc-avatar-tile:not(:disabled):hover ~ .mc-avatar-upload-badge,
+.mc-avatar-tile:focus-visible ~ .mc-avatar-upload-badge {
+  color: var(--text);
+  border-color: var(--text-faint);
 }
 /* Small × badge on the tile's corner when an image is set. */
 .mc-avatar-remove {
@@ -1694,7 +1734,8 @@ html[data-window-idle] .mc-pet * {
     transform: none;
   }
   .mc-pick-pop,
-  .mc-identity-pop {
+  .mc-identity-pop,
+  .mc-identity-fallback {
     animation: none;
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1634,6 +1634,58 @@ html[data-window-idle] .mc-pet * {
 .mc-identity-pop {
   animation: mc-pick-pop 0.3s cubic-bezier(0.16, 1, 0.3, 1) backwards;
 }
+/* Project-dialog avatar tile: the identity preview doubles as the image
+   upload button — hover/focus reveals a camera scrim over it. */
+.mc-avatar-tile {
+  transition: border-color 150ms ease;
+}
+.mc-avatar-tile-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+  color: #fff;
+  opacity: 0;
+  transition: opacity 150ms ease;
+  pointer-events: none;
+}
+.mc-avatar-tile:not(:disabled):hover .mc-avatar-tile-overlay,
+.mc-avatar-tile:focus-visible .mc-avatar-tile-overlay {
+  opacity: 1;
+}
+.mc-avatar-tile:focus-visible,
+.mc-color-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+/* Small × badge on the tile's corner when an image is set. */
+.mc-avatar-remove {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  z-index: 1;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  cursor: pointer;
+}
+.mc-avatar-remove:hover {
+  color: var(--text);
+  border-color: var(--text-faint);
+}
+.mc-avatar-remove:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
 @media (prefers-reduced-motion: reduce) {
   .mc-pick-card:not(:disabled):hover,
   .mc-pick-card:not(:disabled):active,


### PR DESCRIPTION

<table>
  <tr>
    <td align="center">
      <img width="654" alt="Image 1" src="https://github.com/user-attachments/assets/39d639fd-a181-4005-b801-2ced484a2a44" />
    </td>
    <td align="center">
      <img width="675" alt="Image 2" src="https://github.com/user-attachments/assets/0b0783e4-f940-411b-bbb8-005e1dc44323" />
    </td>
  </tr>
</table>

## Summary

Redesigns the **Add project** onboarding dialog into a keyboard-first, single-column flow and adds the Electron IPC plumbing to browse and create folders in-app.

- Single-column Add-project dialog with an appearance disclosure, titled group cards, and a unified selection edge
- Identity row where the avatar tile doubles as upload + live preview
- Agent + layout pickers with a create-then-start-session flow
- Keyboard-driven vertical color picker menu and inline keyboard-first folder browser
- Electron IPC for folder list / create / grant so browsing happens in-app
- New projects are pinned at creation
- Selection motion + keyboard a11y throughout the dialog
- `fix(ui)`: modal footer content is now vertically centered; TextField pinned to an explicit 38px control height

## Test plan

- [x] Open **Add project** — dialog renders as a single column; appearance disclosure toggles
- [x] Browse and create a working directory entirely via keyboard
- [x] Pick a color via the vertical keyboard menu; pick an agent + layout
- [x] Create a project — it starts pinned; optionally starts a session
- [x] Confirm the footer helper text and Cancel / Create buttons sit on one centered line
